### PR TITLE
Add MetaMask Mobile wallet control skill

### DIFF
--- a/domains/coding/skills/wallet-control/references/action-vocab.md
+++ b/domains/coding/skills/wallet-control/references/action-vocab.md
@@ -1,0 +1,25 @@
+# Wallet Control Action Vocabulary
+
+Use this vocabulary when recording mobile validation evidence or composing `/cook` recipes that call MetaMask Mobile agentic scripts. These primitives are mobile-focused; Extension fixture/runtime injection belongs in `/cook` recipe-runtime tooling until it is available in Extension itself.
+
+| Action | Args | MetaMask Mobile command | Return shape |
+|---|---|---|---|
+| `status` | none | `yarn a:status` or `bash scripts/perps/agentic/app-state.sh status` | current account, route, device, platform |
+| `unlock` | `password` or `MM_PASSWORD` | `bash scripts/perps/agentic/unlock-wallet.sh "$WALLET_PASSWORD"` | success/failure plus post-unlock route |
+| `setup-wallet` | `fixturePath` | `bash scripts/perps/agentic/setup-wallet.sh --fixture .agent/wallet-fixture.json` | `{ ok, accountCount, selectedAccount }` or account summary |
+| `navigate` | `routeName`, optional params JSON | `bash scripts/perps/agentic/app-navigate.sh <RouteName> [params-json]` | previous/current route plus optional screenshot path |
+| `screenshot` | `label` or `outputPath` | `bash scripts/perps/agentic/screenshot.sh <label>` | absolute PNG path |
+| `eval-state` | `ref` such as `accounts`, `network`, `perps/positions` | `bash scripts/perps/agentic/app-state.sh status/accounts/eval-ref <ref>` | JSON snapshot |
+
+## Bounded Interaction Helpers
+
+These helpers are lower-level escape hatches for real UI flows. They are not replacements for wallet-semantic primitives and must not fabricate final validation state.
+
+| Helper | MetaMask Mobile command | Use |
+|---|---|---|
+| `press` | `bash scripts/perps/agentic/app-state.sh press <testId>` | Tap a real UI control by test id. |
+| `set-input` / `type` | `bash scripts/perps/agentic/app-state.sh set-input <testId> "value"` | Enter user-provided text through the UI. |
+| `scroll` | `bash scripts/perps/agentic/app-state.sh scroll --test-id <id> --offset <n>` or `--offset <n>` | Reveal content or controls. |
+| `wait-for` | recipe `wait_for`, or shell polling with `app-state.sh` | Wait for route, selector, or state readiness. |
+| `go-back` | `bash scripts/perps/agentic/app-state.sh go-back` | Return to the previous route/screen. |
+| `raw-eval` | `app-state.sh eval`, `eval-async`, `eval-ref` | Debug inspection or setup-only operations when named primitives are insufficient. |

--- a/domains/coding/skills/wallet-control/references/fixture-format.md
+++ b/domains/coding/skills/wallet-control/references/fixture-format.md
@@ -1,0 +1,52 @@
+# Wallet Fixture Format
+
+Fixtures are for local MetaMask Mobile debug builds only. Keep them in a gitignored path such as `.agent/wallet-fixture.json` and use throwaway test wallets.
+
+## Schema
+
+```json
+{
+  "password": "throwaway-password",
+  "accounts": [
+    {
+      "type": "mnemonic",
+      "value": "test test test test test test test test test test test junk"
+    },
+    {
+      "type": "privateKey",
+      "value": "0xabc123...",
+      "name": "Trading"
+    }
+  ],
+  "settings": {
+    "metametrics": false,
+    "skipGtmModals": true,
+    "skipPerpsTutorial": true,
+    "autoLockNever": true,
+    "deviceAuthEnabled": false
+  }
+}
+```
+
+## Fields
+
+| Field | Required | Meaning |
+|---|---:|---|
+| `password` | yes | Debug wallet password used for setup/unlock. |
+| `accounts[]` | yes | Accounts to seed. Include at least one throwaway mnemonic for first vault setup. |
+| `accounts[].type` | yes | `mnemonic` or `privateKey`. |
+| `accounts[].value` | yes | SRP words or `0x` private key. Use throwaway values only. |
+| `accounts[].name` | no | Human-readable label for imported accounts when supported. |
+| `settings.metametrics` | no | Disable/enable metrics opt-in for debug setup. |
+| `settings.skipGtmModals` | no | Skip growth/marketing modals where supported. |
+| `settings.skipPerpsTutorial` | no | Skip Perps tutorial where supported. |
+| `settings.autoLockNever` | no | Keep debug wallet unlocked where supported. |
+| `settings.deviceAuthEnabled` | no | Disable device auth for automation where supported. |
+
+## Security Rules
+
+- Never use production SRPs, private keys, accounts, or funds.
+- Never commit fixture files or raw secret material.
+- Redact raw `password`, `mnemonic`, and `privateKey` values from command transcripts and PR bodies.
+- Fixture seeding is setup/reset only. It is not a valid way to fabricate a mid-test state or bypass the user flow under validation.
+- Existing mobile template: `scripts/perps/agentic/wallet-fixture.example.json` in MetaMask Mobile.

