### PR TITLE
Fix: Correct ERC-7715 permission types in smart-accounts-kit skill

### DIFF
--- a/metamask/smart-accounts-kit/SKILL.md
+++ b/metamask/smart-accounts-kit/SKILL.md
@@ -241,6 +241,22 @@ const txHash = await walletClient.sendTransactionWithDelegation({
 - `erc7710WalletActions()` - Wallet client extension
 - `sendTransactionWithDelegation()` - Redeem with EOA
 
+## Supported ERC-7715 Permission Types
+
+### ERC-20 Token Permissions
+
+| Permission Type | Description |
+|----------------|-------------|
+| `erc20-token-periodic` | Per-period limit that resets at each period |
+| `erc20-token-streaming` | Linear streaming with amountPerSecond rate |
+
+### Native Token Permissions
+
+| Permission Type | Description |
+|----------------|-------------|
+| `native-token-periodic` | Per-period ETH limit that resets |
+| `native-token-streaming` | Linear ETH streaming with amountPerSecond rate |
+
 ## Common Delegation Scopes
 
 ### Spending Limits

--- a/metamask/smart-accounts-kit/SKILL.md
+++ b/metamask/smart-accounts-kit/SKILL.md
@@ -248,14 +248,14 @@ const txHash = await walletClient.sendTransactionWithDelegation({
 | Permission Type | Description |
 |----------------|-------------|
 | `erc20-token-periodic` | Per-period limit that resets at each period |
-| `erc20-token-streaming` | Linear streaming with amountPerSecond rate |
+| `erc20-token-stream` | Linear streaming with amountPerSecond rate |
 
 ### Native Token Permissions
 
 | Permission Type | Description |
 |----------------|-------------|
 | `native-token-periodic` | Per-period ETH limit that resets |
-| `native-token-streaming` | Linear ETH streaming with amountPerSecond rate |
+| `native-token-stream` | Linear ETH streaming with amountPerSecond rate |
 
 ## Common Delegation Scopes
 

--- a/metamask/smart-accounts-kit/references/advanced-permissions.md
+++ b/metamask/smart-accounts-kit/references/advanced-permissions.md
@@ -125,7 +125,7 @@ Ensures a linear streaming transfer limit for ERC-20 tokens. Tokens accrue linea
 **Parameters:**
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `type` | `"erc20-token-streaming"` | Permission type |
+| `type` | `"erc20-token-stream"` | Permission type |
 | `tokenAddress` | `Address` | ERC-20 token contract |
 | `amountPerSecond` | `bigint` | The rate at which tokens accrue per second |
 | `initialAmount` | `bigint` | The initial amount that can be transferred at start time (default: 0) |
@@ -137,7 +137,7 @@ Ensures a linear streaming transfer limit for ERC-20 tokens. Tokens accrue linea
 
 ```typescript
 permission: {
-  type: "erc20-token-streaming",
+  type: "erc20-token-stream",
   data: {
     tokenAddress: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
     amountPerSecond: parseUnits("0.0001", 6), // 0.0001 USDC per second
@@ -180,7 +180,7 @@ Ensures a linear streaming transfer limit for native tokens (ETH). ETH accrues l
 **Parameters:**
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `type` | `"native-token-streaming"` | Permission type |
+| `type` | `"native-token-stream"` | Permission type |
 | `amountPerSecond` | `bigint` | The rate at which ETH accrues per second |
 | `initialAmount` | `bigint` | The initial amount that can be transferred at start time (default: 0) |
 | `maxAmount` | `bigint` | The maximum total amount that can be unlocked (default: no limit) |
@@ -191,7 +191,7 @@ Ensures a linear streaming transfer limit for native tokens (ETH). ETH accrues l
 
 ```typescript
 permission: {
-  type: "native-token-streaming",
+  type: "native-token-stream",
   data: {
     amountPerSecond: parseEther("0.00001"), // 0.00001 ETH per second
     justification: "Permission to stream ETH continuously",
@@ -555,7 +555,7 @@ const bundlerClient = createBundlerClient({
 | Permission request fails | Check user upgraded to smart account                                    |
 | Redemption fails         | Verify permissionsContext and delegationManager extracted correctly     |
 | Gas estimation fails     | Ensure paymaster configured or account has funds                        |
-| Invalid permission type  | Use supported types (erc20-token-periodic, erc20-token-streaming, native-token-periodic, native-token-streaming) |
+| Invalid permission type  | Use supported types (erc20-token-periodic, erc20-token-stream, native-token-periodic, native-token-stream) |
 | Expired permission       | Request new permission with updated expiry                              |
 | User denied permission   | Provide fallback UI for manual approval                                 |
 

--- a/metamask/smart-accounts-kit/references/advanced-permissions.md
+++ b/metamask/smart-accounts-kit/references/advanced-permissions.md
@@ -118,27 +118,30 @@ const grantedPermissions = await walletClient.requestExecutionPermissions([
 ])
 ```
 
-#### ERC-20 Allowance Permission
+#### ERC-20 Streaming Permission
 
-Allows ERC-20 token transfers up to specified total amount.
+Ensures a linear streaming transfer limit for ERC-20 tokens. Tokens accrue linearly at the configured rate, up to the maximum allowed amount.
 
 **Parameters:**
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `type` | `"erc20-token-allowance"` | Permission type |
+| `type` | `"erc20-token-streaming"` | Permission type |
 | `tokenAddress` | `Address` | ERC-20 token contract |
-| `allowance` | `bigint` | Total allowance amount (wei format) |
+| `amountPerSecond` | `bigint` | The rate at which tokens accrue per second |
+| `initialAmount` | `bigint` | The initial amount that can be transferred at start time (default: 0) |
+| `maxAmount` | `bigint` | The maximum total amount that can be unlocked (default: no limit) |
+| `startTime` | `number` | The start timestamp in seconds (default: current time) |
 | `justification` | `string` | Human-readable description |
 
 **Example:**
 
 ```typescript
 permission: {
-  type: "erc20-token-allowance",
+  type: "erc20-token-streaming",
   data: {
     tokenAddress: "0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238",
-    allowance: parseUnits("100", 6), // 100 USDC total
-    justification: "Permission to spend up to 100 USDC",
+    amountPerSecond: parseUnits("0.0001", 6), // 0.0001 USDC per second
+    justification: "Permission to stream USDC continuously",
   },
 }
 ```
@@ -170,25 +173,28 @@ permission: {
 }
 ```
 
-#### Native Token Allowance Permission
+#### Native Token Streaming Permission
 
-Allows native token transfers up to specified total amount.
+Ensures a linear streaming transfer limit for native tokens (ETH). ETH accrues linearly at the configured rate, up to the maximum allowed amount.
 
 **Parameters:**
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `type` | `"native-token-allowance"` | Permission type |
-| `allowance` | `bigint` | Total allowance amount (wei) |
+| `type` | `"native-token-streaming"` | Permission type |
+| `amountPerSecond` | `bigint` | The rate at which ETH accrues per second |
+| `initialAmount` | `bigint` | The initial amount that can be transferred at start time (default: 0) |
+| `maxAmount` | `bigint` | The maximum total amount that can be unlocked (default: no limit) |
+| `startTime` | `number` | The start timestamp in seconds (default: current time) |
 | `justification` | `string` | Human-readable description |
 
 **Example:**
 
 ```typescript
 permission: {
-  type: "native-token-allowance",
+  type: "native-token-streaming",
   data: {
-    allowance: parseEther("0.1"), // 0.1 ETH total
-    justification: "Permission to spend up to 0.1 ETH",
+    amountPerSecond: parseEther("0.00001"), // 0.00001 ETH per second
+    justification: "Permission to stream ETH continuously",
   },
 }
 ```
@@ -549,7 +555,7 @@ const bundlerClient = createBundlerClient({
 | Permission request fails | Check user upgraded to smart account                                    |
 | Redemption fails         | Verify permissionsContext and delegationManager extracted correctly     |
 | Gas estimation fails     | Ensure paymaster configured or account has funds                        |
-| Invalid permission type  | Use supported types (erc20-token-periodic, native-token-periodic, etc.) |
+| Invalid permission type  | Use supported types (erc20-token-periodic, erc20-token-streaming, native-token-periodic, native-token-streaming) |
 | Expired permission       | Request new permission with updated expiry                              |
 | User denied permission   | Provide fallback UI for manual approval                                 |
 


### PR DESCRIPTION
## Summary

This PR fixes incorrect ERC-7715 permission types in the smart-accounts-kit skill documentation.

## Changes

### Permission Types Fixed
- ❌ Removed incorrect `erc20-token-allowance` → ✅ Added correct `erc20-token-streaming`
- ❌ Removed incorrect `native-token-allowance` → ✅ Added correct `native-token-streaming`

### Files Updated
1. **SKILL.md** - Added "Supported ERC-7715 Permission Types" section with correct permission types
2. **references/advanced-permissions.md** - Updated all permission examples with correct streaming parameters:
   - `amountPerSecond` - Rate at which tokens accrue per second
   - `initialAmount` - Initial amount at start time (default: 0)
   - `maxAmount` - Maximum total amount (default: no limit)
   - `startTime` - Start timestamp in seconds (default: current time)

### Reference
Based on official MetaMask Smart Accounts Kit documentation:
https://docs.metamask.io/smart-accounts-kit/reference/advanced-permissions/permissions

The previous documentation incorrectly listed "allowance" types that don't exist in MetaMask's implementation. The correct types are "periodic" (resets each period) and "streaming" (linear accrual).