### PR TITLE
Add ClawdTalk skill - Phone calling and SMS for OpenClaw

### DIFF
--- a/clawdtalk/clawdtalk/SKILL.md
+++ b/clawdtalk/clawdtalk/SKILL.md
@@ -1,0 +1,32 @@
+# ClawdTalk
+
+**Category:** Communication / Voice AI
+
+**Description:** Phone calling and SMS for OpenClaw. Call your AI agent from any phone with deep tool integration for calendar, Jira, web search, and more. Powered by Telnyx.
+
+**URL:** https://clawdtalk.com
+
+**GitHub:** https://github.com/team-telnyx/clawdtalk-client
+
+## Capabilities
+
+- Phone calls and SMS messaging with AI agents
+- Deep tool integration: calendar, Jira, web search, and more
+- Voice AI powered by Telnyx
+- Call your AI agent from any phone
+
+## Installation
+
+Clone the repository and point your OpenClaw agent to:
+```
+https://github.com/team-telnyx/clawdtalk-client
+```
+
+## Usage
+
+Configure your Telnyx credentials and start making calls through your AI agent.
+
+## Requirements
+
+- Telnyx account with phone number
+- OpenClaw agent setup


### PR DESCRIPTION
Adds ClawdTalk to the skills table. ClawdTalk enables phone calling and SMS for OpenClaw with deep tool integration for calendar, Jira, web search, and more. Powered by Telnyx.