--- a/domains/coding/skills/wallet-control/repos/metamask-mobile.md
+++ b/domains/coding/skills/wallet-control/repos/metamask-mobile.md
@@ -1,0 +1,163 @@
+---
+repo: metamask-mobile
+parent: wallet-control
+---
+
+# Wallet Control — MetaMask Mobile
+
+Use the agentic mobile scripts under `scripts/perps/agentic/` to drive a debug MetaMask Mobile app through wallet-semantic primitives. The shell wrappers call `scripts/perps/agentic/cdp-bridge.js` for Hermes/CDP evaluation, route changes, presses, inputs, scrolling, unlock, and eval refs. Reuse `simulator-control` or `agent-device` for generic device inspection when useful, but prefer this overlay for wallet setup, route navigation, screenshots, and controller state.
+
+## Prerequisites
+
+Before any primitive:
+
+1. Confirm you are in a `metamask-mobile` checkout with `scripts/perps/agentic/` present.
+2. Confirm a debug iOS simulator or Android emulator is booted and matches `.js.env` (`IOS_SIMULATOR`, `SIM_UDID`, `ANDROID_DEVICE`, `WATCHER_PORT`).
+3. Confirm Metro is running on the intended `WATCHER_PORT`, or let `preflight.sh` start it.
+4. Confirm fixture files contain only throwaway test wallets. Never paste or commit a real SRP/private key.
+
+If a required simulator, Metro, or fixture prerequisite is missing, stop and ask the user to prepare it instead of silently falling back to manual tapping.
+
+## Status and Preflight
+
+Start with the non-destructive status check whenever the `a:*` aliases are available:
+
+```bash
+yarn a:status
+```
+
+Expected output includes an `account.address`, `route.name`, `deviceName`, and `platform`. If status proves the app is already live/unlocked, validate non-destructive primitives before running any clean fixture setup.
+
+Run preflight when status fails, when the app is not launched, or before the first wallet primitive in a cold session:
+
+```bash
+bash scripts/perps/agentic/preflight.sh --platform ios --mode auto
+```
+
+For setup-wallet validation on a fresh app, use clean setup so `setup-wallet.sh` cannot merely unlock an existing vault:
+
+```bash
+bash scripts/perps/agentic/preflight.sh \
+  --platform ios \
+  --mode clean \
+  --wallet-setup \
+  --wallet-fixture .agent/wallet-fixture.json
+```
+
+Expected output ends with preflight success and CDP connectivity. Failure means the app, Metro, simulator, or CDP bridge is not ready; fix that before running primitives.
+
+## Core Wallet Primitives
+
+### `unlock`
+
+Unlock an existing vault with the fixture password:
+
+```bash
+MM_PASSWORD="$WALLET_PASSWORD" bash scripts/perps/agentic/unlock-wallet.sh
+# or
+bash scripts/perps/agentic/unlock-wallet.sh "$WALLET_PASSWORD"
+```
+
+Expected output prints the current route, unlock result, and route after unlock. Failure usually means the app is not on the login screen, the password is wrong, or CDP is disconnected.
+
+### `setup-wallet`
+
+Seed a debug wallet from a JSON fixture:
+
+```bash
+bash scripts/perps/agentic/setup-wallet.sh --fixture .agent/wallet-fixture.json
+```
+
+Expected output validates the fixture, creates or unlocks the vault, and prints an account summary. For validation evidence, start from clean state or capture a before/after account assertion because the script intentionally skips creation when a vault already exists.
+
+### `navigate`
+
+Navigate to a registered route:
+
+```bash
+bash scripts/perps/agentic/app-navigate.sh WalletTabHome
+bash scripts/perps/agentic/app-navigate.sh PerpsMarketDetails '{"market":{"symbol":"BTC","name":"BTC","price":"0","change24h":"0","change24hPercent":"0","volume":"0","maxLeverage":"100"}}'
+```
+
+Expected output prints the previous and current routes and, unless `--no-screenshot` is used, a verification screenshot path. If a route fails, list mounted routes first:
+
+```bash
+bash scripts/perps/agentic/app-navigate.sh --list
+```
+
+Some route aliases are idempotent when the app is already on the target tab/screen. Treat "previous route equals current route" as success only when the route/status evidence matches the intended destination.
+
+### `screenshot`
+
+Capture the current simulator/emulator screen:
+
+```bash
+bash scripts/perps/agentic/screenshot.sh wallet-control-home
+```
+
+Expected output is an absolute PNG path under `.agent/screenshots/`. Failure usually means no matching booted simulator or connected Android device was found.
+
+### `eval-state`
+
+Read wallet/controller state via CDP:
+
+```bash
+bash scripts/perps/agentic/app-state.sh status
+bash scripts/perps/agentic/app-state.sh accounts
+bash scripts/perps/agentic/app-state.sh eval-ref --list
+bash scripts/perps/agentic/app-state.sh eval-ref perps/positions
+bash scripts/perps/agentic/app-state.sh state engine.backgroundState.AccountsController
+```
+
+Expected output is JSON or route/state text from the running app. Failure means CDP cannot evaluate in the app context or the requested eval ref/path is not registered.
+
+## Interaction Helpers
+
+Use these only to complete real UI flows around the wallet primitives. Do not inject final validation state directly; drive the same UI code path a user would hit.
+
+### `press`
+
+```bash
+bash scripts/perps/agentic/app-state.sh press <testId>
+```
+
+### `set-input` / `type`
+
+```bash
+bash scripts/perps/agentic/app-state.sh set-input <testId> "text value"
+```
+
+### `scroll`
+
+```bash
+bash scripts/perps/agentic/app-state.sh scroll --test-id <testId> --offset 600
+bash scripts/perps/agentic/app-state.sh scroll --offset 600
+```
+
+### `wait-for`
+
+Prefer recipe `wait_for` nodes for repeated polling. For a one-off check, poll a route or expression with `app-state.sh route` or `app-state.sh eval` in the shell and fail loudly on timeout.
+
+### `go-back`
+
+```bash
+bash scripts/perps/agentic/app-state.sh can-go-back
+bash scripts/perps/agentic/app-state.sh go-back
+```
+
+### guarded `raw-eval`
+
+```bash
+bash scripts/perps/agentic/app-state.sh eval 'JSON.stringify({route: globalThis.__AGENTIC__.getRoute().name})'
+bash scripts/perps/agentic/app-state.sh eval-async '(async function(){ return JSON.stringify(await someDebugCall()); })()'
+```
+
+Use raw eval for inspection or debug-only setup, not to fabricate a passing assertion.
+
+## Path Caveat
+
+The primitives currently live under `scripts/perps/agentic/`. A follow-up should graduate them to `scripts/agentic/`; update this skill when that lands.
+
+## Compose-Up Note
+
+If you are authoring a per-PR verification recipe, use `/cook` and let it call these primitives. Do not hand-write large recipe graphs inside this skill.

--- a/domains/coding/skills/wallet-control/skill.md
+++ b/domains/coding/skills/wallet-control/skill.md
@@ -1,0 +1,27 @@
+---
+name: wallet-control
+description: Control MetaMask Mobile debug builds with wallet-aware setup/unlock, route navigation, screenshots, UI interaction, Hermes/CDP state introspection, fixture handling, recovery, and recipe handoff. Use when an agent needs to validate mobile wallet behavior end-to-end or collect PR evidence on a live simulator/emulator.
+maturity: experimental
+---
+
+# Wallet Control
+
+**DEBUG BUILDS ONLY.** This skill imports throwaway fixture wallets and reads runtime wallet state. Use only local debug builds and test wallets, per ADR #0058's dev-only verification boundary. Never use production seed phrases, private keys, accounts, or balances.
+
+`wallet-control` is a MetaMask Mobile agentic-control layer. It covers wallet semantics (`setup-wallet`, `unlock`, account/network/perps state) plus the practical controls needed to validate a real flow (`navigate`, `press`, `set-input`/`type`, `scroll`, `wait-for`, `go-back`, screenshots, guarded CDP/raw eval, recovery, and recipe handoff).
+
+Evidence hygiene: save command logs/screenshots under `/tmp` or repo-local ignored evidence folders; never commit validation artifacts. Redact fixture secrets and avoid dumping full account arrays. Prefer counts, selected account, type/key summaries, and shape-only controller output unless the task explicitly needs a concrete address.
+
+Layering:
+
+1. `simulator-control` / device tools — generic device/browser adapter layer.
+2. `wallet-control` — MetaMask Mobile-aware wallet, UI, Hermes/CDP, fixture, and evidence primitives.
+3. `/cook` / recipes — compose these primitives into reusable per-PR validation flows.
+
+Load the repo overlay for the checkout you are controlling:
+
+- MetaMask Mobile: `repos/metamask-mobile.md`
+
+Installed skills include this file plus the matching repo overlay. Source-repo references under `references/` are reviewer/deep-dive material; the overlays intentionally embed the essential commands and snippets so a fresh agent can start without reading a pile of external docs.
+
+Extension note: full MetaMask Extension fixture/runtime injection is intentionally not carried here. Until that code moves into Extension itself, it belongs in `/cook` / recipe-runtime tooling where recipes can own browser launch, storage prefill, fixture injection, and reset semantics without overloading this mobile control skill.


### PR DESCRIPTION
## Description

Adds a new experimental `wallet-control` coding skill for MetaMask Mobile debug-build validation. The skill documents wallet-aware primitives for setup/unlock, route navigation, screenshots, UI interactions (`press`, `set-input`, `scroll`, `wait-for`, `go-back`), Hermes/CDP state introspection, fixture hygiene, recovery, and `/cook` recipe handoff.

This is intentionally Mobile-scoped for now. Full MetaMask Extension fixture/runtime injection is left to `/cook` / recipe-runtime tooling until that automation can live in Extension itself.

## Type of Change

- [x] New skill
- [ ] Skill improvement/update
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## Skill Details (if adding a new skill)

**Provider Name:** MetaMask  
**Skill Name:** `wallet-control`  
**Brief Description:** Agentic control guidance for validating MetaMask Mobile debug builds with wallet-aware setup, navigation, UI interaction, CDP/Hermes state inspection, and evidence collection.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My skill follows the [SKILL_TEMPLATE.md](.github/SKILL_TEMPLATE.md) format
- [x] I have tested this skill with an AI agent
- [x] My skill does not contain any secrets, private keys, or sensitive data
- [x] I have added appropriate documentation
- [x] My changes don't break existing skills

## Testing

- `git diff --check`
- `./tools/install --repo metamask-mobile --target /Users/deeeed/dev/metamask/metamask-mobile-4 --domain coding --maturity experimental`
- `./tools/install --repo metamask-extension --target /Users/deeeed/dev/metamask/metamask-extension-4 --domain coding --maturity experimental` verified `wallet-control` is skipped for Extension because there is no Extension overlay.
- Cleaned stale generated Extension copies from the local validation checkout after removing the Extension overlay.
- On live `mm-4` iOS CDP session:
  - `yarn a:status` returned `deviceName: mm-4`, `platform: ios`, route `WalletView`.
  - `bash scripts/perps/agentic/app-state.sh scroll --offset 40` returned `{ "ok": true, "deviceName": "mm-4" }`.
- AI-agent validation: ran `codex exec` in `metamask-mobile-4` with the installed `$mms-wallet-control` skill and it successfully used `yarn a:status` only.

Validation artifacts are local under `/tmp/wallet-control-validation/` and are not committed.

## Additional Context

The prior broader Extension-control direction was deliberately trimmed back. The remaining Extension mention is only a scope boundary: full Extension runtime/fixture injection belongs in `/cook` recipe-runtime work, not in this Mobile-specific `wallet-control` skill.