### PR TITLE
feat(perps): cross-review self-gate for review-perps-pr skill

### DIFF
--- a/domains/agentic/skills/recipe-dev/references/metamask-extension-checklist.md
+++ b/domains/agentic/skills/recipe-dev/references/metamask-extension-checklist.md
@@ -1,91 +1,34 @@
 # Extension dev checklist
 
-Use this target-specific checklist for `metamask-extension` feature/dev/investigation work. Unlike fix-ticket flow, do not spend time reproducing a known bug unless the task asks for it; start from desired behavior and acceptance criteria.
+Target checklist for `metamask-extension` feature/dev/investigation work. Start from desired
+behavior and ACs; do not reproduce a known bug unless the task asks.
 
-## Live checklist template
+This file is the human's live progress view. `init-checklist.sh` copies it to the task
+folder as `CHECKLIST.md`. Execute top-to-bottom; the moment a gate completes, flip
+`[ ]` → `[x]` (or `BLOCKED: <reason>` / `N/A: <reason>`) and add the artifact path/result
+under it.
 
-Copy this file to the task artifact folder as `CHECKLIST.md` before product edits. Execute top-to-bottom. Every gate is mandatory unless marked `N/A: <reason>` in the copied file. After each gate, edit the copied file from `[ ]` to `[x]` and add the artifact/path/result below that line. Do not mark final complete with unchecked required gates.
+- [ ] 0. Coffee handoff sent, naming this CHECKLIST.md path to monitor.
+- [ ] 1. Task captured — URL or pasted text, summary, ACs.
+- [ ] 2. AC matrix — numbered ACs; proof mode state/visual/mixed; primary evidence.
+- [ ] 3. Extension target selected — popup, sidepanel, fullscreen, dapp tab, or service-worker/controller + rationale.
+- [ ] 4. Proof plan written before implementation — fixture/profile, route/tab, selectors/testIDs, expected after evidence; before evidence or `Baseline: N/A`.
+- [ ] 5. /mms-recipe-doctor setup readiness recorded — fixtures/tools; malformed fixture or missing tool = BLOCKED.
+- [ ] 6. /mms-recipe-harness install/verify when runtime proof applies — manifest + verify path, or `N/A: <non-runtime reason>`.
+- [ ] 7. /mms-recipe-cook drafted recipe — path + exact command covering ACs.
+- [ ] 8. Minimal implementation — product diff summary; every changed line maps to an AC, no unrelated refactor.
+- [ ] 9. Focused checks run — changed-file typecheck/Jest/lint. Not a stop gate.
+- [ ] 10. Runtime recipe run when applicable — summary.json, trace.json, manifest, screenshots/video.
+- [ ] 11. Visual evidence gate — read PNGs; claimed UI visible in viewport for visual/mixed ACs.
+- [ ] 12. /mms-recipe-quality critique — verdict + gaps.
+- [ ] 13. Improvement/rerun loop — one fix + rerun, or explicit no-rerun verdict.
+- [ ] 14. /mms-recipe-evidence package — PR-ready evidence block/file.
+- [ ] 15. Final response — change, tests, recipe evidence, quality loop, gaps. Ask about runtime cleanup; offer PR on consent.
 
-- [ ] **0. Coffee handoff + progress file** — Human-facing handoff names the copied `CHECKLIST.md` path to monitor.
-- [ ] **1. Task captured** — URL or pasted text, summary, requirements, ACs.
-- [ ] **2. AC matrix written** — Verbatim numbered ACs; proof mode: `state`, `visual`, or `mixed`; primary evidence.
-- [ ] **3. Target selected** — Platform/runtime target with rationale.
-- [ ] **3a. Clean per-run branch prepared** — Worktree clean or previous loop stashed; model-specific branch created; Jira branches start with lowercased ticket key plus hyphen (for example `tat-3216-...`); base SHA recorded for later diff comparison.
-- [ ] **3b. Clean generated harness/runtime state prepared** — Ignored stale outputs removed or task-local harness output selected; harness install path recorded.
-- [ ] **4. Proof plan written before implementation** — Fixture/state setup, target route, selectors/testIDs, expected after evidence; before evidence or `Baseline: N/A`.
-- [ ] **5. `mms-recipe-harness` delegate completed install/verify when runtime proof applies** — Manifest + verify artifact path, or `N/A: <non-runtime reason>`.
-- [ ] **6. `mms-recipe-cook` delegate drafted recipe** — Recipe path + exact command covering ACs.
-- [ ] **7. Minimal implementation completed** — Product diff summary.
-- [ ] **7a. Surgical diff audit** — Every changed product line maps to an AC; no duplicate implementation surfaces; no unrelated cleanup/refactor.
-- [ ] **8. Focused checks run** — Changed-file typecheck/Jest/lint results. This is not a stop gate.
-- [ ] **9. Runtime recipe run when applicable** — `summary.json`, `trace.json`, artifact manifest, screenshots/video.
-- [ ] **10. Visual evidence gate** — Read PNGs; claimed UI is visible in viewport for visual/mixed ACs.
-- [ ] **11. `mms-recipe-quality` delegate/subagent critique** — Verdict + gaps.
-- [ ] **12. Improvement/rerun loop** — One fix + rerun, or explicit no-rerun-needed verdict.
-- [ ] **13. `mms-recipe-evidence` package** — PR-ready evidence block/file.
-- [ ] **14. Resource cleanup prompt** — Ask whether to stop webpack/dev server/browser/CDP or keep runtime alive for review; record the answer.
-- [ ] **15. Final response** — Change, tests, recipe evidence, quality loop, task path, PR package path, human check.
-
-Extension-specific gates:
-
-- Before starting or restarting any runtime command, record the exact command and approval state in this checklist. After read-only runtime discovery, if the caller/orchestrator requires explicit runtime-start approval, do not create `manual-prewarm`, `nohup`, background tmux, detached `sleep`, ad-hoc cache-warming helpers, repo aliases such as `yarn a:ios` / `yarn a:android`, or direct preflight/start scripts such as `scripts/perps/agentic/start-metro.sh --launch` to bypass it; mark `BLOCKED: pending runtime-start approval` with the exact command instead. Prefer installed harness cache/watch-first commands after approval, and do not use Mobile `auto`, `default`, `clean`, `rebuild-native`, manual bundle prewarm/cache warming, Extension `--start-test-watch`, raw `yarn build:test`, or Extension prepare/build unless that exact heavier mode was explicitly approved.
-- Runner command form: Claude/Cursor use `/mms-recipe-*`; Codex/OpenAI agents use `$mms-recipe-*`. When this checklist names `/mms-recipe-harness`, `/mms-recipe-cook`, `/mms-recipe-quality`, `/mms-recipe-evidence`, or `/mms-recipe-wallet-control`, use the runner-appropriate command form or the installed delegate file path for the current runner.
-
-- Generated harness state must be clean before harness install. Remove stale ignored outputs (`${RECIPE_HARNESS_ROOT:-temp/agentic/recipe-harness}/extension`) then install normally. For task-local recipe artifacts, pass `--out <task-local-recipes>` to harness `verify`/`live` (install does not take `--out`); do not let live verify fall back to stale/default installed runner recipes. Delete the stale outputs first; the extension install is idempotent and has no overwrite/force flag.
-- Runtime discovery is portable: prefer `RECIPE_RUNTIME_CONTEXT`, `RECIPE_SLOT_ID`, `RECIPE_CDP_PORT`/`CDP_PORT`, `RECIPE_METRO_PORT`/`METRO_PORT`, `RECIPE_WATCHER_PORT`/`WATCHER_PORT`, simulator/device env, and installed harness summaries before probing fallback ports. If `temp/runtime/agentic-runtime.json` has `runtimeStart.approved: true` plus `runtimeStart.command`, recover runtime through `mms-recipe-harness` launch/live and let the harness run that approved command. Do not assume `9222` or start raw product builds when no context is present; record missing runtime context instead.
-- Harness boundary: do not edit installed `mms-recipe-harness`/wallet-control/cook/quality/evidence delegate files, `${RECIPE_HARNESS_ROOT:-temp/agentic/recipe-harness}` overlays, or copied adapter scripts during a product/ticket run. Inspect summaries/logs only enough to classify failures. If a harness code change is required, stop the runtime lane as `BLOCKED: harness defect` with artifact paths.
-- Delegate recovery order: runtime/CDP blockers go through `mms-recipe-harness` launch/live/verify with caller-approved context; wallet/login/account/route blockers go through `mms-recipe-wallet-control`; stateful setup blockers go through recipe/harness/wallet-supported real flows or documented pre-start fixtures. If the delegate cannot recover, stop with the concrete blocker and artifacts; do not jump to ad-hoc scripts, direct state mutation, or partial evidence packaging unless the human explicitly asks.
+Extension notes:
 
 - Name the browser context and UI target (`popup`, `sidepanel`, `fullscreen`, dapp tab, or service worker/controller).
-- Do not ask whether to proceed with harness/recipe validation after implementation checks. Proceed automatically.
-- A stopped browser/dev server/CDP endpoint is not a user blocker only after runtime-start approval exists. If approval is required and absent, do not run prepare/watch/Chrome-launch/manual aliases; run static/no-start harness checks if useful, record `BLOCKED: pending runtime-start approval` with the exact command, and wait.
-- Only mark runtime proof `BLOCKED` after a concrete harness or recipe command has been attempted and failed for an external reason.
-- CDP bootstrap failure is a stop/root-cause gate, not a packaging gate. If a live Extension recipe cannot connect to the recorded CDP port, `/json/version` is unreachable, no extension target is available, or the runner emits no `summary.json`/`trace.json`, mark the runtime gate `BLOCKED: CDP bootstrap failed`, record the exact command/log path, stop before recipe-quality/evidence packaging, fix runtime/preflight root cause, then restart from clean generated harness state. Do not call this `pass-with-gaps` unless the human explicitly asks for a partial package.
-- Direct app/browser scripts, DOM evals, or screenshots are supporting evidence only. They do not satisfy recipe gates unless `/mms-recipe-harness`, `/mms-recipe-cook`, `/mms-recipe-quality`, and `/mms-recipe-evidence` were explicitly invoked/followed and produced the recipe package artifacts.
-- Do not claim recipe infrastructure is absent just because a repo-root `validate-recipe.js` is missing. Check installed skill delegate paths first (`.claude/skills/mms-recipe-harness`, `.agents/skills/mms-recipe-harness`, `.cursor/rules/mms-recipe-harness`) and follow their scripts/adapters. If no executable `recipe.json` plus harness-produced `summary.json` and `trace.json` exists, classify runtime/visual proof as `FAIL`/`BLOCKED: no recipe protocol`; ad-hoc CDP probes, manual evidence markdown, black screenshots, or human-to-confirm notes do not satisfy the recipe gates.
-- Do not manufacture proof by mutating app state: no `window.stateHooks`, `stateHooks.submitRequestToBackground`, Redux/store writes, React/fiber mutation, DOM injection, controller/provider mutation, or helper that directly creates, closes, clears, seeds, or inserts the target position/value/banner. Use a real user flow or harness-owned pre-start fixture; otherwise mark the affected AC as a fixture/runtime gap.
-- Use viewport visibility (`ui.scroll` `scroll_into_view` + `ui.wait_for` `visible`) plus a screenshot for visible UI/copy/layout claims.
-- Do not claim success from DOM/controller state alone when ACs describe user-visible behavior.
-- For visual/mixed ACs, never mark an AC `code-proven`. If no runtime PNG/video exists because CDP/browser is unavailable, the visual AC is `BLOCKED: no runtime visual evidence`.
-- Fix schema warnings before packaging visual proof. Give `ui.screenshot` nodes a
-  `description` and assert "must (not) show" with `assert_json`/`assert_output`;
-  warning-only schema output is not a clean final state.
-- If the runner/harness does not emit `artifact-manifest.json`, create an
-  explicit evidence manifest that lists recipe path, exact command,
-  `summary.json`, `trace.json`, logs, screenshots/videos, quality verdict, and
-  remaining gaps.
-- `/mms-recipe-evidence` packaging must produce a PR-ready evidence block/file (for example `PR-READY-EVIDENCE.md`) and run `package-pr-evidence.js --task <task-dir>` so reviewers get `pr-package/pr-desc.md` based on the target repo `.github/pull-request-template.md` / `.github/pull_request_template.md`, `pr-package/images/` with easy-to-copy filenames, `pr-package/package-manifest.json`, and `pr-package/final-report.md`. A manifest-only package is still `PASS-WITH-GAPS` for the workflow packaging gate.
-- Final response must print `Task path:`, `PR package path:`, `PR description draft:`, and `Evidence images folder:` so the human can immediately copy/upload PR evidence.
-- Do not stop at an idle prompt after recipe PASS. Continue through quality,
-  improvement/rerun or no-rerun verdict, evidence packaging, and final summary.
-- A failed recipe/action node is not a final blocker after one attempt. Inspect
-  `summary.json`/`trace.json`, the failure screenshot/last-screen artifact, and
-  the actual target screen. If the failure is plausibly caused by route, wait,
-  hydration, scroll, obscured target, unstable click/press, or selector quality,
-  patch the recipe/flow and rerun the smallest meaningful segment before final
-  packaging. Only report `BLOCKED` after concrete retry attempts still fail, and
-  name the exact failed node plus artifacts. Unit tests or manual screenshot
-  suggestions do not replace the missing live recipe proof for visual/mixed ACs.
-- Fallback screenshot metadata controls verdict strength. If a screenshot PNG says
-  `DOM-rendered fallback evidence`, `native browser screenshot timed out/blank`,
-  or `trace.json` records `fallbackReason` for that screenshot, read and package
-  it but keep visual/mixed ACs at `PASS-WITH-GAPS` unless native screenshot/video
-  or an explicitly accepted non-fallback artifact also proves the claim. A recipe
-  `summary.json` pass, DOM/viewport wait, or unit test does not upgrade fallback
-  screenshots to clean visual proof.
-- Before writing `recipe-quality` or final evidence, perform and record an explicit fallback audit: count `trace.json` `fallbackReason`/`captureMode: dom-evidence-card-fallback` entries and read PNG headers/body for `DOM-rendered fallback evidence`. If fallback metadata exists, do not write `native screenshot`, `no fallback`, or clean visual `PASS` for affected ACs.
-- At the cleanup prompt, name the Extension resources that are still running
-  (webpack/dev server, browser/CDP port, service worker target, tmux pane). Do
-  not stop them until the human confirms, unless the user already asked for
-  cleanup. If kept alive, record why in `CHECKLIST.md`.
-- Stateful ACs require explicit setup. If an AC depends on app state such as
-  no-position vs open-position, the recipe must create/clear that state through
-  a real UI/harness flow or documented pre-start fixture before asserting the
-  UI. Do not rely on inherited browser/wallet state or prior validation runs. A
-  read-only observation recipe is only `PASS-WITH-GAPS`/`BLOCKED` for the
-  affected AC unless the required state setup is explicitly proven. Direct
-  background/controller cleanup or seeding, including
-  `stateHooks.submitRequestToBackground('perpsClosePositions', ...)`,
-  `perpsGetPositions`-driven proof, provider/controller mutation, or an ad-hoc
-  state helper, can be diagnostic/supporting evidence but cannot make the
-  no-position/open-position AC cleanly `met` by itself.
+- Runtime start (webpack/dev server/Chrome/CDP) is approval-gated: without approval, record `BLOCKED: pending runtime-start approval` with the exact command and wait; with approval, start through `/mms-recipe-harness`, not raw builds. A live recipe that can't reach CDP (`/json/version` unreachable, no extension target, no summary.json) is `BLOCKED: CDP bootstrap failed` — fix the root cause, don't downgrade to pass-with-gaps.
+- Visual/mixed ACs need a viewport-visible screenshot (`ui.scroll` + `ui.wait_for visible`), not DOM/controller state or a passing recipe alone; without a runtime PNG it is `BLOCKED: no runtime visual evidence`, never `code-proven`.
+- No manufactured state: don't inject via `stateHooks`, store/controller writes, or DOM mutation. Use a real UI flow or harness pre-start fixture, else mark the AC a fixture/runtime gap.
+- A fallback screenshot (`DOM-rendered fallback` / `fallbackReason` in trace.json) keeps that visual AC at `PASS-WITH-GAPS` even if summary.json says pass.

--- a/domains/agentic/skills/recipe-dev/references/metamask-mobile-checklist.md
+++ b/domains/agentic/skills/recipe-dev/references/metamask-mobile-checklist.md
@@ -1,128 +1,34 @@
 # Mobile dev checklist
 
-Use this target-specific checklist for `metamask-mobile` feature/dev/investigation work. Unlike fix-ticket flow, do not spend time reproducing a known bug unless the task asks for it; start from desired behavior and acceptance criteria.
+Target checklist for `metamask-mobile` feature/dev/investigation work. Start from desired
+behavior and ACs; do not reproduce a known bug unless the task asks.
 
-## Live checklist template
+This file is the human's live progress view. `init-checklist.sh` copies it to the task
+folder as `CHECKLIST.md`. Execute top-to-bottom; the moment a gate completes, flip
+`[ ]` → `[x]` (or `BLOCKED: <reason>` / `N/A: <reason>`) and add the artifact path/result
+under it.
 
-Copy this file to the task artifact folder as `CHECKLIST.md` before product edits. Execute top-to-bottom. Every gate is mandatory unless marked `N/A: <reason>` in the copied file. After each gate, edit the copied file from `[ ]` to `[x]` and add the artifact/path/result below that line. Do not mark final complete with unchecked required gates.
+- [ ] 0. Coffee handoff sent, naming this CHECKLIST.md path to monitor.
+- [ ] 1. Task captured — URL or pasted text, summary, ACs.
+- [ ] 2. AC matrix — numbered ACs; proof mode state/visual/mixed; primary evidence.
+- [ ] 3. Mobile target selected — ios, android, or both + rationale.
+- [ ] 4. Proof plan written before implementation — fixture/state, route, selectors/testIDs, expected after evidence; before evidence or `Baseline: N/A`.
+- [ ] 5. /mms-recipe-doctor setup readiness recorded — fixtures/tools; malformed fixture or missing tool = BLOCKED.
+- [ ] 6. /mms-recipe-harness install/verify when runtime proof applies — manifest + verify path, or `N/A: <non-runtime reason>`.
+- [ ] 7. /mms-recipe-cook drafted recipe — path + exact command covering ACs.
+- [ ] 8. Minimal implementation — product diff summary; every changed line maps to an AC, no unrelated refactor.
+- [ ] 9. Focused checks run — changed-file typecheck/Jest/lint. Not a stop gate.
+- [ ] 10. Runtime recipe run when applicable — summary.json, trace.json, manifest, screenshots/video.
+- [ ] 11. Visual evidence gate — read PNGs; claimed UI visible in viewport for visual/mixed ACs.
+- [ ] 12. /mms-recipe-quality critique — verdict + gaps.
+- [ ] 13. Improvement/rerun loop — one fix + rerun, or explicit no-rerun verdict.
+- [ ] 14. /mms-recipe-evidence package — PR-ready evidence block/file.
+- [ ] 15. Final response — change, tests, recipe evidence, quality loop, gaps. Ask about runtime cleanup; offer PR on consent.
 
-- [ ] **0. Coffee handoff + progress file** — Human-facing handoff names the copied `CHECKLIST.md` path to monitor.
-- [ ] **1. Task captured** — URL or pasted text, summary, requirements, ACs.
-- [ ] **2. AC matrix written** — Verbatim numbered ACs; proof mode: `state`, `visual`, or `mixed`; primary evidence.
-- [ ] **3. Target selected** — Platform/runtime target with rationale.
-- [ ] **3a. Clean per-run branch prepared** — Worktree clean or previous loop stashed; model-specific branch created; Jira branches start with lowercased ticket key plus hyphen (for example `tat-3216-...`); base SHA recorded for later diff comparison.
-- [ ] **4. Proof plan written before implementation** — Fixture/state setup, target route, selectors/testIDs, expected after evidence; before evidence or `Baseline: N/A`.
-- [ ] **5. `mms-recipe-harness` delegate completed install/verify when runtime proof applies** — Manifest + verify artifact path, or `N/A: <non-runtime reason>`.
-- [ ] **6. `mms-recipe-cook` delegate drafted recipe** — Recipe path + exact command covering ACs.
-- [ ] **7. Minimal implementation completed** — Product diff summary.
-- [ ] **7a. Surgical diff audit** — Every changed product line maps to an AC; no duplicate implementation surfaces; no unrelated cleanup/refactor.
-- [ ] **8. Focused checks run** — Changed-file typecheck/Jest/lint results. This is not a stop gate.
-- [ ] **9. Runtime recipe run when applicable** — `summary.json`, `trace.json`, artifact manifest, screenshots/video.
-- [ ] **10. Visual evidence gate** — Read PNGs; claimed UI is visible in viewport for visual/mixed ACs.
-- [ ] **11. `mms-recipe-quality` delegate/subagent critique** — Verdict + gaps.
-- [ ] **12. Improvement/rerun loop** — One fix + rerun, or explicit no-rerun-needed verdict.
-- [ ] **13. `mms-recipe-evidence` package** — PR-ready evidence block/file.
-- [ ] **14. Resource cleanup prompt** — Ask whether to stop Metro/release simulator or keep runtime alive for review; record the answer.
-- [ ] **15. Final response** — Change, tests, recipe evidence, quality loop, task path, PR package path, human check.
+Mobile notes:
 
-Mobile-specific gates:
-
-- Before starting or restarting any runtime command, record the exact command and approval state in this checklist. After read-only runtime discovery, if the caller/orchestrator requires explicit runtime-start approval, do not create `manual-prewarm`, `nohup`, background tmux, detached `sleep`, ad-hoc cache-warming helpers, repo aliases such as `yarn a:ios` / `yarn a:android`, or direct preflight/start scripts such as `scripts/perps/agentic/start-metro.sh --launch` to bypass it; mark `BLOCKED: pending runtime-start approval` with the exact command instead. Prefer installed harness cache/watch-first commands after approval, and do not use Mobile `auto`, `default`, `clean`, `rebuild-native`, manual bundle prewarm/cache warming, Extension `--start-test-watch`, raw `yarn build:test`, or Extension prepare/build unless that exact heavier mode was explicitly approved.
-- Runner command form: Claude/Cursor use `/mms-recipe-*`; Codex/OpenAI agents use `$mms-recipe-*`. When this checklist names `/mms-recipe-harness`, `/mms-recipe-cook`, `/mms-recipe-quality`, `/mms-recipe-evidence`, or `/mms-recipe-wallet-control`, use the runner-appropriate command form or the installed delegate file path for the current runner.
-
-- Runtime discovery is portable: prefer `RECIPE_RUNTIME_CONTEXT`, `RECIPE_SLOT_ID`, `RECIPE_CDP_PORT`/`CDP_PORT`, `RECIPE_METRO_PORT`/`METRO_PORT`, `RECIPE_WATCHER_PORT`/`WATCHER_PORT`, simulator/device env, and installed harness summaries before probing fallback ports. Do not assume `9222` or start raw product builds when no context is present; record missing runtime context instead.
-- Harness boundary: do not edit installed `mms-recipe-harness`/wallet-control/cook/quality/evidence delegate files, `${RECIPE_HARNESS_ROOT:-temp/agentic/recipe-harness}` overlays, or copied adapter scripts during a product/ticket run. Inspect summaries/logs only enough to classify failures. If a harness code change is required, stop the runtime lane as `BLOCKED: harness defect` with artifact paths.
-
-- Prefer after evidence for new/additive UI; use before/after when there is a meaningful previous state.
-- Do not ask whether to proceed with harness/recipe validation after implementation checks. Proceed automatically.
-- A stopped app/simulator/Metro is not a user blocker only after runtime-start approval exists. If approval is required and absent, do not run preflight/launch/manual aliases; run static/no-start harness checks if useful, record `BLOCKED: pending runtime-start approval` with the exact command, and wait.
-- Only mark runtime proof `BLOCKED` after a concrete harness or recipe command has been attempted and failed for an external reason.
-- Direct `scripts/perps/agentic/*` screenshots or evals are supporting evidence only. They do not satisfy recipe gates unless `/mms-recipe-harness`, `/mms-recipe-cook`, `/mms-recipe-quality`, and `/mms-recipe-evidence` were explicitly invoked/followed and produced the recipe package artifacts.
-- Do not claim recipe infrastructure is absent just because a repo-root `validate-recipe.js` is missing. Check installed skill delegate paths first (`.claude/skills/mms-recipe-harness`, `.agents/skills/mms-recipe-harness`, `.cursor/rules/mms-recipe-harness`) and follow their scripts/adapters. If no executable `recipe.json` plus harness-produced `summary.json` and `trace.json` exists, classify runtime/visual proof as `FAIL`/`BLOCKED: no recipe protocol`; ad-hoc CDP probes, manual evidence markdown, black screenshots, or human-to-confirm notes do not satisfy the recipe gates.
-- Do not manufacture proof by mutating app state: no `window.stateHooks`, `stateHooks.submitRequestToBackground`, Redux/store writes, React/fiber mutation, DOM/native-tree injection, controller/provider mutation, or helper that directly creates, closes, clears, seeds, or inserts the target position/value/banner. Use a real user flow or harness-owned pre-start fixture; otherwise mark the affected AC as a fixture/runtime gap.
-- Use viewport visibility (`ui.scroll` `scroll_into_view` + `ui.wait_for` `visible`) plus a screenshot for visible UI/copy/layout claims.
-- Do not claim success from controller state alone when ACs describe user-visible behavior.
-- For visual/mixed ACs, never mark an AC `code-proven`. If no runtime PNG/video exists because Metro/CDP/device is unavailable, the visual AC is `BLOCKED: no runtime visual evidence`.
-- Fix schema warnings before packaging visual proof. Give `ui.screenshot` nodes a
-  `description` and assert "must (not) show" with `assert_json`/`assert_output`;
-  warning-only schema output is not a clean final state.
-- If the runner/harness does not emit `artifact-manifest.json`, create an
-  explicit evidence manifest that lists recipe path, exact command,
-  `summary.json`, `trace.json`, logs, screenshots/videos, quality verdict, and
-  remaining gaps.
-- `/mms-recipe-evidence` packaging must produce a PR-ready evidence block/file (for example `PR-READY-EVIDENCE.md`) and run `package-pr-evidence.js --task <task-dir>` so reviewers get `pr-package/pr-desc.md` based on the target repo `.github/pull-request-template.md` / `.github/pull_request_template.md`, `pr-package/images/` with easy-to-copy filenames, `pr-package/package-manifest.json`, and `pr-package/final-report.md`. A manifest-only package is still `PASS-WITH-GAPS` for the workflow packaging gate.
-- Final response must print `Task path:`, `PR package path:`, `PR description draft:`, and `Evidence images folder:` so the human can immediately copy/upload PR evidence.
-- Do not stop at an idle prompt after recipe PASS. Continue through quality,
-  improvement/rerun or no-rerun verdict, evidence packaging, and final summary.
-- A `pass-with-gaps` quality verdict is not full completion. Package it, but
-  report the lane as `PASS-WITH-GAPS`/`PARTIAL` and list each unproved AC.
-- If a recipe node fails, read the failure PNG before diagnosing the blocker.
-  When the PNG visibly proves the UI claim, fix the recipe selector/assertion and
-  rerun; do not call it a navigation/product blocker from the route JSON alone.
-- For CDP recovery, do not run `scripts/perps/agentic/cdp-bridge.js` without a
-  subcommand. Use `/mms-recipe-harness` verify/preflight or the repo preflight
-  wrapper, then require `app-state.sh status` to return a route/account instead
-  of `[]`.
-- For Perps home recipes, avoid the broad `Perps` root target when it lands on
-  wallet tab routing. Prefer the screen-specific target (`PerpsHomeView` /
-  `PerpsMarketListView`) and let screenshot validation decide whether the
-  resulting screen is correct.
-- If Mobile can prove the target exists in fiber/tree but cannot viewport-measure
-  a newly-added React Native node (`Target exists in fiber tree but no measurable
-  native node was found`), do not claim a clean visual pass from the tree result.
-  Either add a better measurable target/scroll/navigation and rerun, or keep the
-  verdict `PASS-WITH-GAPS` and rely on visually-read screenshots as weaker proof.
-- If preflight/verify succeeds but a later recipe loses Metro/CDP, try running
-  preflight and the v1 runner (`${RECIPE_HARNESS_ROOT:-temp/agentic/recipe-harness}/mobile/runner/bin/metamask-recipe run ...`) in one shell so Metro remains alive, then
-  record that command in the evidence package.
-- If the artifact manifest lists logical screenshot names but the runner writes
-  timestamped PNGs, create/update an evidence manifest with the actual PNG paths
-  before final packaging.
-- A failed recipe/action node is not a final blocker after one attempt. Inspect
-  `summary.json`/`trace.json`, the failure screenshot/last-screen artifact, and
-  the actual target screen. If the failure is plausibly caused by route, wait,
-  hydration, scroll, obscured target, unstable click/press, or selector quality,
-  patch the recipe/flow and rerun the smallest meaningful segment before final
-  packaging. Only report `BLOCKED` after concrete retry attempts still fail, and
-  name the exact failed node plus artifacts. Unit tests or manual screenshot
-  suggestions do not replace the missing live recipe proof for visual/mixed ACs.
-- A failed precondition node is also not final after one attempt. If the live
-  run stops on `Login`, `wallet.unlocked`, `perps.ready_to_trade`,
-  `perps.sufficient_balance`, `CLIENT_NOT_INITIALIZED`, no CDP target, or a
-  stopped simulator, check runtime-start approval first. If approval has not
-  been granted, do not run prepare/launch/simulator-boot or any recovery command
-  that starts a runtime process; run static/no-start harness checks if useful,
-  record `BLOCKED: pending runtime-start approval` with the needed command, and
-  wait. If runtime-start approval exists, run `/mms-recipe-harness`
-  verify/preflight and `/mms-recipe-wallet-control`/wallet setup using the
-  provided `RECIPE_RUNTIME_CONTEXT`, `RECIPE_SLOT_ID`, `IOS_SIMULATOR`,
-  `SIMULATOR`, `WATCHER_PORT`, `METRO_PORT`, `ANDROID_SERIAL`, `ADB_SERIAL`,
-  or equivalent caller-provided runtime env. Record the recovery command,
-  app-state/status output, and rerun command. Static-only verify plus a failed
-  live precondition is `PASS-WITH-GAPS`/`BLOCKED_PRECONDITIONS`, not a complete
-  visual proof package.
-- Fallback screenshot metadata controls verdict strength. If a screenshot PNG says
-  `DOM-rendered fallback evidence`, `native browser screenshot timed out/blank`,
-  or `trace.json` records `fallbackReason` for that screenshot, read and package
-  it but keep visual/mixed ACs at `PASS-WITH-GAPS` unless native screenshot/video
-  or an explicitly accepted non-fallback artifact also proves the claim. A recipe
-  `summary.json` pass, DOM/viewport wait, or unit test does not upgrade fallback
-  screenshots to clean visual proof.
-- Before writing `recipe-quality` or final evidence, perform and record an explicit fallback audit: count `trace.json` `fallbackReason`/`captureMode: dom-evidence-card-fallback` entries and read PNG headers/body for `DOM-rendered fallback evidence`. If fallback metadata exists, do not write `native screenshot`, `no fallback`, or clean visual `PASS` for affected ACs.
-- At the cleanup prompt, name the Mobile resources that are still running
-  (Metro port, simulator/device, app process, tmux pane). Do not stop them until
-  the human confirms, unless the user already asked for cleanup. If kept alive,
-  record why in `CHECKLIST.md`.
-- Runtime recovery is capped: after one harness/preflight recovery and one targeted rerun, do not keep rebuilding native iOS/Android or repeatedly restarting Metro/CDP. If the app cannot keep a reachable target, package `BLOCKED_RUNTIME` with transcript, Metro/CDP logs, and the last `summary.json`/`trace.json`.
-- Stateful setup must branch on existing state. If the account already has BTC, an open-position button may be intentionally absent; route to the open-position visual AC or close/clear via documented real UI/harness flow before the no-position lane. Do not mark a wait timeout on an absent open button as final without reading the screen and checking current positions/route.
-- Stateful ACs require explicit setup. If an AC depends on app state such as
-  no-position vs open-position, the recipe must create/clear that state through
-  a real UI/harness flow or documented pre-start fixture before asserting the
-  UI. Do not rely on inherited browser/wallet state or prior validation runs. A
-  read-only observation recipe is only `PASS-WITH-GAPS`/`BLOCKED` for the
-  affected AC unless the required state setup is explicitly proven. Direct
-  background/controller cleanup or seeding, including
-  `stateHooks.submitRequestToBackground('perpsClosePositions', ...)`,
-  `perpsGetPositions`-driven proof, provider/controller mutation, or an ad-hoc
-  state helper, can be diagnostic/supporting evidence but cannot make the
-  no-position/open-position AC cleanly `met` by itself.
+- Name the target (`ios`/`android`/`both`). Prefer after evidence for new UI; use before/after only when a meaningful prior state exists.
+- Runtime start (Metro/simulator) is approval-gated: without approval, record `BLOCKED: pending runtime-start approval` with the exact command and wait; with approval, start through `/mms-recipe-harness`, not raw `yarn`/native rebuilds.
+- Visual/mixed ACs need a viewport-visible screenshot (`ui.scroll` + `ui.wait_for visible`), not fiber-tree/controller state or a passing recipe alone; without a runtime PNG it is `BLOCKED: no runtime visual evidence`, never `code-proven`.
+- No manufactured state: don't inject via `stateHooks`, store/controller writes, or DOM/fiber mutation. Use a real UI flow or harness pre-start fixture, else mark the AC a fixture/runtime gap.
+- A fallback screenshot (`DOM-rendered fallback` / `fallbackReason` in trace.json) keeps that visual AC at `PASS-WITH-GAPS` even if summary.json says pass.

--- a/domains/agentic/skills/recipe-dev/skill.md
+++ b/domains/agentic/skills/recipe-dev/skill.md
@@ -1,661 +1,120 @@
 ---
 name: recipe-dev
-description: Build a MetaMask feature, investigation, or product change from a clear task/ticket with acceptance criteria and recipe-backed validation. Use when an agent should implement desired behavior without first reproducing an existing bug, prove the happy path in a live Mobile or Extension runtime when applicable, package evidence, and stop for human review.
+description: Build a MetaMask feature, investigation, or product change from a task/ticket with acceptance criteria and prove it with a recipe. The human hands off a task and walks away; this drives task → implementation → recipe proof → evidence package, then stops for review. Use when an agent implements desired behavior without first reproducing a bug. For bug fixes that need reproduction first, use /mms-recipe-fix-ticket.
 maturity: experimental
 ---
 
 # Recipe Dev
 
-`/mms-recipe-dev` is the high-level workflow for feature/dev work that should end near a working fix plus reviewable proof.
+A thin orchestrator over the recipe pipeline (`/mms-recipe-doctor` → `/mms-recipe-harness` →
+`/mms-recipe-cook` → `/mms-recipe-quality` → `/mms-recipe-evidence`). The human starts it and
+leaves; you run autonomously to a finalized, reviewer-ready result. Unlike
+`/mms-recipe-fix-ticket`, you start from desired behavior and clear ACs — no time spent
+reproducing an existing failure unless the task asks for it.
 
-## Runner Invocation Compatibility
+The proof, runtime, and recipe rules live in the lower skills. This wrapper only orders the
+delegates, keeps the run honest, and stops with an evidence package. Do **not** re-derive
+harness/recipe/runtime detail here — invoke or follow the named delegate instead.
 
-Different agent runners expose installed skills differently:
+## Handoff (do first)
 
-- Claude/Cursor: use the slash-command form, for example `/mms-recipe-dev <task>`.
-- Codex/OpenAI agents: use the skill trigger form, for example `$mms-recipe-dev <task>`.
+1. Create the progress file the human monitors, then continue without waiting:
+   ```bash
+   .agents/skills/mms-recipe-dev/scripts/init-checklist.sh --platform <mobile|extension> --slug <task-slug>
+   ```
+   It prints the `CHECKLIST.md` path. Fallback: copy `references/metamask-<platform>-checklist.md`
+   to `temp/tasks/<skill>/<timestamp>-<slug>/CHECKLIST.md`.
+2. Reply once: *"Go get a coffee ☕ — I'll take it from task → implementation → recipe →
+   evidence and report back when it's done or concretely blocked. Live progress: `<path>`."*
+   Then run autonomously; do not wait for the human after this.
+3. `CHECKLIST.md` is the source of truth. Mark each gate `[x]` / `BLOCKED: <reason>` /
+   `N/A: <reason>` with its artifact path as you go — not in one batch at the end.
 
-If a human pasted the wrong runner-specific command shape and the runner rejects
-it, immediately continue by translating to the correct equivalent command. Do
-not stop or ask the human to re-run the command. Record the runner-specific
-invocation correction in the evidence package and continue through the full
-checklist.
+## Source of truth
 
-Recommended Codex/OpenAI-agent invocation shape:
+The task prompt or pasted details are authoritative. If the task source returns a login
+wall, empty issue, or ambiguous page, ask the human once for the summary + acceptance
+criteria, then continue. Never infer or rewrite ACs from branch names, stale artifacts, or
+prior runs. Before editing product code, print the numbered AC matrix: target surface, state
+precondition, exact copy, and proof mode (`state` / `visual` / `mixed`). Label any inferred
+field `UNKNOWN` and ask rather than guess.
 
-```text
-$mms-recipe-dev <ticket-or-task-url-or-task-prompt>
+## Delegate chain (in order)
+
+Each gate must actually invoke or follow the named skill; ad-hoc scripts, controller evals,
+or screenshots do not satisfy it. Record the delegate output path or blocker in `CHECKLIST.md`.
+
+1. `/mms-recipe-doctor` — setup/fixture readiness. A malformed fixture or missing tool/harness
+   is `BLOCKED`; fix before product edits.
+2. `/mms-recipe-harness` — install/verify the runtime when live proof applies.
+3. `/mms-recipe-cook` — draft the happy-path recipe before or alongside implementation; note
+   whether a before/baseline is meaningful or `Baseline: N/A`. recipe-cook owns recipe format,
+   proof modes, reuse, and the no-fake-state rule.
+4. Implement the **smallest** product change that satisfies the ACs (every changed line traces
+   to an AC; no adjacent refactors). Run focused lint/type/unit checks — passing only unlocks
+   proof, it is not a stop point.
+5. Run the recipe live and read the screenshots yourself before trusting `status: pass`.
+6. `/mms-recipe-quality` — critique against the AC matrix; apply one improve/rerun cycle or
+   record that none is needed.
+7. `/mms-recipe-evidence` — PR-ready package: product diff, recipe path, run command,
+   `summary.json`, `trace.json`, artifact manifest, screenshots, quality verdict, gaps.
+
+## Safety invariants
+
+- **Runtime start is approval-gated.** Do not start or restart Metro, a simulator, webpack,
+  or Chrome/CDP — including wrappers, aliases, `nohup`, or background tmux that do — without
+  approval. Missing approval → record `BLOCKED: pending runtime-start approval` with the exact
+  command and wait. With approval, drive starts through `/mms-recipe-harness`, not raw builds.
+- **No manufactured state.** Do not prove a user-visible AC by injecting state (`stateHooks`,
+  Redux/store writes, fiber/DOM mutation, controller/background calls). Valid proof is a real
+  UI-flow recipe or a harness-loaded pre-start fixture; otherwise mark the AC
+  `BLOCKED`/`PASS-WITH-GAPS` and name the missing fixture.
+- **Fallback screenshots are not clean visual proof.** A PNG marked DOM-fallback /
+  native-capture-blank, or a `trace.json` `fallbackReason`, keeps that visual AC at
+  `PASS-WITH-GAPS` even when `summary.json` says pass.
+
+## Honest verdict
+
+Final verdict is `PASS` only when every AC proof target passed. Any unrun, blocked, or
+fallback-only AC ⇒ `PASS-WITH-GAPS` or `PARTIAL`, listed by AC number. Never claim "all ACs
+met" or "ready" from a code diff or unit tests alone. For visual/mixed ACs, "code-proven" is
+not a valid status.
+
+## Ordered checklist
+
+`init-checklist.sh` copies the platform checklist into `CHECKLIST.md` **for the human to
+follow** — it is their live progress view while they wait. Execute it in order and flip each
+box `[ ]` → `[x]` (or `BLOCKED`/`N/A`) with its artifact path the moment that gate completes,
+so the human watching the file always sees the true current state. The canonical sequence:
+
+```markdown
+- [ ] 0. Coffee handoff sent.
+- [ ] 1. Task captured: URL or pasted text, summary, ACs.
+- [ ] 2. AC matrix: each AC numbered with proof mode (state/visual/mixed).
+- [ ] 3. Target runtime selected (Mobile/Extension + env).
+- [ ] 4. Proof plan written (before evidence meaningful, or Baseline: N/A).
+- [ ] 5. /mms-recipe-doctor setup status recorded.
+- [ ] 6. /mms-recipe-harness install/verify; manifest path recorded.
+- [ ] 7. /mms-recipe-cook drafted the recipe + run command.
+- [ ] 8. Smallest product change implemented.
+- [ ] 9. Focused checks run (type/jest/lint).
+- [ ] 10. Recipe run live; summary.json/trace.json/manifest paths recorded.
+- [ ] 11. Screenshots read; claimed UI visible (not hidden/offscreen/wrong tab).
+- [ ] 12. /mms-recipe-quality critique against AC matrix + artifacts.
+- [ ] 13. One improve/rerun cycle, or quality says none needed.
+- [ ] 14. /mms-recipe-evidence PR-ready package produced.
+- [ ] 15. Final report: change, recipe evidence, quality loop, gaps. Offer PR on consent.
 ```
 
-## Live Checklist File Protocol
-
-Before product edits, before implementation planning, and before telling the
-human to go get coffee, create a live checklist file from the installed platform reference:
-
-```bash
-# Pick mobile or extension after identifying the target repo from cwd/task.
-.agents/skills/mms-recipe-dev/scripts/init-checklist.sh --platform <mobile|extension> --slug <ticket-or-task-slug>
-```
-
-If the skill is installed somewhere else, run the same script from the installed
-skill directory, or manually copy the matching reference checklist to:
-
-```text
-temp/tasks/<skill>/<timestamp>-<slug>/CHECKLIST.md
-```
-
-The copied `CHECKLIST.md` is the source of truth for progress. It must contain
-`[ ]` checkboxes. After every gate:
-
-1. edit `CHECKLIST.md` from `[ ]` to `[x]` for the completed gate;
-2. add the artifact path, command, result, or blocker under that gate;
-3. immediately continue to the next unchecked gate.
-
-Do not rely on private scratch notes as the progress record. Do not final-answer
-with unchecked required gates unless the remaining gates are explicitly marked
-`BLOCKED: <concrete reason>` or `N/A: <reason>` in `CHECKLIST.md`. No
-`SIGNAL.json` is required for interactive skill runs.
-
-
-## Karpathy-Style Execution Discipline
-
-Apply this discipline throughout the workflow:
-
-- Think before coding: if task source, target surface, ACs, fixture state, or evidence requirement is ambiguous, record the ambiguity in `CHECKLIST.md` and ask once before product edits.
-- Simplicity first: implement the smallest reversible change that satisfies the stated ACs. Do not add abstractions, generic actions, or speculative configuration unless the recipe proof requires it.
-- Surgical changes: every changed product line must trace to an AC. Do not refactor adjacent code, move existing logic, or clean unrelated files.
-- Goal-driven execution: each checklist gate must have a concrete verifier/path/result. Do not mark `[x]` from intent, code inspection, or tests that do not cover the gate.
-
-
-## Clean Per-Run Branch Protocol
-
-Every new validation loop must run on a clean, model-specific branch so the
-human can compare Claude/Codex/Cursor diffs afterwards. Before product edits:
-
-1. ensure the worktree has no unstaged product changes from a previous loop; if
-   it does, stash them with a descriptive `adr58-validation-...` message and
-   record the stash in `CHECKLIST.md`;
-2. record the base branch and base SHA in `CHECKLIST.md`;
-3. create or switch to a fresh branch named with the runner/model, skill, ticket
-   or task slug, and run id. If the source is a Jira ticket, the branch name
-   **must start with the lowercased Jira key followed by a hyphen** on both
-   Mobile and Extension targets so regular MetaMask tooling can
-   associate it, for example
-   `tat-3216-adr58-codex-mms-recipe-dev-fresh2`. For non-Jira prompts, use a
-   stable sanitized task slug such as `adr58-codex-mms-recipe-dev-demo-fresh1`;
-4. keep all product edits for that loop on that branch only;
-5. include branch name, base SHA, and `git diff --stat <base>...HEAD` in the
-   final evidence package.
-
-If the branch cannot be made clean, mark the branch gate `BLOCKED` before
-implementation. Do not mix multiple model attempts on the same product branch.
-
-## Setup Doctor Gate
-
-Before implementation planning or harness install, invoke/follow
-`/mms-recipe-doctor` from the target checkout when it is installed:
-
-```bash
-.agents/skills/mms-recipe-doctor/scripts/recipe-doctor --target .
-```
-
-Record the doctor status in `CHECKLIST.md`, including fixture/profile status.
-If it reports missing fixtures only, continue only after recording that wallet
-setup may be slower/manual or after the human chooses to create the fixture. If
-it reports an invalid/malformed fixture, missing required tools, or missing
-harness skills, mark the gate `BLOCKED` and fix setup before product edits.
-
-## Clean Generated Harness State Protocol
-
-A clean product worktree is not enough. Generated, ignored harness/runtime
-outputs can make a fresh run reuse stale recipe code or stale CDP metadata.
-Before the proof plan or harness install gate, record and clean these generated
-paths for the current target repo unless the caller explicitly asks to preserve
-runtime state for debugging:
-
-```bash
-rm -rf "${RECIPE_HARNESS_ROOT:-temp/agentic/recipe-harness}/extension" "${RECIPE_HARNESS_ROOT:-temp/agentic/recipe-harness}/mobile"
-rm -rf temp/tasks/<this-run>/harness
-```
-
-Then reinstall the lower-level harness from the currently installed skill. The
-install manifest also records an exact `cleanupCommand` (it honors
-`RECIPE_HARNESS_ROOT`) for the full backup-aware cleanup. Do not pass
-`--force-overlay`; deleting known generated outputs first is the idempotent
-refresh. Do not edit `.agents/skills/...`, `.claude/skills/...`, or harness
-source files during product validation.
-
-For Extension, keep task-local recipe artifacts isolated from shared installed
-runner recipe state by passing `--out` to `verify`/`live` (install does not take
-`--out`):
-
-```bash
-# Install normally (writes the harness under the resolved root):
-.agents/skills/mms-recipe-harness/scripts/recipe-harness.sh extension install --target .
-# Task-local recipe artifacts: verify/live honor --out
-.agents/skills/mms-recipe-harness/scripts/recipe-harness.sh extension verify --target . --out temp/tasks/<this-run>/harness/recipes
-```
-
-Run and validate recipes through the v1 runner —
-`${RECIPE_HARNESS_ROOT:-temp/agentic/recipe-harness}/extension/runner/bin/metamask-recipe run ...`,
-then `farmslot-recipe validate ...` (see recipe-cook). If an existing shared
-harness install must be reused, verify its manifest and content hash in
-`CHECKLIST.md`; do not silently reuse stale ignored files.
-
-## First Response to the Human
-
-After creating `CHECKLIST.md`, immediately acknowledge the handoff with a short, friendly message that includes the checklist path the human can monitor. Use this exact spirit, adapted only if the user gave a stricter tone:
-
-> Ok, relax and go get a coffee ☕. I’ll take this from task → implementation → recipe → evidence package. You can monitor live progress in `<CHECKLIST.md path>`, and I’ll report back when it is done or concretely blocked.
-
-After that message, continue autonomously. Do not wait for the user after the
-acknowledgement. If the task source cannot be fetched, ask for the missing task
-text once; after the user pastes it, resume at checklist step 1 and continue to
-the recipe/evidence gates.
-
-
-## Runtime Startup Approval Gate
-
-Before any command that can start or restart a live runtime, write the exact
-command and approval state in `CHECKLIST.md`. This includes Mobile Metro,
-simulator/app launch, bundle prewarm/cache-warming helpers, `recipe-harness
-live`, Extension webpack/watch, Chrome/CDP launch, and any wrapper that would
-prepare/build runtime artifacts.
-
-Respect the caller/orchestrator policy for the lane. If the current goal,
-checklist, or human says runtime startup needs explicit approval, do **not**
-work around that by creating `manual-prewarm`, `nohup`, background tmux,
-`sleep`/detached shell, ad-hoc cache-warming helpers, repo aliases such as
-`yarn a:ios` / `yarn a:android`, or direct preflight/start scripts such as
-`scripts/perps/agentic/start-metro.sh --launch`. Instead record `BLOCKED:
-pending runtime-start approval` with the exact command you would run and
-continue only after approval is provided.
-
-When approval exists, prefer the installed harness delegate and cache/watch-first
-commands. Do not run Mobile `auto`, `default`, `clean`, `rebuild-native`,
-manual bundle prewarm/cache warming, Extension `--start-test-watch`, or
-Extension prepare/build unless that heavier mode was explicitly approved.
-
-## Portable Runtime Discovery Gate
-
-Before choosing any runtime command or port, perform read-only discovery in this
-order and record the result in `CHECKLIST.md`:
-
-1. caller-provided runtime context: `RECIPE_RUNTIME_CONTEXT` JSON path,
-   `RECIPE_SLOT_ID`, `RECIPE_CDP_PORT`, `CDP_PORT`, `RECIPE_METRO_PORT`,
-   `METRO_PORT`, `RECIPE_WATCHER_PORT`, `WATCHER_PORT`, `IOS_SIMULATOR`,
-   `SIMULATOR`, `ANDROID_SERIAL`, `ADB_SERIAL`, and comparable env vars;
-2. repo-local generic runtime context: `temp/runtime/agentic-runtime.json`
-   (and `temp/runtime/agentic-runtime.env` if you want to source it). If this
-   file has `strict: true`, use only the recorded slot/port/device values and
-   do not probe or fall back to other local runtimes. If it has
-   `runtimeStart.approved: true` plus `runtimeStart.command`, pass recovery
-   through `/mms-recipe-harness` launch/live/verify and let the harness run that
-   approved command; outside managed runtimes, any developer/tool may provide the same
-   context or `RECIPE_RUNTIME_START_APPROVED=1` with `RECIPE_RUNTIME_START_CMD`;
-3. installed recipe-harness/delegate summaries or manifests in the current
-   checkout that identify an already-owned runtime;
-4. currently listening local CDP/device endpoints only as fallbacks, never as a
-   reason to ignore caller-provided context.
-
-Do not assume default ports such as `9222` when no context was supplied. Do not
-turn missing runtime context into a raw product build (`yarn build:test`,
-`start:test`, native rebuild, or direct Chrome/simulator launch). Use static
-verify/no-start checks where useful, then record the missing runtime context or
-needed harness command as the blocker.
-
-## Harness Boundary Gate
-
-This high-level skill owns product code, recipes, and evidence. It does **not**
-own the lower-level harness implementation during a product/ticket run. Do not
-edit installed delegate files such as `.agents/skills/mms-recipe-harness`,
-`.claude/skills/mms-recipe-harness`, `.cursor/rules/mms-recipe-harness`,
-`${RECIPE_HARNESS_ROOT:-temp/agentic/recipe-harness}`, or copied harness adapter scripts while fixing a
-product ticket or validating this high-level workflow.
-
-If the harness fails, inspect only enough logs/summaries to classify the failure
-and capture artifact paths. Rerun only with documented harness flags and the
-discovered runtime context. If success would require changing harness code, stop
-the runtime lane as `BLOCKED: harness defect` (or `PASS-WITH-GAPS` for product
-code already checked) and report the exact summary/log path. Do not patch the
-harness unless the explicit task is a harness-maintenance task.
-
-## Delegate Recovery Decision Tree
-
-When a live proof is blocked, escalate through the lower-level delegates before
-using ad-hoc commands or packaging partial evidence:
-
-1. **Runtime/CDP unavailable** — use `/mms-recipe-harness` (or the installed
-   delegate path) to launch, live-verify, or recover the runtime with the
-   caller-approved context/prepare command. The high-level skill should not run
-   raw build/watch/Chrome/simulator commands when a harness path exists. If no
-   runtime context or start approval exists, stop with `BLOCKED: missing runtime
-   context` or `BLOCKED: pending runtime-start approval`.
-2. **Wallet locked, wrong account, onboarding, route, or app-ready blocker** —
-   use `/mms-recipe-wallet-control` (or the installed delegate path) for unlock,
-   account, route, and wallet readiness primitives. Do not invent private aliases
-   or mutate controller/store state to prove user-visible ACs.
-3. **Stateful product setup unavailable** — use recipe/harness/wallet-control
-   supported flows or documented pre-start fixtures. If no real flow/fixture
-   exists, record a fixture/state setup blocker; do not manufacture the target
-   state.
-4. **Delegate cannot recover** — stop at the concrete blocker with command/log
-   paths. Fix the delegate/runtime/root cause and restart from clean generated
-   harness state rather than continuing to a partial evidence package, unless
-   the human explicitly asks for partial packaging.
-
-## CDP Bootstrap Failure Stop Gate
-
-For Extension visual or mixed ACs, a live recipe that fails before CDP session
-bootstrap (for example `ECONNREFUSED 127.0.0.1:<port>`, missing `/json/version`,
-no extension target, or no `summary.json`/`trace.json` emitted) is not a
-quality/evidence packaging condition. Stop the product validation lane, record
-`BLOCKED: CDP bootstrap failed`, preserve the exact command/log path, and fix
-the runtime/preflight root cause before restarting from a clean generated
-harness state.
-
-Only continue to recipe-quality/evidence packaging after either:
-
-1. the live recipe emitted normal runtime artifacts (`summary.json`,
-   `trace.json`, artifact manifest, screenshots/video where applicable); or
-2. the human explicitly asks for a partial package despite the bootstrap
-   blocker.
-
-Do not convert pre-bootstrap CDP failure into `pass-with-gaps`. Do not keep
-retrying inside the same dirty product run. Fix the root cause, clean generated
-outputs, and restart.
-
-## Task Source-of-Truth Gate
-
-The Jira/task prompt or pasted task details are the source of truth. If Jira,
-MCP, WebFetch, or browser access returns a login wall, timeout, permission
-error, empty issue, or ambiguous page, ask the human for the task summary,
-description, requirements, and acceptance criteria before coding. Do this even
-if branch names, prior artifacts, local task folders, web search results, or
-repo history look suggestive.
-
-Do **not** infer or rewrite acceptance criteria from branch names, stale ADR58
-artifacts, previous validation runs, or web search. Do **not** change the target
-surface, gating condition, exact copy, or required state unless the task text
-says so. If task details remain unavailable, stop before product edits and
-report `BLOCKED: missing task source of truth`; do not implement a guessed
-patch.
-
-Before editing product code, print the extracted AC matrix with the exact target
-surface, state precondition, copy, styling, and proof requirement. If any field
-is inferred rather than stated, label it `UNKNOWN` and ask for the missing task
-text instead of proceeding.
-
-It exists to steer the agent through the full loop. Lower-level recipe skills are proof tools; this skill makes the agent use them instead of stopping at a code diff, unit tests, or a confidence summary.
-
-Use it when the task is broader than a bug fix: new feature work, exploratory implementation, investigation, or behavior changes that start from desired acceptance criteria rather than a known broken state. For pure bugs, prefer `/mms-recipe-fix-ticket` because bug-fix flow spends time reproducing or understanding the existing failure before patching.
-
-Load only what applies:
-
-- Setup readiness: `/mms-recipe-doctor`
-- Runtime setup: `/mms-recipe-harness`
-- Recipe authoring: `/mms-recipe-cook`
-- Recipe critique: `/mms-recipe-quality`
-- PR evidence formatting: `/mms-recipe-evidence`
-- Wallet/app primitives: `/mms-recipe-wallet-control`
-- Target-repo dev notes are appended below when installed.
-- Target checklist reference: load only one of `references/metamask-mobile-checklist.md` or `references/metamask-extension-checklist.md`.
-
-## Lower-Level Skill Invocation Contract
-
-The lower-level recipe skills are required gates, not optional background
-reading. For every delegate gate, do one of these explicitly:
-
-1. invoke the named skill using the runner-specific command form (slash for Claude/Cursor, `$` for Codex) if the runner supports nested skill calls; or
-2. if nested slash calls are unavailable, open the installed skill file and
-   follow it as the delegate protocol:
-   - `.claude/skills/mms-recipe-harness/SKILL.md`
-   - `.claude/skills/mms-recipe-cook/SKILL.md`
-   - `.claude/skills/mms-recipe-quality/SKILL.md`
-   - `.claude/skills/mms-recipe-evidence/SKILL.md`
-   - equivalent `.agents/skills/.../SKILL.md` or `.cursor/rules/.../RULE.md`
-     when running under Codex/OpenAI agents or Cursor.
-
-For each delegate, write `Invoking mms-recipe-...` in `CHECKLIST.md` and
-record the delegate output path or blocker. Direct ad-hoc app scripts,
-controller evals, DOM/fiber checks, screenshots, or unit tests do **not**
-satisfy these gates unless they are wrapped into the recipe protocol with an
-executable recipe path, exact command, `summary.json`, `trace.json`, artifact
-manifest, recipe-quality critique, and evidence package.
-
-Do **not** claim recipe tooling is absent just because a repo-root
-`validate-recipe.js` or `scripts/recipe-*` file is missing. Before declaring a
-recipe/harness blocker, inspect the installed delegate locations for the current
-runner:
-
-- `.claude/skills/mms-recipe-harness/SKILL.md` and `scripts/` / `adapters/`;
-- `.agents/skills/mms-recipe-harness/SKILL.md` and `scripts/` / `adapters/`;
-- `.cursor/rules/mms-recipe-harness/RULE.md` and copied references/scripts.
-
-If the installed delegate exists, follow it. If no executable recipe run exists
-(no `recipe.json` plus `summary.json` and `trace.json` from the harness), final
-status for runtime/visual work is `FAIL` or `BLOCKED: no recipe protocol`, not
-`PASS-WITH-GAPS`. Ad-hoc CDP probes, handwritten evidence packages, black
-screenshots, or “human should visually confirm” instructions are supporting
-notes only; they do not satisfy harness/cook/quality/evidence gates.
-
-## No Manufactured Runtime State
-
-Do **not** prove a user-visible AC by mutating app/UI/runtime state directly.
-Forbidden proof setup includes `window.stateHooks`,
-`stateHooks.submitRequestToBackground`, Redux/store writes, React/fiber
-mutation, DOM injection, controller/provider state mutation, or any ad-hoc
-helper that directly creates, closes, clears, seeds, or inserts the target
-value/position/banner into the running app. These may be useful for diagnosis,
-but they are not valid AC proof.
-
-Valid proof must use one of:
-
-- the real user flow encoded as a recipe;
-- a documented fixture/profile loaded before app start by the harness; or
-- an honest `BLOCKED`/`PASS-WITH-GAPS` verdict that names the missing fixture or
-  runtime capability.
-
-If a recipe uses state injection or controller/background calls to create or
-clear the exact condition being asserted (for example injecting or closing a BTC
-Perps position, mutating a controller value, inserting a banner/form value, or
-changing a DOM node), the corresponding stateful AC is **not clean proof**. It
-may be included as diagnostic/supporting evidence only; keep the affected AC at
-`PASS-WITH-GAPS`/`BLOCKED` until a real UI flow or documented harness-owned
-pre-start fixture proves the state. Do not call it `code-proven`, `visually
-proven`, or `all ACs met`; classify it as a fixture/recipe gap and feed that
-back to `/mms-recipe-cook`.
-
-## Default Contract
-
-Do not stop at a code diff when the change is user-visible, stateful, or acceptance-criteria-driven. Unlike `/mms-recipe-fix-ticket`, this flow does **not** spend time reproducing an existing failure unless the task asks for it; it starts from desired behavior and clear acceptance criteria.
-
-A final response is forbidden until one of these is true:
-
-1. The implementation checks passed, a recipe was authored/run when runtime proof applies, screenshots/artifacts were reviewed, and an evidence package was produced; or
-2. runtime proof was attempted through `/mms-recipe-harness`, failed for a concrete external reason, and the response clearly labels recipe proof as `BLOCKED` rather than claiming the acceptance criteria are proven.
-
-Passing typecheck/Jest is not a stop gate. It only unlocks recipe/evidence steps.
-If any acceptance criterion remains unrun, blocked, or covered only by weaker
-fallback proof, the final verdict is `PASS-WITH-GAPS` or `PARTIAL`, not
-`complete`, `all ACs met`, or `ready`. DOM-rendered fallback screenshots
-created because native screenshot capture timed out/blank count as weaker
-fallback proof for visual ACs: package them, read them, and keep the gap in the
-final verdict unless a native screenshot/video (or explicitly accepted alternate
-artifact) also exists. Evidence packaging must preserve the gap
-by AC number.
-
-For visual or mixed ACs, "code-proven" is not a valid proof status. Code review
-can prove minimality or placement intent, but visible copy/color/layout/ordering
-remain unproved until a live runtime recipe produces screenshot/video evidence
-that the runner reads visually. If CDP/browser is unavailable, mark those ACs
-`BLOCKED: no runtime visual evidence`.
-
-Do not ask the human whether to proceed with recipe/harness validation. The
-answer is already yes for this skill. If the app, simulator, Metro, browser, or
-CDP is not currently running, check the Runtime Startup Approval Gate above. If
-runtime-start approval exists, invoke `/mms-recipe-harness` and let its
-verify/preflight path start or recover the runtime. If approval is required and
-absent, run static/no-start harness checks, record `BLOCKED: pending
-runtime-start approval` with the exact command, and wait. Only declare
-`BLOCKED` for a concrete external failure after the harness or recipe command
-was actually attempted with approval.
-
-Honor runtime environment variables first. If `RECIPE_RUNTIME_CONTEXT`, `RECIPE_SLOT_ID`, `CDP_PORT`, `RECIPE_CDP_PORT`,
-`ADB_SERIAL`, simulator/device, or equivalent caller-provided runtime variables
-are present, use those values in harness verify and recipe commands before
-probing default ports. Do
-not claim "no CDP/browser/device" until the env-provided target was attempted
-and its failure artifact was recorded. If the env-provided runtime fails but a
-fallback port works, record both; if only fallback probing was done, the runtime
-gate is incomplete.
-
-Do not ask to commit, create a PR, or package the work as done while any required
-recipe gate is incomplete. If the product diff and implementation checks are
-done but the recipe package is missing, the only valid next action is to invoke
-the next lower-level recipe skill or mark that specific gate `BLOCKED` with the
-attempted command and failure artifact.
-
-## Runtime Failure Recovery Gate
-
-A failed live recipe node is not automatically a final blocker. Before final
-packaging, inspect the failed node in `summary.json`/`trace.json`, read any
-failure screenshot or last-screen artifact, and decide whether the failure is a
-recipe/action sequencing issue that can be fixed locally. Typical fixable cases
-include wrong route, below-the-fold or obscured target, unstable click/press,
-missing wait for hydration, stale selector, wrong browser context, or a broad
-shared flow landing on the wrong screen.
-
-If the failure is plausibly recipe/action quality, patch the recipe or shared
-flow with the smallest navigation/wait/scroll/stable-click correction and rerun
-the smallest meaningful recipe segment or the full recipe. Do this before
-returning a final summary. Only mark the proof target `BLOCKED` after concrete
-retry attempts still fail, and then report the exact failed node, command,
-artifact paths, observed screen, and the recipe/harness improvement needed.
-
-Do not loop indefinitely on native rebuilds, Metro/CDP reconnects, or simulator
-launch churn. After one harness/preflight recovery plus one targeted rerun, cap
-the lane as `BLOCKED_RUNTIME` if CDP/Metro remains unstable, and package the
-transcript plus runtime logs instead of spending unbounded time rebuilding.
-
-For stateful setup flows, branch on the observed state. If the recipe wants to
-open a BTC position but the account already has BTC, do not wait for an
-open-long button that is correctly absent; either route directly to the
-open-position visual AC, or first close/clear via the documented real UI/harness
-flow and then rerun the no-state lane. Existing-state branching must be recorded
-in the recipe notes and verdict.
-
-Unit tests, DOM/fiber/controller assertions, or a manual screenshot suggestion
-do not replace the missing live recipe proof. They may support the code diff,
-but visual/mixed ACs with a failed runtime node remain `PASS-WITH-GAPS`,
-`PARTIAL`, or `BLOCKED` by AC number.
-
-## Runtime Precondition Recovery Gate
-
-A recipe that fails before the first workflow node because preconditions are not
-ready is not a final package yet. If `summary.json`/`failure.json` reports
-`wallet.unlocked`, `Login`, `perps.ready_to_trade`,
-`perps.sufficient_balance`, `CLIENT_NOT_INITIALIZED`, no CDP target, or a
-stopped simulator/browser, check runtime-start approval before attempting
-recovery:
-
-- **If runtime-start approval has not been granted**, do not run
-  prepare/watch/launch/simulator-boot or any command that starts or restarts a
-  runtime process. Run static/no-start harness checks if useful, record
-  `BLOCKED: pending runtime-start approval` with the exact command that would be
-  needed, and wait for explicit approval.
-- **If runtime-start approval exists**, invoke/follow `/mms-recipe-harness`
-  verify/preflight for the platform, using the provided `RECIPE_RUNTIME_CONTEXT`, `RECIPE_SLOT_ID`, `CDP_PORT`,
-  `RECIPE_CDP_PORT`, `IOS_SIMULATOR`, `SIMULATOR`, `ADB_SERIAL`,
-  `ANDROID_SERIAL`, `WATCHER_PORT`, `METRO_PORT`, or equivalent caller-provided
-  env vars first;
-- for wallet/login readiness, invoke/follow `/mms-recipe-wallet-control` or the
-  repo harness wallet setup/unlock command rather than asking the human to run a
-  private alias;
-- record the exact recovery command, output artifact, app-state/status result,
-  and whether it reached a route/account/perps-ready state;
-- rerun the same recipe command after recovery, or explain the concrete external
-  reason recovery could not run.
-
-Static-only harness verification plus a failed live precondition attempt is a
-useful artifact, but it is not enough to close a stateful/visual proof lane when
-the target runtime env was available. If recovery still leaves the app on the
-login screen or `CLIENT_NOT_INITIALIZED`, package the lane as
-`PASS-WITH-GAPS`/`BLOCKED_PRECONDITIONS` and name the missing runtime setup
-explicitly.
-
-## Stateful AC Setup Gate
-
-For acceptance criteria that depend on a required app state, the recipe must
-explicitly create or verify that state before asserting the UI. Do not rely on
-whatever state happens to be present in the active browser, simulator, wallet,
-or prior validation run. For example, a ticket with both `no BTC position` and
-`open BTC position` ACs needs separate no-state and with-state setup paths:
-close/clear through a real UI/harness flow, open/create through a real
-UI/harness flow, or load a documented harness-owned pre-start fixture.
-
-A read-only observation recipe is acceptable only for investigation or for an
-AC whose required state is already the subject being observed and cannot be
-changed safely; in that case the affected AC must be labelled
-`PASS-WITH-GAPS`/`BLOCKED` with the missing setup flow named. If existing shared
-flows or platform fixtures can attempt the setup, try them before final
-packaging. Unit tests may support the code path but do not substitute for
-runtime setup of stateful visual ACs.
-
-## Fallback Screenshot Verdict Gate
-
-Treat screenshot artifact metadata as part of the proof, not just the visible
-bitmap. If a PNG says `DOM-rendered fallback evidence`, `native browser
-screenshot timed out/blank`, or `trace.json` records a screenshot
-`fallbackReason`, then native visual capture failed for that AC. Read and
-package the fallback PNG, but a visual/mixed AC proven only by that fallback is
-not a clean visual pass. The final verdict must remain `PASS-WITH-GAPS` (or
-`PARTIAL`/`BLOCKED` if the fallback does not show the claim), even when
-`summary.json` says `status: pass` and DOM/viewport assertions passed.
-
-Before writing the final verdict or `recipe-quality`, scan `trace.json`,
-screenshot captions, and the PNG header/body for fallback labels. The scan must
-be explicit in the notes, for example `Fallback audit: trace fallbackReason=<n>,
-PNG DOM fallback labels=<n>`. If any visual AC depends on fallback evidence,
-list the affected AC numbers and the native screenshot/video gap. Do not let a
-later successful rerun or unit test overwrite this proof-strength classification
-unless it produced native screenshot/video or another explicitly accepted
-non-fallback artifact. If `recipe-quality` or the final summary says `native
-screenshot`, `no fallback`, or clean visual `PASS` while `trace.json` or a PNG
-shows fallback metadata, the quality gate is incomplete; correct the verdict to
-`PASS-WITH-GAPS` and rewrite the evidence package before final response.
-
-## Final Package Barrier
-
-A recipe `PASS` is **not** the end of this skill. After the runtime recipe run,
-continue through these gates before showing an idle prompt or final response:
-
-1. open `summary.json`, `trace.json`, run log, issue review, and the artifact
-   manifest/evidence manifest;
-2. read every recipe-produced PNG/video, not only ad-hoc screenshots captured
-   before the recipe;
-3. invoke or follow `/mms-recipe-quality` and record its verdict;
-4. apply one recipe/evidence improvement and rerun, or record the quality
-   verdict that no rerun is needed;
-5. invoke/follow `/mms-recipe-evidence` and write a PR-ready evidence block/file
-   (for example `PR-READY-EVIDENCE.md`) with task, diff, commands, artifact
-   paths, screenshot notes, quality verdict, fallback audit, and remaining gaps;
-6. run `.agents/skills/mms-recipe-evidence/scripts/package-pr-evidence.js --task <task-dir>`
-   (or the runner-equivalent installed path) so the task contains
-   `pr-package/pr-desc.md`, `pr-package/images/` with easy-to-copy filenames,
-   `pr-package/package-manifest.json`, and `pr-package/final-report.md`.
-   The `pr-desc.md` draft must follow the target repo's
-   `.github/pull-request-template.md` / `.github/pull_request_template.md`
-   when present.
-   A JSON manifest alone is not a PR-ready evidence package.
-
-If you find yourself at the model prompt with quality/evidence/package gates
-unchecked, that is a workflow failure. Continue immediately from the earliest
-unchecked gate; do not wait for the human to say "continue".
-
-If `/mms-recipe-quality` returns `pass-with-gaps`, finish the evidence package
-but keep the final verdict as `PASS-WITH-GAPS`. Do not say the workflow is fully
-complete unless every required AC proof target passed or is explicitly outside
-the requested scope.
-
-## Ordered Checklist Protocol
-
-Maintain the copied `CHECKLIST.md` file and execute it in order. Load the Mobile or Extension checklist reference installed with this skill (for example `.agents/skills/mms-recipe-dev/references/metamask-mobile-checklist.md` or `.agents/skills/mms-recipe-dev/references/metamask-extension-checklist.md`; Claude/Cursor installs may expose the same files under their runner-specific skill directories). Do not search only for a repo-root `references/` folder and declare the checklist absent. Mark every step `[x]`, `BLOCKED`, or `N/A: <reason>`. After each step, write the artifact/path/result, then immediately continue to the next unchecked step.
-
-`CHECKLIST.md` must exist before editing product behavior. Update it after every gate, not only at the end. If you realize you skipped an earlier
-gate, stop, backfill the missing gate honestly, and continue from the earliest
-unchecked required step. Do not silently replace this workflow with an
-implementation/test-only workflow.
-
-Optimization rule: use lower-level skills as focused delegates instead of manually re-deriving their protocols. Call `/mms-recipe-harness` for setup, `/mms-recipe-cook` for recipe authoring, `/mms-recipe-quality` for critique, and `/mms-recipe-evidence` for PR-ready packaging. If the runner supports subagents/tasks, use a subagent for independent recipe-quality review and evidence-package critique. Do not delegate product code editing unless the user explicitly asked for multi-agent implementation.
-
-Hard gates:
-
-- AC matrix and proof plan happen before implementation.
-- Clean per-run branch gate happens before implementation.
-- Harness/cook/quality/evidence gates must explicitly invoke or follow the
-  corresponding lower-level skill; ad-hoc screenshots or helper scripts alone
-  are insufficient.
-- Implementation checks are not a stopping point.
-- Surgical diff audit must happen after product edits and before final evidence packaging.
-- Visual evidence must come from the recipe artifact package when runtime proof
-  applies; miscellaneous screenshots may be supporting evidence only.
-- Visual or mixed ACs require screenshot/video evidence tied to that AC.
-- State-only assertions cannot prove visible copy/color/layout claims.
-- Schema warnings on screenshot nodes are quality failures for visual tasks. Give
-  the `ui.screenshot` node a `description` of what it must prove and back any
-  "must (not) show" condition with a real assertion (`assert_json`/`assert_output`),
-  then rerun validation instead of treating warning-only schema output as clean.
-- The evidence package must contain `artifact-manifest.json` from the harness or
-  an explicit evidence manifest you create that lists `summary.json`,
-  `trace.json`, logs, screenshots/videos, quality verdict, and recipe path.
-- After final artifacts are captured, ask the human whether they want runtime
-  resources cleaned up now. Name the concrete resources (for example Metro
-  port, simulator/device, webpack/dev server, browser/CDP process, tmux pane)
-  and only stop/release them after confirmation, unless the user already asked
-  for cleanup.
-- If runtime proof is `N/A` or `BLOCKED`, the final response must say exactly why and must not claim runtime proof.
-- If a recipe step fails, inspect any failure screenshot before classifying the
-  blocker. A screenshot that visibly proves the target UI usually means the
-  recipe assertion/selector is wrong; fix the recipe and rerun instead of
-  reporting a product/runtime blocker.
-
-## Workflow
-
-1. Create the live `CHECKLIST.md` from the embedded platform checklist, then send the coffee handoff message with its path.
-2. Read the task/ticket and extract clear acceptance criteria. If the task description is too vague to prove, ask once for sharper criteria; when the user supplies it, continue without stopping.
-3. Select the target repo/platform and load the matching checklist reference.
-4. Write the AC matrix and proof modes before implementation.
-5. Write the proof plan, including whether before evidence is meaningful or `Baseline: N/A`.
-6. Call `/mms-recipe-harness` for install/verify when runtime proof applies.
-7. Call `/mms-recipe-cook` to draft the recipe before or alongside implementation planning.
-8. Make the smallest product change.
-9. Run focused implementation checks.
-10. Run the live recipe when applicable and save artifacts.
-11. Read screenshot PNGs for visual/mixed ACs; rerun if evidence is weak.
-12. Call `/mms-recipe-quality` or a recipe-quality subagent on recipe + artifacts.
-13. Improve once and rerun from the smallest meaningful point, unless quality says no rerun needed.
-14. Call `/mms-recipe-evidence` or package equivalent PR-ready evidence.
-15. Ask whether to clean up runtime resources such as Metro/simulator/webpack/CDP now, or record that they were intentionally left running for review.
-16. Return a PR-ready summary and stop for human validation unless asked to open a PR.
-
-For every visual or mixed acceptance criterion, the recipe must bring the target
-into the viewport and wait for it to be visible before capturing screenshot
-evidence (scroll into view, then wait — the runner polls until `timeout_ms`):
-
-```json
-[
-  { "action": "ui.scroll", "test_id": "target-test-id", "scroll_into_view": true },
-  { "action": "ui.wait_for", "test_id": "target-test-id", "visible": true, "timeout_ms": 10000 }
-]
-```
-
-Then capture the screenshot and describe what it must prove. Express any
-"must not show" condition as a real state assertion (`assert_json` over a
-`metamask.*` read, or `assert_output`), not a screenshot field:
-
-```json
-{
-  "action": "ui.screenshot",
-  "description": "AC1: target component is visible with the expected text",
-  "path": "screenshots/after-ac1-target-visible.png"
-}
-```
-
-Do not treat `ui.wait_for` fiber-tree/DOM presence, controller state, or a passing
-recipe as proof that a user can see the element. Visual claims need viewport
-visibility (`ui.scroll` + `ui.wait_for` with `visible`) plus a reviewer-visible
-screenshot, followed by human/quality review of the PNG/video.
-
-The evidence package should include: task URL or prompt, product diff summary, harness verify path, recipe path, exact run command, `summary.json`, `trace.json`, `artifact-manifest.json`, screenshots/video for UI claims, quality critique, and explicit gaps.
-
-If runtime state cannot be created, report the gap. Do not claim success from code inspection alone.
-
-## PR creation (offer)
-
-Once evidence is packaged, ASK the human whether to create a PR + upload evidence. If yes → `/mms-recipe-evidence` "Create PR + upload" (artifacts owner is dynamic via `gh api user`, never hard-coded; consent-gate every outward step: repo create, upload, PR create/edit).
-
-## Output
+Steps 1–4 precede implementation. A runtime blocker is valid only after step 6 or the
+relevant recipe run was actually attempted and the exact failure recorded.
+
+## Finish
+
+Ask whether to clean up runtime resources (Metro port, simulator/device, webpack/CDP, tmux
+pane) now or leave them for review. Once evidence is packaged, ask whether to open a PR; if
+yes, use `/mms-recipe-evidence` "Create PR + upload" (owner via `gh api user`, consent-gate
+every outward step). Then return:
 
 1. `Change` — files changed and why.
 2. `Recipe` — path and run command.

--- a/domains/agentic/skills/recipe-fix-ticket/references/metamask-extension-checklist.md
+++ b/domains/agentic/skills/recipe-fix-ticket/references/metamask-extension-checklist.md
@@ -1,96 +1,36 @@
 # Extension fix-ticket checklist
 
-Use this target-specific checklist for `metamask-extension` bug tickets. Execute in order; mark every row in the copied `CHECKLIST.md` with `[x]`, `BLOCKED`, or `N/A: <reason>`.
+Target checklist for `metamask-extension` bug tickets. Reproduce or understand the failure
+before patching.
 
-## Live checklist template
+This file is the human's live progress view. `init-checklist.sh` copies it to the task
+folder as `CHECKLIST.md`. Execute top-to-bottom; the moment a gate completes, flip
+`[ ]` → `[x]` (or `BLOCKED: <reason>` / `N/A: <reason>`) and add the artifact path/result
+under it.
 
-Copy this file to the task artifact folder as `CHECKLIST.md` before product edits. Execute top-to-bottom. Every gate is mandatory unless marked `N/A: <reason>` in the copied file. After each gate, edit the copied file from `[ ]` to `[x]` and add the artifact/path/result below that line. Do not mark final complete with unchecked required gates.
+- [ ] 0. Coffee handoff sent, naming this CHECKLIST.md path to monitor.
+- [ ] 1. Ticket captured — URL or pasted text, summary, ACs.
+- [ ] 2. AC matrix — numbered ACs; proof mode state/visual/mixed; primary evidence.
+- [ ] 3. Extension target selected — popup, sidepanel, fullscreen, dapp tab, or service-worker/controller + rationale.
+- [ ] 4. Repro/baseline plan written before behavior edits — route/tab, fixture/profile, selectors/testIDs, expected before evidence.
+- [ ] 5. /mms-recipe-doctor setup readiness recorded — fixtures/tools; malformed fixture or missing tool = BLOCKED.
+- [ ] 6. /mms-recipe-harness install/verify — manifest + verify path.
+- [ ] 7. /mms-recipe-cook baseline/no-state recipe — path + exact command, or `BLOCKED: <reason>`.
+- [ ] 8. Baseline/no-state recipe run — summary.json, trace.json, screenshot/manifest paths, or blocked reason.
+- [ ] 9. Minimal fix implemented — product diff (excl. harness/generated); every changed line maps to an AC, no unrelated refactor.
+- [ ] 10. Focused checks run — changed-file typecheck/Jest/lint. Not a stop gate.
+- [ ] 11. /mms-recipe-cook after/with-state recipe — path + exact command proving each AC.
+- [ ] 12. Runtime recipe run — summary.json, trace.json, manifest, logs.
+- [ ] 13. Visual evidence gate — read PNGs; claimed UI visible in viewport for visual/mixed ACs.
+- [ ] 14. /mms-recipe-quality critique — verdict; gaps assigned to product/recipe/fixture/harness/evidence.
+- [ ] 15. Improvement/rerun loop — one fix + rerun, or explicit no-rerun verdict.
+- [ ] 16. /mms-recipe-evidence package — PR-ready evidence block/file with artifact paths and blocked gaps.
+- [ ] 17. Final response — fix, tests, recipe evidence, quality loop, remaining risk. Ask about runtime cleanup; offer PR on consent.
 
-- [ ] **0. Coffee handoff + progress file** — Human-facing handoff names the copied `CHECKLIST.md` path to monitor.
-- [ ] **1. Ticket captured** — URL or pasted text, summary, requirements, ACs.
-- [ ] **2. AC matrix written** — Verbatim numbered ACs; proof mode: `state`, `visual`, or `mixed`; primary evidence.
-- [ ] **3. Target runtime selected** — Mobile/Extension + platform/env + rationale.
-- [ ] **3a. Clean per-run branch prepared** — Worktree clean or previous loop stashed; model-specific branch created; Jira branches start with lowercased ticket key plus hyphen (for example `tat-3216-...`); base SHA recorded for later diff comparison.
-- [ ] **3b. Clean generated harness/runtime state prepared** — Ignored stale outputs removed or task-local harness output selected; harness install path recorded.
-- [ ] **4. Baseline/repro plan written before behavior edits** — Route, fixture/state setup, selectors/testIDs, expected before evidence.
-- [ ] **5. `mms-recipe-harness` delegate completed install/verify** — Manifest + verify artifact path.
-- [ ] **6. Baseline/no-state recipe authored by `mms-recipe-cook`** — Recipe path + exact command, or `BLOCKED: <reason>`.
-- [ ] **7. Baseline/no-state recipe run** — `summary.json`, `trace.json`, screenshot/manifest paths, or blocked reason.
-- [ ] **8. Minimal fix implemented** — Product diff summary; no harness/generated files counted as product diff.
-- [ ] **8a. Surgical diff audit** — Every changed product line maps to an AC; no duplicate implementation surfaces; no unrelated cleanup/refactor.
-- [ ] **9. Focused checks run** — Changed-file typecheck/Jest/lint results. This is not a stop gate.
-- [ ] **10. After/with-state recipe updated by `mms-recipe-cook`** — Recipe path + exact command proving each AC.
-- [ ] **11. Runtime recipe run** — `summary.json`, `trace.json`, artifact manifest, logs.
-- [ ] **12. Visual evidence gate** — Read every PNG; for visual/mixed ACs, claimed UI is visible in viewport.
-- [ ] **13. `mms-recipe-quality` delegate/subagent critique** — Verdict table; gaps assigned to product/recipe/fixture/harness/evidence.
-- [ ] **14. Improvement/rerun loop** — One fix + rerun, or explicit “no rerun needed” from quality verdict.
-- [ ] **15. `mms-recipe-evidence` package** — PR-ready evidence block/file with artifact paths and blocked gaps.
-- [ ] **16. Resource cleanup prompt** — Ask whether to stop webpack/dev server/browser/CDP or keep runtime alive for review; record the answer.
-- [ ] **17. Final response** — Fix, tests, recipe evidence, quality loop, task path, PR package path, remaining risk.
+Extension notes:
 
-Extension-specific gates:
-
-- Before starting or restarting any runtime command, record the exact command and approval state in this checklist. After read-only runtime discovery, if the caller/orchestrator requires explicit runtime-start approval, do not create `manual-prewarm`, `nohup`, background tmux, detached `sleep`, ad-hoc cache-warming helpers, repo aliases such as `yarn a:ios` / `yarn a:android`, or direct preflight/start scripts such as `scripts/perps/agentic/start-metro.sh --launch` to bypass it; mark `BLOCKED: pending runtime-start approval` with the exact command instead. Prefer installed harness cache/watch-first commands after approval, and do not use Mobile `auto`, `default`, `clean`, `rebuild-native`, manual bundle prewarm/cache warming, Extension `--start-test-watch`, raw `yarn build:test`, or Extension prepare/build unless that exact heavier mode was explicitly approved.
-- Runner command form: Claude/Cursor use `/mms-recipe-*`; Codex/OpenAI agents use `$mms-recipe-*`. When this checklist names `/mms-recipe-harness`, `/mms-recipe-cook`, `/mms-recipe-quality`, `/mms-recipe-evidence`, or `/mms-recipe-wallet-control`, use the runner-appropriate command form or the installed delegate file path for the current runner.
-
-- Generated harness state must be clean before harness install. Remove stale ignored outputs (`${RECIPE_HARNESS_ROOT:-temp/agentic/recipe-harness}/extension`) then install normally. For task-local recipe artifacts, pass `--out <task-local-recipes>` to harness `verify`/`live` (install does not take `--out`); do not let live verify fall back to stale/default installed runner recipes. Delete the stale outputs first; the extension install is idempotent and has no overwrite/force flag.
-- Runtime discovery is portable: prefer `RECIPE_RUNTIME_CONTEXT`, `RECIPE_SLOT_ID`, `RECIPE_CDP_PORT`/`CDP_PORT`, `RECIPE_METRO_PORT`/`METRO_PORT`, `RECIPE_WATCHER_PORT`/`WATCHER_PORT`, simulator/device env, and installed harness summaries before probing fallback ports. If `temp/runtime/agentic-runtime.json` has `runtimeStart.approved: true` plus `runtimeStart.command`, recover runtime through `mms-recipe-harness` launch/live and let the harness run that approved command. Do not assume `9222` or start raw product builds when no context is present; record missing runtime context instead.
-- Harness boundary: do not edit installed `mms-recipe-harness`/wallet-control/cook/quality/evidence delegate files, `${RECIPE_HARNESS_ROOT:-temp/agentic/recipe-harness}` overlays, or copied adapter scripts during a product/ticket run. Inspect summaries/logs only enough to classify failures. If a harness code change is required, stop the runtime lane as `BLOCKED: harness defect` with artifact paths.
-- Delegate recovery order: runtime/CDP blockers go through `mms-recipe-harness` launch/live/verify with caller-approved context; wallet/login/account/route blockers go through `mms-recipe-wallet-control`; stateful setup blockers go through recipe/harness/wallet-supported real flows or documented pre-start fixtures. If the delegate cannot recover, stop with the concrete blocker and artifacts; do not jump to ad-hoc scripts, direct state mutation, or partial evidence packaging unless the human explicitly asks.
-
-- Because `/mms-recipe-fix-ticket` was invoked, do not switch to the dev protocol or mark baseline/repro `N/A` merely because the Jira says POC/debug. Attempt a before/no-state recipe or record the concrete `/mms-recipe-cook` blocker.
-- Name the browser context and UI target (`popup`, `sidepanel`, `fullscreen`, dapp tab, or service worker/controller).
-- Do not ask whether to proceed with harness/recipe validation after typecheck or Jest. Proceed automatically.
-- A stopped browser/dev server/CDP endpoint is not a user blocker only after runtime-start approval exists. If approval is required and absent, do not run prepare/watch/Chrome-launch/manual aliases; run static/no-start harness checks if useful, record `BLOCKED: pending runtime-start approval` with the exact command, and wait.
-- Only mark runtime proof `BLOCKED` after a concrete harness or recipe command has been attempted and failed for an external reason.
-- CDP bootstrap failure is a stop/root-cause gate, not a packaging gate. If a live Extension recipe cannot connect to the recorded CDP port, `/json/version` is unreachable, no extension target is available, or the runner emits no `summary.json`/`trace.json`, mark the runtime gate `BLOCKED: CDP bootstrap failed`, record the exact command/log path, stop before recipe-quality/evidence packaging, fix runtime/preflight root cause, then restart from clean generated harness state. Do not call this `pass-with-gaps` unless the human explicitly asks for a partial package.
-- Direct app/browser scripts, DOM evals, or screenshots are supporting evidence only. They do not satisfy gates 5–15 unless `/mms-recipe-harness`, `/mms-recipe-cook`, `/mms-recipe-quality`, and `/mms-recipe-evidence` were explicitly invoked/followed and produced the recipe package artifacts.
-- Do not claim recipe infrastructure is absent just because a repo-root `validate-recipe.js` is missing. Check installed skill delegate paths first (`.claude/skills/mms-recipe-harness`, `.agents/skills/mms-recipe-harness`, `.cursor/rules/mms-recipe-harness`) and follow their scripts/adapters. If no executable `recipe.json` plus harness-produced `summary.json` and `trace.json` exists, classify runtime/visual proof as `FAIL`/`BLOCKED: no recipe protocol`; ad-hoc CDP probes, manual evidence markdown, black screenshots, or human-to-confirm notes do not satisfy the recipe gates.
-- Do not manufacture proof by mutating app state: no `window.stateHooks`, `stateHooks.submitRequestToBackground`, Redux/store writes, React/fiber mutation, DOM injection, controller/provider mutation, or helper that directly creates, closes, clears, seeds, or inserts the target position/value/banner. Use a real user flow or harness-owned pre-start fixture; otherwise mark the affected AC as a fixture/runtime gap.
-- If visual proof is needed, screenshot after a `ui.wait_for` with `visible` (the target is present and on-screen); use `ui.scroll` with `scroll_into_view` first if it can be below the fold.
-- DOM query or controller eval success is not enough for UI claims; inspect the PNG.
-- For visual/mixed ACs, never mark an AC `code-proven`. If no runtime PNG/video exists because CDP/browser is unavailable, the visual AC is `BLOCKED: no runtime visual evidence`.
-- If CDP/browser state cannot be prepared and runtime-start approval exists, run harness recovery once before declaring `BLOCKED`. If runtime-start approval has not been granted, do not run prepare/watch/Chrome-launch or any command that starts a runtime process; record `BLOCKED: pending runtime-start approval` with the needed command and wait.
-- Fix schema warnings before packaging visual proof. Give `ui.screenshot` nodes a
-  `description` and assert "must (not) show" with `assert_json`/`assert_output`;
-  warning-only schema output is not a clean final state.
-- If the runner/harness does not emit `artifact-manifest.json`, create an
-  explicit evidence manifest that lists recipe path, exact command,
-  `summary.json`, `trace.json`, logs, screenshots/videos, quality verdict, and
-  remaining gaps.
-- `/mms-recipe-evidence` packaging must produce a PR-ready evidence block/file (for example `PR-READY-EVIDENCE.md`) and run `package-pr-evidence.js --task <task-dir>` so reviewers get `pr-package/pr-desc.md` based on the target repo `.github/pull-request-template.md` / `.github/pull_request_template.md`, `pr-package/images/` with easy-to-copy filenames, `pr-package/package-manifest.json`, and `pr-package/final-report.md`. A manifest-only package is still `PASS-WITH-GAPS` for the workflow packaging gate.
-- Final response must print `Task path:`, `PR package path:`, `PR description draft:`, and `Evidence images folder:` so the human can immediately copy/upload PR evidence.
-- Do not stop at an idle prompt after recipe PASS. Continue through gates 13-16
-  (`/mms-recipe-quality`, improvement/rerun or no-rerun verdict,
-  `/mms-recipe-evidence`, final summary).
-- A failed recipe/action node is not a final blocker after one attempt. Inspect
-  `summary.json`/`trace.json`, the failure screenshot/last-screen artifact, and
-  the actual target screen. If the failure is plausibly caused by route, wait,
-  hydration, scroll, obscured target, unstable click/press, or selector quality,
-  patch the recipe/flow and rerun the smallest meaningful segment before final
-  packaging. Only report `BLOCKED` after concrete retry attempts still fail, and
-  name the exact failed node plus artifacts. Unit tests or manual screenshot
-  suggestions do not replace the missing live recipe proof for visual/mixed ACs.
-- Fallback screenshot metadata controls verdict strength. If a screenshot PNG says
-  `DOM-rendered fallback evidence`, `native browser screenshot timed out/blank`,
-  or `trace.json` records `fallbackReason` for that screenshot, read and package
-  it but keep visual/mixed ACs at `PASS-WITH-GAPS` unless native screenshot/video
-  or an explicitly accepted non-fallback artifact also proves the claim. A recipe
-  `summary.json` pass, DOM/viewport wait, or unit test does not upgrade fallback
-  screenshots to clean visual proof.
-- Before writing `recipe-quality` or final evidence, perform and record an explicit fallback audit: count `trace.json` `fallbackReason`/`captureMode: dom-evidence-card-fallback` entries and read PNG headers/body for `DOM-rendered fallback evidence`. If fallback metadata exists, do not write `native screenshot`, `no fallback`, or clean visual `PASS` for affected ACs.
-- At the cleanup prompt, name the Extension resources that are still running
-  (webpack/dev server, browser/CDP port, service worker target, tmux pane). Do
-  not stop them until the human confirms, unless the user already asked for
-  cleanup. If kept alive, record why in `CHECKLIST.md`.
-- Stateful ACs require explicit setup. If an AC depends on app state such as
-  no-position vs open-position, the recipe must create/clear that state through
-  a real UI/harness flow or documented pre-start fixture before asserting the
-  UI. Do not rely on inherited browser/wallet state or prior validation runs. A
-  read-only observation recipe is only `PASS-WITH-GAPS`/`BLOCKED` for the
-  affected AC unless the required state setup is explicitly proven. Direct
-  background/controller cleanup or seeding, including
-  `stateHooks.submitRequestToBackground('perpsClosePositions', ...)`,
-  `perpsGetPositions`-driven proof, provider/controller mutation, or an ad-hoc
-  state helper, can be diagnostic/supporting evidence but cannot make the
-  no-position/open-position AC cleanly `met` by itself.
+- Because fix-ticket was invoked, do not switch to the dev protocol or mark baseline/repro `N/A` just because the ticket says POC/debug. Author a before/no-state recipe or record the concrete `/mms-recipe-cook` blocker. Name the fixture/flow used to create no-position/open-position state — don't rely on inherited browser/wallet state.
+- Runtime start (webpack/dev server/Chrome/CDP) is approval-gated: without approval, record `BLOCKED: pending runtime-start approval` with the exact command and wait; with approval, start through `/mms-recipe-harness`, not raw builds. A live recipe that can't reach CDP (`/json/version` unreachable, no extension target, no summary.json) is `BLOCKED: CDP bootstrap failed` — fix the root cause, don't downgrade to pass-with-gaps.
+- Visual/mixed ACs need a viewport-visible screenshot (`ui.scroll` + `ui.wait_for visible`), not DOM/controller state or a passing recipe alone; without a runtime PNG it is `BLOCKED: no runtime visual evidence`, never `code-proven`.
+- No manufactured state: don't inject via `stateHooks`, store/controller writes, or DOM mutation. Use a real UI flow or harness pre-start fixture, else mark the AC a fixture/runtime gap.
+- A fallback screenshot (`DOM-rendered fallback` / `fallbackReason` in trace.json) keeps that visual AC at `PASS-WITH-GAPS` even if summary.json says pass.

--- a/domains/agentic/skills/recipe-fix-ticket/references/metamask-mobile-checklist.md
+++ b/domains/agentic/skills/recipe-fix-ticket/references/metamask-mobile-checklist.md
@@ -1,133 +1,36 @@
 # Mobile fix-ticket checklist
 
-Use this target-specific checklist for `metamask-mobile` bug tickets. Execute in order; mark every row in the copied `CHECKLIST.md` with `[x]`, `BLOCKED`, or `N/A: <reason>`.
+Target checklist for `metamask-mobile` bug tickets. Reproduce or understand the failure
+before patching.
 
-## Live checklist template
+This file is the human's live progress view. `init-checklist.sh` copies it to the task
+folder as `CHECKLIST.md`. Execute top-to-bottom; the moment a gate completes, flip
+`[ ]` → `[x]` (or `BLOCKED: <reason>` / `N/A: <reason>`) and add the artifact path/result
+under it.
 
-Copy this file to the task artifact folder as `CHECKLIST.md` before product edits. Execute top-to-bottom. Every gate is mandatory unless marked `N/A: <reason>` in the copied file. After each gate, edit the copied file from `[ ]` to `[x]` and add the artifact/path/result below that line. Do not mark final complete with unchecked required gates.
+- [ ] 0. Coffee handoff sent, naming this CHECKLIST.md path to monitor.
+- [ ] 1. Ticket captured — URL or pasted text, summary, ACs.
+- [ ] 2. AC matrix — numbered ACs; proof mode state/visual/mixed; primary evidence.
+- [ ] 3. Mobile target selected — ios, android, or both + rationale.
+- [ ] 4. Repro/baseline plan written before behavior edits — route, fixture/state, selectors/testIDs, expected before evidence.
+- [ ] 5. /mms-recipe-doctor setup readiness recorded — fixtures/tools; malformed fixture or missing tool = BLOCKED.
+- [ ] 6. /mms-recipe-harness install/verify — manifest + verify path.
+- [ ] 7. /mms-recipe-cook baseline/no-state recipe — path + exact command, or `BLOCKED: <reason>`.
+- [ ] 8. Baseline/no-state recipe run — summary.json, trace.json, screenshot/manifest paths, or blocked reason.
+- [ ] 9. Minimal fix implemented — product diff (excl. harness/generated); every changed line maps to an AC, no unrelated refactor.
+- [ ] 10. Focused checks run — changed-file typecheck/Jest/lint. Not a stop gate.
+- [ ] 11. /mms-recipe-cook after/with-state recipe — path + exact command proving each AC.
+- [ ] 12. Runtime recipe run — summary.json, trace.json, manifest, logs.
+- [ ] 13. Visual evidence gate — read PNGs; claimed UI visible in viewport for visual/mixed ACs.
+- [ ] 14. /mms-recipe-quality critique — verdict; gaps assigned to product/recipe/fixture/harness/evidence.
+- [ ] 15. Improvement/rerun loop — one fix + rerun, or explicit no-rerun verdict.
+- [ ] 16. /mms-recipe-evidence package — PR-ready evidence block/file with artifact paths and blocked gaps.
+- [ ] 17. Final response — fix, tests, recipe evidence, quality loop, remaining risk. Ask about runtime cleanup; offer PR on consent.
 
-- [ ] **0. Coffee handoff + progress file** — Human-facing handoff names the copied `CHECKLIST.md` path to monitor.
-- [ ] **1. Ticket captured** — URL or pasted text, summary, requirements, ACs.
-- [ ] **2. AC matrix written** — Verbatim numbered ACs; proof mode: `state`, `visual`, or `mixed`; primary evidence.
-- [ ] **3. Target runtime selected** — Mobile/Extension + platform/env + rationale.
-- [ ] **3a. Clean per-run branch prepared** — Worktree clean or previous loop stashed; model-specific branch created; Jira branches start with lowercased ticket key plus hyphen (for example `tat-3216-...`); base SHA recorded for later diff comparison.
-- [ ] **4. Baseline/repro plan written before behavior edits** — Route, fixture/state setup, selectors/testIDs, expected before evidence.
-- [ ] **5. `mms-recipe-harness` delegate completed install/verify** — Manifest + verify artifact path.
-- [ ] **6. Baseline/no-state recipe authored by `mms-recipe-cook`** — Recipe path + exact command, or `BLOCKED: <reason>`.
-- [ ] **7. Baseline/no-state recipe run** — `summary.json`, `trace.json`, screenshot/manifest paths, or blocked reason.
-- [ ] **8. Minimal fix implemented** — Product diff summary; no harness/generated files counted as product diff.
-- [ ] **8a. Surgical diff audit** — Every changed product line maps to an AC; no duplicate implementation surfaces; no unrelated cleanup/refactor.
-- [ ] **9. Focused checks run** — Changed-file typecheck/Jest/lint results. This is not a stop gate.
-- [ ] **10. After/with-state recipe updated by `mms-recipe-cook`** — Recipe path + exact command proving each AC.
-- [ ] **11. Runtime recipe run** — `summary.json`, `trace.json`, artifact manifest, logs.
-- [ ] **12. Visual evidence gate** — Read every PNG; for visual/mixed ACs, claimed UI is visible in viewport.
-- [ ] **13. `mms-recipe-quality` delegate/subagent critique** — Verdict table; gaps assigned to product/recipe/fixture/harness/evidence.
-- [ ] **14. Improvement/rerun loop** — One fix + rerun, or explicit “no rerun needed” from quality verdict.
-- [ ] **15. `mms-recipe-evidence` package** — PR-ready evidence block/file with artifact paths and blocked gaps.
-- [ ] **16. Resource cleanup prompt** — Ask whether to stop Metro/release simulator or keep runtime alive for review; record the answer.
-- [ ] **17. Final response** — Fix, tests, recipe evidence, quality loop, task path, PR package path, remaining risk.
+Mobile notes:
 
-Mobile-specific gates:
-
-- Before starting or restarting any runtime command, record the exact command and approval state in this checklist. After read-only runtime discovery, if the caller/orchestrator requires explicit runtime-start approval, do not create `manual-prewarm`, `nohup`, background tmux, detached `sleep`, ad-hoc cache-warming helpers, repo aliases such as `yarn a:ios` / `yarn a:android`, or direct preflight/start scripts such as `scripts/perps/agentic/start-metro.sh --launch` to bypass it; mark `BLOCKED: pending runtime-start approval` with the exact command instead. Prefer installed harness cache/watch-first commands after approval, and do not use Mobile `auto`, `default`, `clean`, `rebuild-native`, manual bundle prewarm/cache warming, Extension `--start-test-watch`, raw `yarn build:test`, or Extension prepare/build unless that exact heavier mode was explicitly approved.
-- Runner command form: Claude/Cursor use `/mms-recipe-*`; Codex/OpenAI agents use `$mms-recipe-*`. When this checklist names `/mms-recipe-harness`, `/mms-recipe-cook`, `/mms-recipe-quality`, `/mms-recipe-evidence`, or `/mms-recipe-wallet-control`, use the runner-appropriate command form or the installed delegate file path for the current runner.
-
-- Runtime discovery is portable: prefer `RECIPE_RUNTIME_CONTEXT`, `RECIPE_SLOT_ID`, `RECIPE_CDP_PORT`/`CDP_PORT`, `RECIPE_METRO_PORT`/`METRO_PORT`, `RECIPE_WATCHER_PORT`/`WATCHER_PORT`, simulator/device env, and installed harness summaries before probing fallback ports. Do not assume `9222` or start raw product builds when no context is present; record missing runtime context instead.
-- Harness boundary: do not edit installed `mms-recipe-harness`/wallet-control/cook/quality/evidence delegate files, `${RECIPE_HARNESS_ROOT:-temp/agentic/recipe-harness}` overlays, or copied adapter scripts during a product/ticket run. Inspect summaries/logs only enough to classify failures. If a harness code change is required, stop the runtime lane as `BLOCKED: harness defect` with artifact paths.
-
-- Because `/mms-recipe-fix-ticket` was invoked, do not switch to the dev protocol or mark baseline/repro `N/A` merely because the Jira says POC/debug. Attempt a before/no-state recipe or record the concrete `/mms-recipe-cook` blocker.
-- Do not rely on inherited simulator state. Name the fixture or setup flow used to create no-position/open-position states.
-- Do not ask whether to proceed with harness/recipe validation after typecheck or Jest. Proceed automatically.
-- A stopped app/simulator/Metro is not a user blocker only after runtime-start approval exists. If approval is required and absent, do not run preflight/launch/manual aliases; run static/no-start harness checks if useful, record `BLOCKED: pending runtime-start approval` with the exact command, and wait.
-- Only mark runtime proof `BLOCKED` after a concrete harness or recipe command has been attempted and failed for an external reason.
-- Direct `scripts/perps/agentic/*` screenshots or evals are supporting evidence only. They do not satisfy gates 5–15 unless `/mms-recipe-harness`, `/mms-recipe-cook`, `/mms-recipe-quality`, and `/mms-recipe-evidence` were explicitly invoked/followed and produced the recipe package artifacts.
-- Do not claim recipe infrastructure is absent just because a repo-root `validate-recipe.js` is missing. Check installed skill delegate paths first (`.claude/skills/mms-recipe-harness`, `.agents/skills/mms-recipe-harness`, `.cursor/rules/mms-recipe-harness`) and follow their scripts/adapters. If no executable `recipe.json` plus harness-produced `summary.json` and `trace.json` exists, classify runtime/visual proof as `FAIL`/`BLOCKED: no recipe protocol`; ad-hoc CDP probes, manual evidence markdown, black screenshots, or human-to-confirm notes do not satisfy the recipe gates.
-- Do not manufacture proof by mutating app state: no `window.stateHooks`, `stateHooks.submitRequestToBackground`, Redux/store writes, React/fiber mutation, DOM/native-tree injection, controller/provider mutation, or helper that directly creates, closes, clears, seeds, or inserts the target position/value/banner. Use a real user flow or harness-owned pre-start fixture; otherwise mark the affected AC as a fixture/runtime gap.
-- If visual proof is needed, screenshot after a `ui.wait_for` with `visible` (the target is present and on-screen).
-- If the target can be below the fold, use `ui.scroll` with `scroll_into_view` before the screenshot.
-- Fiber-tree/eval success is not enough for UI claims; inspect the PNG.
-- For visual/mixed ACs, never mark an AC `code-proven`. If no runtime PNG/video exists because Metro/CDP/device is unavailable, the visual AC is `BLOCKED: no runtime visual evidence`.
-- Fix schema warnings before packaging visual proof. Give `ui.screenshot` nodes a
-  `description` and assert "must (not) show" with `assert_json`/`assert_output`;
-  warning-only schema output is not a clean final state.
-- If the runner/harness does not emit `artifact-manifest.json`, create an
-  explicit evidence manifest that lists recipe path, exact command,
-  `summary.json`, `trace.json`, logs, screenshots/videos, quality verdict, and
-  remaining gaps.
-- `/mms-recipe-evidence` packaging must produce a PR-ready evidence block/file (for example `PR-READY-EVIDENCE.md`) and run `package-pr-evidence.js --task <task-dir>` so reviewers get `pr-package/pr-desc.md` based on the target repo `.github/pull-request-template.md` / `.github/pull_request_template.md`, `pr-package/images/` with easy-to-copy filenames, `pr-package/package-manifest.json`, and `pr-package/final-report.md`. A manifest-only package is still `PASS-WITH-GAPS` for the workflow packaging gate.
-- Final response must print `Task path:`, `PR package path:`, `PR description draft:`, and `Evidence images folder:` so the human can immediately copy/upload PR evidence.
-- Do not stop at an idle prompt after recipe PASS. Continue through gates 13-16
-  (`/mms-recipe-quality`, improvement/rerun or no-rerun verdict,
-  `/mms-recipe-evidence`, final summary).
-- A `pass-with-gaps` quality verdict is not full completion. Package it, but
-  report the lane as `PASS-WITH-GAPS`/`PARTIAL` and list each unproved AC.
-- If a recipe node fails, read the failure PNG before diagnosing the blocker.
-  When the PNG visibly proves the UI claim, fix the recipe selector/assertion and
-  rerun; do not call it a navigation/product blocker from the route JSON alone.
-- For CDP recovery, do not run `scripts/perps/agentic/cdp-bridge.js` without a
-  subcommand. Use `/mms-recipe-harness` verify/preflight or the repo preflight
-  wrapper, then require `app-state.sh status` to return a route/account instead
-  of `[]`.
-- For Perps home recipes, avoid the broad `Perps` root target when it lands on
-  wallet tab routing. Prefer the screen-specific target (`PerpsHomeView` /
-  `PerpsMarketListView`) and let screenshot validation decide whether the
-  resulting screen is correct.
-- If Mobile can prove the target exists in fiber/tree but cannot viewport-measure
-  a newly-added React Native node (`Target exists in fiber tree but no measurable
-  native node was found`), do not claim a clean visual pass from the tree result.
-  Either add a better measurable target/scroll/navigation and rerun, or keep the
-  verdict `PASS-WITH-GAPS` and rely on visually-read screenshots as weaker proof.
-- If preflight/verify succeeds but a later recipe loses Metro/CDP, try running
-  preflight and the v1 runner (`${RECIPE_HARNESS_ROOT:-temp/agentic/recipe-harness}/mobile/runner/bin/metamask-recipe run ...`) in one shell so Metro remains alive, then
-  record that command in the evidence package.
-- If the artifact manifest lists logical screenshot names but the runner writes
-  timestamped PNGs, create/update an evidence manifest with the actual PNG paths
-  before final packaging.
-- A failed recipe/action node is not a final blocker after one attempt. Inspect
-  `summary.json`/`trace.json`, the failure screenshot/last-screen artifact, and
-  the actual target screen. If the failure is plausibly caused by route, wait,
-  hydration, scroll, obscured target, unstable click/press, or selector quality,
-  patch the recipe/flow and rerun the smallest meaningful segment before final
-  packaging. Only report `BLOCKED` after concrete retry attempts still fail, and
-  name the exact failed node plus artifacts. Unit tests or manual screenshot
-  suggestions do not replace the missing live recipe proof for visual/mixed ACs.
-- A failed precondition node is also not final after one attempt. If the live
-  run stops on `Login`, `wallet.unlocked`, `perps.ready_to_trade`,
-  `perps.sufficient_balance`, `CLIENT_NOT_INITIALIZED`, no CDP target, or a
-  stopped simulator, check runtime-start approval first. If approval has not
-  been granted, do not run prepare/launch/simulator-boot or any recovery command
-  that starts a runtime process; run static/no-start harness checks if useful,
-  record `BLOCKED: pending runtime-start approval` with the needed command, and
-  wait. If runtime-start approval exists, run `/mms-recipe-harness`
-  verify/preflight and `/mms-recipe-wallet-control`/wallet setup using the
-  provided `RECIPE_RUNTIME_CONTEXT`, `RECIPE_SLOT_ID`, `IOS_SIMULATOR`,
-  `SIMULATOR`, `WATCHER_PORT`, `METRO_PORT`, `ANDROID_SERIAL`, `ADB_SERIAL`,
-  or equivalent caller-provided runtime env. Record the recovery command,
-  app-state/status output, and rerun command. Static-only verify plus a failed
-  live precondition is `PASS-WITH-GAPS`/`BLOCKED_PRECONDITIONS`, not a complete
-  visual proof package.
-- Fallback screenshot metadata controls verdict strength. If a screenshot PNG says
-  `DOM-rendered fallback evidence`, `native browser screenshot timed out/blank`,
-  or `trace.json` records `fallbackReason` for that screenshot, read and package
-  it but keep visual/mixed ACs at `PASS-WITH-GAPS` unless native screenshot/video
-  or an explicitly accepted non-fallback artifact also proves the claim. A recipe
-  `summary.json` pass, DOM/viewport wait, or unit test does not upgrade fallback
-  screenshots to clean visual proof.
-- Before writing `recipe-quality` or final evidence, perform and record an explicit fallback audit: count `trace.json` `fallbackReason`/`captureMode: dom-evidence-card-fallback` entries and read PNG headers/body for `DOM-rendered fallback evidence`. If fallback metadata exists, do not write `native screenshot`, `no fallback`, or clean visual `PASS` for affected ACs.
-- At the cleanup prompt, name the Mobile resources that are still running
-  (Metro port, simulator/device, app process, tmux pane). Do not stop them until
-  the human confirms, unless the user already asked for cleanup. If kept alive,
-  record why in `CHECKLIST.md`.
-- Runtime recovery is capped: after one harness/preflight recovery and one targeted rerun, do not keep rebuilding native iOS/Android or repeatedly restarting Metro/CDP. If the app cannot keep a reachable target, package `BLOCKED_RUNTIME` with transcript, Metro/CDP logs, and the last `summary.json`/`trace.json`.
-- Stateful setup must branch on existing state. If the account already has BTC, an open-position button may be intentionally absent; route to the open-position visual AC or close/clear via documented real UI/harness flow before the no-position lane. Do not mark a wait timeout on an absent open button as final without reading the screen and checking current positions/route.
-- Stateful ACs require explicit setup. If an AC depends on app state such as
-  no-position vs open-position, the recipe must create/clear that state through
-  a real UI/harness flow or documented pre-start fixture before asserting the
-  UI. Do not rely on inherited browser/wallet state or prior validation runs. A
-  read-only observation recipe is only `PASS-WITH-GAPS`/`BLOCKED` for the
-  affected AC unless the required state setup is explicitly proven. Direct
-  background/controller cleanup or seeding, including
-  `stateHooks.submitRequestToBackground('perpsClosePositions', ...)`,
-  `perpsGetPositions`-driven proof, provider/controller mutation, or an ad-hoc
-  state helper, can be diagnostic/supporting evidence but cannot make the
-  no-position/open-position AC cleanly `met` by itself.
+- Because fix-ticket was invoked, do not switch to the dev protocol or mark baseline/repro `N/A` just because the ticket says POC/debug. Author a before/no-state recipe or record the concrete `/mms-recipe-cook` blocker. Name the fixture/flow used to create no-position/open-position state — don't rely on inherited simulator state.
+- Runtime start (Metro/simulator) is approval-gated: without approval, record `BLOCKED: pending runtime-start approval` with the exact command and wait; with approval, start through `/mms-recipe-harness`, not raw `yarn`/native rebuilds.
+- Visual/mixed ACs need a viewport-visible screenshot (`ui.scroll` + `ui.wait_for visible`), not fiber-tree/controller state or a passing recipe alone; without a runtime PNG it is `BLOCKED: no runtime visual evidence`, never `code-proven`.
+- No manufactured state: don't inject via `stateHooks`, store/controller writes, or DOM/fiber mutation. Use a real UI flow or harness pre-start fixture, else mark the AC a fixture/runtime gap.
+- A fallback screenshot (`DOM-rendered fallback` / `fallbackReason` in trace.json) keeps that visual AC at `PASS-WITH-GAPS` even if summary.json says pass.

--- a/domains/agentic/skills/recipe-fix-ticket/skill.md
+++ b/domains/agentic/skills/recipe-fix-ticket/skill.md
@@ -1,741 +1,125 @@
 ---
 name: recipe-fix-ticket
-description: Fix a MetaMask bug from a Jira/GitHub ticket using recipe-backed validation. Use when an agent needs to reproduce or understand an existing failure, implement a minimal fix, prove the acceptance criteria with a recipe, and prepare reviewer-ready evidence.
+description: Fix a MetaMask bug from a Jira/GitHub ticket and prove it with a recipe. The human hands off a ticket and walks away; this drives ticket → repro → minimal fix → recipe proof → evidence package, then stops for review. Use when an agent must reproduce or understand an existing failure before fixing it. For new behavior with no bug to reproduce, use /mms-recipe-dev.
 maturity: experimental
 ---
 
 # Recipe Fix Ticket
 
-`recipe-fix-ticket` is for bug-fix work that must end with proof, not just a patch. Unlike `/mms-recipe-dev`, it starts by reproducing or understanding an existing failure before making the smallest fix.
-
-If the user invoked `/mms-recipe-fix-ticket`, stay in the fix-ticket protocol
-even when the ticket is a POC/debug change or looks feature-like. Do not
-silently downgrade baseline/repro gates to `N/A` because the change is "new".
-For visual/stateful tickets, still create a before/no-state recipe or record the
-specific failed `/mms-recipe-cook` attempt that made baseline proof impossible.
-
-## Runner Invocation Compatibility
-
-Different agent runners expose installed skills differently:
-
-- Claude/Cursor: use the slash-command form, for example `/mms-recipe-fix-ticket <ticket>`.
-- Codex/OpenAI agents: use the skill trigger form, for example `$mms-recipe-fix-ticket <ticket>`.
-
-If a human pasted the wrong runner-specific command shape and the runner rejects
-it, immediately continue by translating to the correct equivalent command. Do
-not stop or ask the human to re-run the command. Record the runner-specific
-invocation correction in the evidence package and continue through the full
-checklist.
-
-Recommended Codex/OpenAI-agent invocation shape:
-
-```text
-$mms-recipe-fix-ticket <ticket-or-task-url>
-```
-
-For `/mms-recipe-dev`, use `$mms-recipe-dev <ticket-or-task-url-or-task-prompt>`.
-
-## Live Checklist File Protocol
-
-Before product edits, before implementation planning, and before telling the
-human to go get coffee, create a live checklist file from the installed platform reference:
-
-```bash
-# Pick mobile or extension after identifying the target repo from cwd/ticket.
-.agents/skills/mms-recipe-fix-ticket/scripts/init-checklist.sh --platform <mobile|extension> --slug <ticket-or-task-slug>
-```
-
-If the skill is installed somewhere else, run the same script from the installed
-skill directory, or manually copy the matching reference checklist to:
-
-```text
-temp/tasks/<skill>/<timestamp>-<slug>/CHECKLIST.md
-```
-
-The copied `CHECKLIST.md` is the source of truth for progress. It must contain
-`[ ]` checkboxes. After every gate:
-
-1. edit `CHECKLIST.md` from `[ ]` to `[x]` for the completed gate;
-2. add the artifact path, command, result, or blocker under that gate;
-3. immediately continue to the next unchecked gate.
-
-Do not rely on private scratch notes as the progress record. Do not final-answer
-with unchecked required gates unless the remaining gates are explicitly marked
-`BLOCKED: <concrete reason>` or `N/A: <reason>` in `CHECKLIST.md`. No
-`SIGNAL.json` is required for interactive skill runs.
-
-
-## Karpathy-Style Execution Discipline
-
-Apply this discipline throughout the workflow:
-
-- Think before coding: if task source, target surface, ACs, fixture state, or evidence requirement is ambiguous, record the ambiguity in `CHECKLIST.md` and ask once before product edits.
-- Simplicity first: implement the smallest reversible change that satisfies the stated ACs. Do not add abstractions, generic actions, or speculative configuration unless the recipe proof requires it.
-- Surgical changes: every changed product line must trace to an AC. Do not refactor adjacent code, move existing logic, or clean unrelated files.
-- Goal-driven execution: each checklist gate must have a concrete verifier/path/result. Do not mark `[x]` from intent, code inspection, or tests that do not cover the gate.
-
-
-## Clean Per-Run Branch Protocol
-
-Every new validation loop must run on a clean, model-specific branch so the
-human can compare Claude/Codex/Cursor diffs afterwards. Before product edits:
-
-1. ensure the worktree has no unstaged product changes from a previous loop; if
-   it does, stash them with a descriptive `adr58-validation-...` message and
-   record the stash in `CHECKLIST.md`;
-2. record the base branch and base SHA in `CHECKLIST.md`;
-3. create or switch to a fresh branch named with the runner/model, skill, ticket
-   or task slug, and run id. If the source is a Jira ticket, the branch name
-   **must start with the lowercased Jira key followed by a hyphen** on both
-   Mobile and Extension targets so regular MetaMask tooling can
-   associate it, for example
-   `tat-3216-adr58-codex-mms-recipe-fix-ticket-fresh2`. For non-Jira prompts, use a
-   stable sanitized task slug such as `adr58-codex-mms-recipe-fix-ticket-demo-fresh1`;
-4. keep all product edits for that loop on that branch only;
-5. include branch name, base SHA, and `git diff --stat <base>...HEAD` in the
-   final evidence package.
-
-If the branch cannot be made clean, mark the branch gate `BLOCKED` before
-implementation. Do not mix multiple model attempts on the same product branch.
-
-## Setup Doctor Gate
-
-Before reproduction planning or harness install, invoke/follow
-`/mms-recipe-doctor` from the target checkout when it is installed:
-
-```bash
-.agents/skills/mms-recipe-doctor/scripts/recipe-doctor --target .
-```
-
-Record the doctor status in `CHECKLIST.md`, including fixture/profile status.
-If it reports missing fixtures only, continue only after recording that wallet
-setup may be slower/manual or after the human chooses to create the fixture. If
-it reports an invalid/malformed fixture, missing required tools, or missing
-harness skills, mark the gate `BLOCKED` and fix setup before product edits.
-
-## Clean Generated Harness State Protocol
-
-A clean product worktree is not enough. Generated, ignored harness/runtime
-outputs can make a fresh run reuse stale recipe code or stale CDP metadata.
-Before the proof plan or harness install gate, record and clean these generated
-paths for the current target repo unless the caller explicitly asks to preserve
-runtime state for debugging:
-
-```bash
-rm -rf "${RECIPE_HARNESS_ROOT:-temp/agentic/recipe-harness}/extension" "${RECIPE_HARNESS_ROOT:-temp/agentic/recipe-harness}/mobile"
-rm -rf temp/tasks/<this-run>/harness
-```
-
-Then reinstall the lower-level harness from the currently installed skill. The
-install manifest also records an exact `cleanupCommand` (it honors
-`RECIPE_HARNESS_ROOT`) for the full backup-aware cleanup. Do not pass
-`--force-overlay`; deleting known generated outputs first is the idempotent
-refresh. Do not edit `.agents/skills/...`, `.claude/skills/...`, or harness
-source files during product validation.
-
-For Extension, keep task-local recipe artifacts isolated from shared installed
-runner recipe state by passing `--out` to `verify`/`live` (install does not take
-`--out`):
-
-```bash
-# Install normally (writes the harness under the resolved root):
-.agents/skills/mms-recipe-harness/scripts/recipe-harness.sh extension install --target .
-# Task-local recipe artifacts: verify/live honor --out
-.agents/skills/mms-recipe-harness/scripts/recipe-harness.sh extension verify --target . --out temp/tasks/<this-run>/harness/recipes
-```
-
-Run and validate recipes through the v1 runner —
-`${RECIPE_HARNESS_ROOT:-temp/agentic/recipe-harness}/extension/runner/bin/metamask-recipe run ...`,
-then `farmslot-recipe validate ...` (see recipe-cook). If an existing shared
-harness install must be reused, verify its manifest and content hash in
-`CHECKLIST.md`; do not silently reuse stale ignored files.
-
-## First Response to the Human
-
-After creating `CHECKLIST.md`, immediately acknowledge the handoff with a short, friendly message that includes the checklist path the human can monitor. Use this exact spirit, adapted only if the user gave a stricter tone:
-
-> Ok, relax and go get a coffee ☕. I’ll take this from ticket → fix → recipe → evidence package. You can monitor live progress in `<CHECKLIST.md path>`, and I’ll report back when it is done or concretely blocked.
-
-After that message, continue autonomously. Do not wait for the user after the
-acknowledgement. If Jira/MCP cannot fetch the ticket, ask for the missing ticket
-text once; after the user pastes it, resume at checklist step 1 and continue to
-the recipe/evidence gates.
-
-
-## Runtime Startup Approval Gate
-
-Before any command that can start or restart a live runtime, write the exact
-command and approval state in `CHECKLIST.md`. This includes Mobile Metro,
-simulator/app launch, bundle prewarm/cache-warming helpers, `recipe-harness
-live`, Extension webpack/watch, Chrome/CDP launch, and any wrapper that would
-prepare/build runtime artifacts.
-
-Respect the caller/orchestrator policy for the lane. If the current goal,
-checklist, or human says runtime startup needs explicit approval, do **not**
-work around that by creating `manual-prewarm`, `nohup`, background tmux,
-`sleep`/detached shell, ad-hoc cache-warming helpers, repo aliases such as
-`yarn a:ios` / `yarn a:android`, or direct preflight/start scripts such as
-`scripts/perps/agentic/start-metro.sh --launch`. Instead record `BLOCKED:
-pending runtime-start approval` with the exact command you would run and
-continue only after approval is provided.
-
-When approval exists, prefer the installed harness delegate and cache/watch-first
-commands. Do not run Mobile `auto`, `default`, `clean`, `rebuild-native`,
-manual bundle prewarm/cache warming, Extension `--start-test-watch`, or
-Extension prepare/build unless that heavier mode was explicitly approved.
-
-## Portable Runtime Discovery Gate
-
-Before choosing any runtime command or port, perform read-only discovery in this
-order and record the result in `CHECKLIST.md`:
-
-1. caller-provided runtime context: `RECIPE_RUNTIME_CONTEXT` JSON path,
-   `RECIPE_SLOT_ID`, `RECIPE_CDP_PORT`, `CDP_PORT`, `RECIPE_METRO_PORT`,
-   `METRO_PORT`, `RECIPE_WATCHER_PORT`, `WATCHER_PORT`, `IOS_SIMULATOR`,
-   `SIMULATOR`, `ANDROID_SERIAL`, `ADB_SERIAL`, and comparable env vars;
-2. repo-local generic runtime context: `temp/runtime/agentic-runtime.json`
-   (and `temp/runtime/agentic-runtime.env` if you want to source it). If this
-   file has `strict: true`, use only the recorded slot/port/device values and
-   do not probe or fall back to other local runtimes. If it has
-   `runtimeStart.approved: true` plus `runtimeStart.command`, pass recovery
-   through `/mms-recipe-harness` launch/live/verify and let the harness run that
-   approved command; outside managed runtimes, any developer/tool may provide the same
-   context or `RECIPE_RUNTIME_START_APPROVED=1` with `RECIPE_RUNTIME_START_CMD`;
-3. installed recipe-harness/delegate summaries or manifests in the current
-   checkout that identify an already-owned runtime;
-4. currently listening local CDP/device endpoints only as fallbacks, never as a
-   reason to ignore caller-provided context.
-
-Do not assume default ports such as `9222` when no context was supplied. Do not
-turn missing runtime context into a raw product build (`yarn build:test`,
-`start:test`, native rebuild, or direct Chrome/simulator launch). Use static
-verify/no-start checks where useful, then record the missing runtime context or
-needed harness command as the blocker.
-
-## Harness Boundary Gate
-
-This high-level skill owns product code, recipes, and evidence. It does **not**
-own the lower-level harness implementation during a product/ticket run. Do not
-edit installed delegate files such as `.agents/skills/mms-recipe-harness`,
-`.claude/skills/mms-recipe-harness`, `.cursor/rules/mms-recipe-harness`,
-`${RECIPE_HARNESS_ROOT:-temp/agentic/recipe-harness}`, or copied harness adapter scripts while fixing a
-product ticket or validating this high-level workflow.
-
-If the harness fails, inspect only enough logs/summaries to classify the failure
-and capture artifact paths. Rerun only with documented harness flags and the
-discovered runtime context. If success would require changing harness code, stop
-the runtime lane as `BLOCKED: harness defect` (or `PASS-WITH-GAPS` for product
-code already checked) and report the exact summary/log path. Do not patch the
-harness unless the explicit task is a harness-maintenance task.
-
-## Delegate Recovery Decision Tree
-
-When a live proof is blocked, escalate through the lower-level delegates before
-using ad-hoc commands or packaging partial evidence:
-
-1. **Runtime/CDP unavailable** — use `/mms-recipe-harness` (or the installed
-   delegate path) to launch, live-verify, or recover the runtime with the
-   caller-approved context/prepare command. The high-level skill should not run
-   raw build/watch/Chrome/simulator commands when a harness path exists. If no
-   runtime context or start approval exists, stop with `BLOCKED: missing runtime
-   context` or `BLOCKED: pending runtime-start approval`.
-2. **Wallet locked, wrong account, onboarding, route, or app-ready blocker** —
-   use `/mms-recipe-wallet-control` (or the installed delegate path) for unlock,
-   account, route, and wallet readiness primitives. Do not invent private aliases
-   or mutate controller/store state to prove user-visible ACs.
-3. **Stateful product setup unavailable** — use recipe/harness/wallet-control
-   supported flows or documented pre-start fixtures. If no real flow/fixture
-   exists, record a fixture/state setup blocker; do not manufacture the target
-   state.
-4. **Delegate cannot recover** — stop at the concrete blocker with command/log
-   paths. Fix the delegate/runtime/root cause and restart from clean generated
-   harness state rather than continuing to a partial evidence package, unless
-   the human explicitly asks for partial packaging.
-
-## CDP Bootstrap Failure Stop Gate
-
-For Extension visual or mixed ACs, a live recipe that fails before CDP session
-bootstrap (for example `ECONNREFUSED 127.0.0.1:<port>`, missing `/json/version`,
-no extension target, or no `summary.json`/`trace.json` emitted) is not a
-quality/evidence packaging condition. Stop the product validation lane, record
-`BLOCKED: CDP bootstrap failed`, preserve the exact command/log path, and fix
-the runtime/preflight root cause before restarting from a clean generated
-harness state.
-
-Only continue to recipe-quality/evidence packaging after either:
-
-1. the live recipe emitted normal runtime artifacts (`summary.json`,
-   `trace.json`, artifact manifest, screenshots/video where applicable); or
-2. the human explicitly asks for a partial package despite the bootstrap
-   blocker.
-
-Do not convert pre-bootstrap CDP failure into `pass-with-gaps`. Do not keep
-retrying inside the same dirty product run. Fix the root cause, clean generated
-outputs, and restart.
-
-## Ticket Source-of-Truth Gate
-
-The ticket text or pasted task details are the source of truth. If Jira, MCP,
-WebFetch, or browser access returns a login wall, timeout, permission error,
-empty issue, or ambiguous page, ask the human for the ticket summary,
-description, requirements, and acceptance criteria before coding. Do this even
-if branch names, prior artifacts, local task folders, web search results, or
-repo history look suggestive.
-
-Do **not** infer or rewrite acceptance criteria from branch names, stale ADR58
-artifacts, previous validation runs, or web search. Do **not** change the target
-surface (for example Perps home vs market detail), gating condition, exact copy,
-or required state unless the ticket text says so. If ticket details remain
-unavailable, stop before product edits and report `BLOCKED: missing ticket
-source of truth`; do not implement a guessed patch.
-
-Before editing product code, print the extracted AC matrix with the exact target
-surface, state precondition, copy, styling, and proof requirement. If any field
-is inferred rather than stated, label it `UNKNOWN` and ask for the missing ticket
-text instead of proceeding.
-
-Load only what applies:
-
-- Setup readiness: `/mms-recipe-doctor`
-- Runtime setup: `/mms-recipe-harness`
-- Recipe authoring: `/mms-recipe-cook`
-- Recipe critique: `/mms-recipe-quality`
-- PR evidence formatting: `/mms-recipe-evidence`
-- Target-repo fix notes are appended below when installed.
-- Target checklist reference: load only one of `references/metamask-mobile-checklist.md` or `references/metamask-extension-checklist.md`.
-
-## Lower-Level Skill Invocation Contract
-
-The lower-level recipe skills are required gates, not optional background
-reading. For every delegate gate, do one of these explicitly:
-
-1. invoke the named skill using the runner-specific command form (slash for Claude/Cursor, `$` for Codex) if the runner supports nested skill calls; or
-2. if nested slash calls are unavailable, open the installed skill file and
-   follow it as the delegate protocol:
-   - `.claude/skills/mms-recipe-harness/SKILL.md`
-   - `.claude/skills/mms-recipe-cook/SKILL.md`
-   - `.claude/skills/mms-recipe-quality/SKILL.md`
-   - `.claude/skills/mms-recipe-evidence/SKILL.md`
-   - equivalent `.agents/skills/.../SKILL.md` or `.cursor/rules/.../RULE.md`
-     when running under Codex/OpenAI agents or Cursor.
-
-For each delegate, write `Invoking mms-recipe-...` in `CHECKLIST.md` and
-record the delegate output path or blocker. Direct ad-hoc app scripts,
-controller evals, DOM/fiber checks, screenshots, or unit tests do **not**
-satisfy these gates unless they are wrapped into the recipe protocol with an
-executable recipe path, exact command, `summary.json`, `trace.json`, artifact
-manifest, recipe-quality critique, and evidence package.
-
-Do **not** claim recipe tooling is absent just because a repo-root
-`validate-recipe.js` or `scripts/recipe-*` file is missing. Before declaring a
-recipe/harness blocker, inspect the installed delegate locations for the current
-runner:
-
-- `.claude/skills/mms-recipe-harness/SKILL.md` and `scripts/` / `adapters/`;
-- `.agents/skills/mms-recipe-harness/SKILL.md` and `scripts/` / `adapters/`;
-- `.cursor/rules/mms-recipe-harness/RULE.md` and copied references/scripts.
-
-If the installed delegate exists, follow it. If no executable recipe run exists
-(no `recipe.json` plus `summary.json` and `trace.json` from the harness), final
-status for runtime/visual work is `FAIL` or `BLOCKED: no recipe protocol`, not
-`PASS-WITH-GAPS`. Ad-hoc CDP probes, handwritten evidence packages, black
-screenshots, or “human should visually confirm” instructions are supporting
-notes only; they do not satisfy harness/cook/quality/evidence gates.
-
-## No Manufactured Runtime State
-
-Do **not** prove a user-visible AC by mutating app/UI/runtime state directly.
-Forbidden proof setup includes `window.stateHooks`,
-`stateHooks.submitRequestToBackground`, Redux/store writes, React/fiber
-mutation, DOM injection, controller/provider state mutation, or any ad-hoc
-helper that directly creates, closes, clears, seeds, or inserts the target
-value/position/banner into the running app. These may be useful for diagnosis,
-but they are not valid AC proof.
-
-Valid proof must use one of:
-
-- the real user flow encoded as a recipe;
-- a documented fixture/profile loaded before app start by the harness; or
-- an honest `BLOCKED`/`PASS-WITH-GAPS` verdict that names the missing fixture or
-  runtime capability.
-
-If a recipe uses state injection or controller/background calls to create or
-clear the exact condition being asserted (for example injecting or closing a BTC
-Perps position, mutating a controller value, inserting a banner/form value, or
-changing a DOM node), the corresponding stateful AC is **not clean proof**. It
-may be included as diagnostic/supporting evidence only; keep the affected AC at
-`PASS-WITH-GAPS`/`BLOCKED` until a real UI flow or documented harness-owned
-pre-start fixture proves the state. Do not call it `code-proven`, `visually
-proven`, or `all ACs met`; classify it as a fixture/recipe gap and feed that
-back to `/mms-recipe-cook`.
-
-## Non-Negotiable Proof Contract
-
-For user-visible, stateful, or acceptance-criteria-driven tickets, do **not**
-stop at a code diff, unit tests, or type checks. A complete fix package must
-include:
-
-- the ticket URL or copied ticket prompt;
-- a product diff summary excluding harness/generated files;
-- `/mms-recipe-harness` install/verify status and artifact path;
-- an executable recipe path;
-- the exact recipe run command;
-- `summary.json`;
-- `trace.json`;
-- `artifact-manifest.json` or evidence manifest;
-- screenshots/video for reviewer-visible UI claims;
-- `/mms-recipe-quality` critique;
-- one improvement/rerun cycle, or an explicit note that the first pass already
-  meets the evidence bar;
-- a PR-ready evidence summary;
-- explicit gaps for any unexercised proof target.
-
-If the runtime cannot create the required state (for example a BTC open-position
-fixture is unavailable), mark that proof target as `blocked`/`gap`. Do **not**
-claim the acceptance criteria are met from code inspection or unit tests alone.
-If any acceptance criterion remains unrun, blocked, or covered only by weaker
-fallback proof, the final verdict is `PASS-WITH-GAPS` or `PARTIAL`, not
-`complete`, `all ACs met`, or `ready`. DOM-rendered fallback screenshots
-created because native screenshot capture timed out/blank count as weaker
-fallback proof for visual ACs: package them, read them, and keep the gap in the
-final verdict unless a native screenshot/video (or explicitly accepted alternate
-artifact) also exists. Packaging the gap is required, but it
-does not turn the gap into a pass.
-
-For visual or mixed ACs, "code-proven" is not a valid proof status. Code review
-can prove minimality or placement intent, but visible copy/color/layout/ordering
-remain unproved until a live runtime recipe produces screenshot/video evidence
-that the runner reads visually. If CDP/browser is unavailable, mark those ACs
-`BLOCKED: no runtime visual evidence`.
-
-## Runtime Failure Recovery Gate
-
-A failed live recipe node is not automatically a final blocker. Before final
-packaging, inspect the failed node in `summary.json`/`trace.json`, read any
-failure screenshot or last-screen artifact, and decide whether the failure is a
-recipe/action sequencing issue that can be fixed locally. Typical fixable cases
-include wrong route, below-the-fold or obscured target, unstable click/press,
-missing wait for hydration, stale selector, wrong browser context, or a broad
-shared flow landing on the wrong screen.
-
-If the failure is plausibly recipe/action quality, patch the recipe or shared
-flow with the smallest navigation/wait/scroll/stable-click correction and rerun
-the smallest meaningful recipe segment or the full recipe. Do this before
-returning a final summary. Only mark the proof target `BLOCKED` after concrete
-retry attempts still fail, and then report the exact failed node, command,
-artifact paths, observed screen, and the recipe/harness improvement needed.
-
-Do not loop indefinitely on native rebuilds, Metro/CDP reconnects, or simulator
-launch churn. After one harness/preflight recovery plus one targeted rerun, cap
-the lane as `BLOCKED_RUNTIME` if CDP/Metro remains unstable, and package the
-transcript plus runtime logs instead of spending unbounded time rebuilding.
-
-For stateful setup flows, branch on the observed state. If the recipe wants to
-open a BTC position but the account already has BTC, do not wait for an
-open-long button that is correctly absent; either route directly to the
-open-position visual AC, or first close/clear via the documented real UI/harness
-flow and then rerun the no-state lane. Existing-state branching must be recorded
-in the recipe notes and verdict.
-
-Unit tests, DOM/fiber/controller assertions, or a manual screenshot suggestion
-do not replace the missing live recipe proof. They may support the code diff,
-but visual/mixed ACs with a failed runtime node remain `PASS-WITH-GAPS`,
-`PARTIAL`, or `BLOCKED` by AC number.
-
-## Runtime Precondition Recovery Gate
-
-A recipe that fails before the first workflow node because preconditions are not
-ready is not a final package yet. If `summary.json`/`failure.json` reports
-`wallet.unlocked`, `Login`, `perps.ready_to_trade`,
-`perps.sufficient_balance`, `CLIENT_NOT_INITIALIZED`, no CDP target, or a
-stopped simulator/browser, check runtime-start approval before attempting
-recovery:
-
-- **If runtime-start approval has not been granted**, do not run
-  prepare/watch/launch/simulator-boot or any command that starts or restarts a
-  runtime process. Run static/no-start harness checks if useful, record
-  `BLOCKED: pending runtime-start approval` with the exact command that would be
-  needed, and wait for explicit approval.
-- **If runtime-start approval exists**, invoke/follow `/mms-recipe-harness`
-  verify/preflight for the platform, using the provided `RECIPE_RUNTIME_CONTEXT`, `RECIPE_SLOT_ID`, `CDP_PORT`,
-  `RECIPE_CDP_PORT`, `IOS_SIMULATOR`, `SIMULATOR`, `ADB_SERIAL`,
-  `ANDROID_SERIAL`, `WATCHER_PORT`, `METRO_PORT`, or equivalent caller-provided
-  env vars first;
-- for wallet/login readiness, invoke/follow `/mms-recipe-wallet-control` or the
-  repo harness wallet setup/unlock command rather than asking the human to run a
-  private alias;
-- record the exact recovery command, output artifact, app-state/status result,
-  and whether it reached a route/account/perps-ready state;
-- rerun the same recipe command after recovery, or explain the concrete external
-  reason recovery could not run.
-
-Static-only harness verification plus a failed live precondition attempt is a
-useful artifact, but it is not enough to close a stateful/visual proof lane when
-the target runtime env was available. If recovery still leaves the app on the
-login screen or `CLIENT_NOT_INITIALIZED`, package the lane as
-`PASS-WITH-GAPS`/`BLOCKED_PRECONDITIONS` and name the missing runtime setup
-explicitly.
-
-## Stateful AC Setup Gate
-
-For acceptance criteria that depend on a required app state, the recipe must
-explicitly create or verify that state before asserting the UI. Do not rely on
-whatever state happens to be present in the active browser, simulator, wallet,
-or prior validation run. For example, a ticket with both `no BTC position` and
-`open BTC position` ACs needs separate no-state and with-state setup paths:
-close/clear through a real UI/harness flow, open/create through a real
-UI/harness flow, or load a documented harness-owned pre-start fixture.
-
-A read-only observation recipe is acceptable only for investigation or for an
-AC whose required state is already the subject being observed and cannot be
-changed safely; in that case the affected AC must be labelled
-`PASS-WITH-GAPS`/`BLOCKED` with the missing setup flow named. If existing shared
-flows or platform fixtures can attempt the setup, try them before final
-packaging. Unit tests may support the code path but do not substitute for
-runtime setup of stateful visual ACs.
-
-## Fallback Screenshot Verdict Gate
-
-Treat screenshot artifact metadata as part of the proof, not just the visible
-bitmap. If a PNG says `DOM-rendered fallback evidence`, `native browser
-screenshot timed out/blank`, or `trace.json` records a screenshot
-`fallbackReason`, then native visual capture failed for that AC. Read and
-package the fallback PNG, but a visual/mixed AC proven only by that fallback is
-not a clean visual pass. The final verdict must remain `PASS-WITH-GAPS` (or
-`PARTIAL`/`BLOCKED` if the fallback does not show the claim), even when
-`summary.json` says `status: pass` and DOM/viewport assertions passed.
-
-Before writing the final verdict or `recipe-quality`, scan `trace.json`,
-screenshot captions, and the PNG header/body for fallback labels. The scan must
-be explicit in the notes, for example `Fallback audit: trace fallbackReason=<n>,
-PNG DOM fallback labels=<n>`. If any visual AC depends on fallback evidence,
-list the affected AC numbers and the native screenshot/video gap. Do not let a
-later successful rerun or unit test overwrite this proof-strength classification
-unless it produced native screenshot/video or another explicitly accepted
-non-fallback artifact. If `recipe-quality` or the final summary says `native
-screenshot`, `no fallback`, or clean visual `PASS` while `trace.json` or a PNG
-shows fallback metadata, the quality gate is incomplete; correct the verdict to
-`PASS-WITH-GAPS` and rewrite the evidence package before final response.
-
-## Mandatory Continuation Gate
-
-After any product code change, the next step is **not** the final response. The
-agent must continue into the recipe/evidence pipeline even in an interactive
-session, even when Jira/Atlassian had to be pasted manually, and even when
-typecheck/Jest pass.
-
-A final response is forbidden until one of these is true:
-
-1. A recipe was authored or updated, run against the live target runtime, and the
-   evidence package was produced; or
-2. the runtime proof path was attempted through `/mms-recipe-harness`, failed for
-   a concrete external reason, and the response clearly labels the recipe proof
-   as `BLOCKED` rather than claiming the acceptance criteria are proven.
-
-Do not say “all acceptance criteria met”, “all green”, or “ready” from
-implementation tests alone. Say “code/tests pass; recipe proof still pending”
-until the recipe artifacts exist.
-
-Do not ask the human whether to proceed with recipe/harness validation. The
-answer is already yes. If the app, simulator, Metro, browser, or CDP is not
-currently running, check the Runtime Startup Approval Gate above. If
-runtime-start approval exists, invoke `/mms-recipe-harness` and let its
-verify/preflight path start or recover the runtime. If approval is required and
-absent, run static/no-start harness checks, record `BLOCKED: pending
-runtime-start approval` with the exact command, and wait. Only declare
-`BLOCKED` for a concrete external failure after the harness or recipe command
-was actually attempted with approval.
-
-Honor runtime environment variables first. If `RECIPE_RUNTIME_CONTEXT`, `RECIPE_SLOT_ID`, `CDP_PORT`, `RECIPE_CDP_PORT`,
-`ADB_SERIAL`, simulator/device, or equivalent caller-provided runtime variables
-are present, use those values in harness verify and recipe commands before
-probing default ports. Do
-not claim "no CDP/browser/device" until the env-provided target was attempted
-and its failure artifact was recorded. If the env-provided runtime fails but a
-fallback port works, record both; if only fallback probing was done, the runtime
-gate is incomplete.
-
-Do not ask to commit, create a PR, or package the work as done while any required
-recipe gate is incomplete. If the product diff and implementation checks are
-done but the recipe package is missing, the only valid next action is to invoke
-the next lower-level recipe skill or mark that specific gate `BLOCKED` with the
-attempted command and failure artifact.
-
-Minimum post-code sequence for visible/stateful changes:
-
-1. Delegate harness setup/verification to `/mms-recipe-harness`.
-2. Delegate recipe authoring to `/mms-recipe-cook`.
-3. Run the exact recipe command and capture artifacts.
-4. Delegate recipe/evidence critique to `/mms-recipe-quality`; if a subagent tool
-   is available, spawn it as an independent reviewer with the recipe path, AC
-   matrix, and artifact manifest.
-5. Read the screenshot PNGs yourself as the final worker gate; verify claimed UI
-   is visible and rerun if weak.
-6. Delegate final PR-ready packaging to `/mms-recipe-evidence` or produce the
-   same evidence package shape.
-
-## Final Package Barrier
-
-A recipe `PASS` is **not** the end of this skill. After the runtime recipe run,
-continue through these gates before showing an idle prompt or final response:
-
-1. open `summary.json`, `trace.json`, run log, issue review, and the artifact
-   manifest/evidence manifest;
-2. read every recipe-produced PNG/video, not only ad-hoc screenshots captured
-   before the recipe;
-3. invoke or follow `/mms-recipe-quality` and record its verdict;
-4. apply one recipe/evidence improvement and rerun, or record the quality
-   verdict that no rerun is needed;
-5. invoke/follow `/mms-recipe-evidence` and write a PR-ready evidence block/file
-   (for example `PR-READY-EVIDENCE.md`) with task, diff, commands, artifact
-   paths, screenshot notes, quality verdict, fallback audit, and remaining gaps;
-6. run `.agents/skills/mms-recipe-evidence/scripts/package-pr-evidence.js --task <task-dir>`
-   (or the runner-equivalent installed path) so the task contains
-   `pr-package/pr-desc.md`, `pr-package/images/` with easy-to-copy filenames,
-   `pr-package/package-manifest.json`, and `pr-package/final-report.md`.
-   The `pr-desc.md` draft must follow the target repo's
-   `.github/pull-request-template.md` / `.github/pull_request_template.md`
-   when present.
-   A JSON manifest alone is not a PR-ready evidence package.
-
-If you find yourself at the model prompt with steps 13-17 unchecked, that is a
-workflow failure. Continue immediately from the earliest unchecked gate; do not
-wait for the human to say "continue".
-
-If `/mms-recipe-quality` returns `pass-with-gaps`, continue to evidence
-packaging, but keep the final verdict as `PASS-WITH-GAPS` and list each missing
-AC by number. Do not write "all checklist gates complete" unless every AC proof
-target is either passed or explicitly outside the ticket scope.
-
-## Ordered Checklist Protocol
-
-Maintain the copied `CHECKLIST.md` file and execute it in order. Also load the target-specific checklist reference installed with this skill (for example `.agents/skills/mms-recipe-fix-ticket/references/metamask-mobile-checklist.md` or `.agents/skills/mms-recipe-fix-ticket/references/metamask-extension-checklist.md`; Claude/Cursor installs may expose the same files under their runner-specific skill directories) and use it as the concrete platform checklist. Do not search only for a repo-root `references/` folder and declare the checklist absent. After each
-step, mark it `[x]`, write the artifact/path/result, then immediately continue
-to the next unchecked step. Do not jump ahead. Do not final-answer with unchecked
-required steps.
-
-`CHECKLIST.md` must exist before editing product behavior. Update it after every gate, not only at the end. If you realize you skipped an earlier
-gate, stop, backfill the missing gate honestly, and continue from the earliest
-unchecked required step. Do not silently replace this workflow with an
-implementation/test-only workflow.
-
-Optimization rule: use the lower-level skills as focused delegates instead of
-manually re-deriving their protocols. If the runner supports subagents/tasks, use
-a subagent for independent recipe-quality review and evidence-package critique;
-do not delegate product code editing unless the user explicitly asked for a
-multi-agent implementation. The main agent remains responsible for ordering,
-truthfulness, and final evidence claims.
-
-If a step fails, fix that layer and rerun the smallest relevant step; if it
-cannot be fixed locally, mark the step `BLOCKED: <concrete reason>` and continue
-only to package the blocker honestly.
+A thin orchestrator over the recipe pipeline (`/mms-recipe-doctor` → `/mms-recipe-harness`
+→ `/mms-recipe-cook` → `/mms-recipe-quality` → `/mms-recipe-evidence`). The human starts it
+and leaves; you run autonomously to a finalized, reviewer-ready result. Unlike
+`/mms-recipe-dev`, you reproduce or understand the failure before patching.
+
+The proof, runtime, and recipe rules live in the lower skills. This wrapper only orders the
+delegates, keeps the run honest, and stops with an evidence package. Do **not** re-derive
+harness/recipe/runtime detail here — invoke or follow the named delegate instead.
+
+## Handoff (do first)
+
+1. Create the progress file the human monitors, then continue without waiting:
+   ```bash
+   .agents/skills/mms-recipe-fix-ticket/scripts/init-checklist.sh --platform <mobile|extension> --slug <ticket-slug>
+   ```
+   It prints the `CHECKLIST.md` path. Fallback: copy `references/metamask-<platform>-checklist.md`
+   to `temp/tasks/<skill>/<timestamp>-<slug>/CHECKLIST.md`.
+2. Reply once: *"Go get a coffee ☕ — I'll take it from ticket → fix → recipe → evidence and
+   report back when it's done or concretely blocked. Live progress: `<path>`."* Then run
+   autonomously; do not wait for the human after this.
+3. `CHECKLIST.md` is the source of truth. Mark each gate `[x]` / `BLOCKED: <reason>` /
+   `N/A: <reason>` with its artifact path as you go — not in one batch at the end.
+
+## Source of truth
+
+The ticket text or pasted details are authoritative. If Jira/MCP/web returns a login wall,
+empty issue, or ambiguous page, ask the human once for the summary + acceptance criteria,
+then continue. Never infer or rewrite ACs from branch names, stale artifacts, or prior runs.
+Before editing product code, print the numbered AC matrix: target surface, state
+precondition, exact copy, and proof mode (`state` / `visual` / `mixed`). Label any inferred
+field `UNKNOWN` and ask rather than guess.
+
+## Delegate chain (in order)
+
+Each gate must actually invoke or follow the named skill; ad-hoc scripts, controller evals,
+or screenshots do not satisfy it. Record the delegate output path or blocker in `CHECKLIST.md`.
+
+1. `/mms-recipe-doctor` — setup/fixture readiness. A malformed fixture or missing tool/harness
+   is `BLOCKED`; fix before product edits.
+2. `/mms-recipe-harness` — install/verify the runtime when live proof applies.
+3. `/mms-recipe-cook` — author the baseline/no-state recipe that captures the failure first,
+   then the after/with-state recipe that proves the fix. recipe-cook owns recipe format, proof
+   modes, reuse, and the no-fake-state rule.
+4. Implement the **smallest** fix that satisfies the ACs (every changed line traces to an AC;
+   no adjacent refactors). Run focused lint/type/unit checks — passing only unlocks proof, it
+   is not a stop point.
+5. Run the recipe live and read the screenshots yourself before trusting `status: pass`.
+6. `/mms-recipe-quality` — critique against the AC matrix; apply one improve/rerun cycle or
+   record that none is needed.
+7. `/mms-recipe-evidence` — PR-ready package: product diff, recipe path, run command,
+   `summary.json`, `trace.json`, artifact manifest, screenshots, quality verdict, gaps.
+
+## Safety invariants
+
+- **Runtime start is approval-gated.** Do not start or restart Metro, a simulator, webpack,
+  or Chrome/CDP — including wrappers, aliases, `nohup`, or background tmux that do — without
+  approval. Missing approval → record `BLOCKED: pending runtime-start approval` with the exact
+  command and wait. With approval, drive starts through `/mms-recipe-harness`, not raw builds.
+- **No manufactured state.** Do not prove a user-visible AC by injecting state (`stateHooks`,
+  Redux/store writes, fiber/DOM mutation, controller/background calls). Valid proof is a real
+  UI-flow recipe or a harness-loaded pre-start fixture; otherwise mark the AC
+  `BLOCKED`/`PASS-WITH-GAPS` and name the missing fixture.
+- **Fallback screenshots are not clean visual proof.** A PNG marked DOM-fallback /
+  native-capture-blank, or a `trace.json` `fallbackReason`, keeps that visual AC at
+  `PASS-WITH-GAPS` even when `summary.json` says pass.
+
+## Honest verdict
+
+Final verdict is `PASS` only when every AC proof target passed. Any unrun, blocked, or
+fallback-only AC ⇒ `PASS-WITH-GAPS` or `BLOCKED`, listed by AC number. Never claim "all ACs
+met" or "ready" from a code diff or unit tests alone. For visual/mixed ACs, "code-proven" is
+not a valid status.
+
+## Ordered checklist
+
+`init-checklist.sh` copies the platform checklist into `CHECKLIST.md` **for the human to
+follow** — it is their live progress view while they wait. Execute it in order and flip each
+box `[ ]` → `[x]` (or `BLOCKED`/`N/A`) with its artifact path the moment that gate completes,
+so the human watching the file always sees the true current state. The canonical sequence:
 
 ```markdown
-## mms-recipe-fix-ticket checklist
-- [ ] 0. Coffee handoff sent to human.
-- [ ] 1. Ticket captured: URL or pasted text, summary, requirements, ACs.
-- [ ] 2. AC matrix written: each AC numbered verbatim with proof mode (`state`, `visual`, or `mixed`) and primary evidence.
-- [ ] 3. Target runtime selected: Mobile/Extension + platform/env + rationale.
-- [ ] 4. Repro/baseline plan written before product behavior edits.
-- [ ] 5. `/mms-recipe-harness` delegate completed install/verify; manifest path recorded.
-- [ ] 6. `/mms-recipe-cook` delegate produced baseline/no-state recipe path and command, or baseline is explicitly blocked with reason.
-- [ ] 7. Baseline/no-state recipe command run, or explicitly blocked with reason.
-- [ ] 8. Minimal product fix implemented by the main agent.
-- [ ] 9. Focused implementation checks run (typecheck/Jest/lint as relevant).
-- [ ] 10. `/mms-recipe-cook` delegate updated after/with-state recipe path and command.
-- [ ] 11. Runtime recipe command run; `summary.json`, `trace.json`, and manifest paths recorded.
-- [ ] 12. Screenshot evidence read visually by the main agent; claimed UI is visible, not hidden/offscreen/wrong tab.
-- [ ] 13. `/mms-recipe-quality` delegate/subagent critique completed against AC matrix + artifacts.
-- [ ] 14. One improvement/rerun cycle completed, or quality critique says no rerun needed.
-- [ ] 15. `/mms-recipe-evidence` delegate/package produced PR-ready evidence text.
-- [ ] 16. Asked the human whether to clean up runtime resources now, or recorded that they should stay running for review.
-- [ ] 17. Final response includes fix summary, tests, recipe evidence, quality loop, and remaining gaps only if truly blocked.
+- [ ] 0. Coffee handoff sent.
+- [ ] 1. Ticket captured: URL or pasted text, summary, ACs.
+- [ ] 2. AC matrix: each AC numbered with proof mode (state/visual/mixed).
+- [ ] 3. Target runtime selected (Mobile/Extension + env).
+- [ ] 4. Repro/baseline plan written before product edits.
+- [ ] 5. /mms-recipe-doctor setup status recorded.
+- [ ] 6. /mms-recipe-harness install/verify; manifest path recorded.
+- [ ] 7. /mms-recipe-cook baseline/no-state recipe + command (or baseline BLOCKED with reason).
+- [ ] 8. Baseline recipe run, or explicitly blocked.
+- [ ] 9. Minimal fix implemented.
+- [ ] 10. Focused checks run (type/jest/lint).
+- [ ] 11. /mms-recipe-cook after/with-state recipe + command.
+- [ ] 12. Recipe run live; summary.json/trace.json/manifest paths recorded.
+- [ ] 13. Screenshots read; claimed UI visible (not hidden/offscreen/wrong tab).
+- [ ] 14. /mms-recipe-quality critique against AC matrix + artifacts.
+- [ ] 15. One improve/rerun cycle, or quality says none needed.
+- [ ] 16. /mms-recipe-evidence PR-ready package produced.
+- [ ] 17. Final report: fix, tests, recipe evidence, gaps. Offer PR on consent.
 ```
 
-Hard ordering gates:
+Steps 1–4 precede behavior edits (except a tiny locator-only `testID` add needed to make
+baseline evidence executable). A runtime blocker is valid only after step 6 or the relevant
+recipe run was actually attempted and the exact failure recorded.
 
-- Steps 1–4 happen before behavior/source edits, except tiny locator-only testID
-  additions needed to make baseline evidence executable.
-- Step 5 must explicitly invoke/follow `/mms-recipe-harness`; ad-hoc runtime
-  status scripts are not a substitute.
-- Step 6 and step 10 must explicitly invoke/follow `/mms-recipe-cook`; ad-hoc
-  screenshots are not a substitute for an executable recipe.
-- Step 9 is not a stopping point. Passing typecheck/Jest only unlocks steps 10–15.
-- Step 12 requires reading PNG/video evidence produced by the recipe artifact
-  package, not only screenshots captured by miscellaneous helper scripts.
-- Visual or mixed ACs require screenshot/video evidence tied to that AC.
-- State-only assertions cannot prove visible copy/color/layout claims.
-- Schema warnings on screenshot nodes are quality failures for visual tickets.
-  Give the `ui.screenshot` node a `description` and back any "must (not) show"
-  condition with a real assertion (`assert_json`/`assert_output`), then rerun
-  validation instead of treating warning-only schema output as clean.
-- The evidence package must contain `artifact-manifest.json` from the harness or
-  an explicit evidence manifest you create that lists `summary.json`,
-  `trace.json`, logs, screenshots/videos, quality verdict, and recipe path.
-- After final artifacts are captured, ask the human whether they want runtime
-  resources cleaned up now. Name the concrete resources (for example Metro
-  port, simulator/device, webpack/dev server, browser/CDP process, tmux pane)
-  and only stop/release them after confirmation, unless the user already asked
-  for cleanup.
-- A runtime blocker is acceptable only after step 5 or the relevant recipe run was
-  actually attempted and the exact failure is recorded.
+## Finish
 
-For every visual or mixed acceptance criterion, bring the target into the
-viewport and wait for it to be visible before capturing screenshot evidence
-(scroll into view, then wait — the runner polls until `timeout_ms`):
-
-```json
-[
-  { "action": "ui.scroll", "test_id": "target-test-id", "scroll_into_view": true },
-  { "action": "ui.wait_for", "test_id": "target-test-id", "visible": true, "timeout_ms": 10000 }
-]
-```
-
-Then capture the screenshot and describe what it must prove. Express any
-"must not show" condition as a real state assertion (`assert_json` over a
-`metamask.*` read, or `assert_output`), not a screenshot field:
-
-```json
-{
-  "action": "ui.screenshot",
-  "description": "AC1: target component is visible with the expected text",
-  "path": "screenshots/after-ac1-target-visible.png"
-}
-```
-
-Do not treat `ui.wait_for` fiber-tree/DOM/native presence, controller state, or a
-passing recipe as proof that a user can see the element. Visual claims need
-viewport visibility (`ui.scroll` + `ui.wait_for` with `visible`) plus a
-reviewer-visible screenshot, followed by human/quality review of the PNG/video.
-
-## Workflow
-
-1. Create the live `CHECKLIST.md` from the embedded platform checklist, then send the coffee handoff message with its path.
-2. Read the ticket, linked PRs/issues, logs, screenshots, and acceptance criteria. If the expected behavior or acceptance criteria are unclear, ask for clarification once; when the user supplies it, continue without stopping.
-3. Write the AC matrix and proof modes before editing behavior code.
-4. Reconstruct the expected behavior and failure mode.
-5. Find the smallest relevant code path and existing tests.
-6. Call `/mms-recipe-harness` for install/verify; record manifest and verification artifacts.
-7. Call `/mms-recipe-cook` for baseline/no-state and after/with-state recipe planning for user-visible, stateful, cross-system, historically flaky, or acceptance-criteria-tied bugs.
-8. Add or update focused tests where they directly prove the bug.
-9. Patch the root cause with the smallest product diff.
-10. Run focused implementation checks.
-11. Continue into after/with-state recipe proof; a dry-run is schema-only and is not runtime proof.
-12. Call `/mms-recipe-quality` or a recipe-quality subagent on the recipe plus evidence.
-13. Classify any weakness into the correct layer: product, recipe, fixture/state setup, harness/runtime, skill instruction, evidence packaging, or runner steering.
-14. Patch the smallest correct layer and rerun from the smallest meaningful point.
-15. Call `/mms-recipe-evidence` or package equivalent PR-ready evidence.
-16. Return the patch summary and evidence only after the Mandatory Continuation Gate and checklist are satisfied.
-
-## PR creation (offer)
-
-Once evidence is packaged, ASK the human whether to create a PR + upload evidence. If yes → `/mms-recipe-evidence` "Create PR + upload" (artifacts owner is dynamic via `gh api user`, never hard-coded; consent-gate every outward step: repo create, upload, PR create/edit).
-
-## Output
+Ask whether to clean up runtime resources (Metro port, simulator/device, webpack/CDP, tmux
+pane) now or leave them for review. Once evidence is packaged, ask whether to open a PR; if
+yes, use `/mms-recipe-evidence` "Create PR + upload" (owner via `gh api user`, consent-gate
+every outward step). Then return:
 
 1. `Root Cause` — concise explanation.
 2. `Fix` — files changed and why.
 3. `Tests` — commands run and result.
-4. `Recipe Evidence` — recipe path, artifacts, and verdict.
-5. `Quality Loop` — critique result, improvement made, and rerun status.
-6. `Remaining Risk` — only if something is unproven.
+4. `Recipe Evidence` — recipe path, artifacts, verdict.
+5. `Remaining Risk` — only if something is unproven.

--- a/domains/perps/skills/review-perps-pr/skill.md
+++ b/domains/perps/skills/review-perps-pr/skill.md
@@ -1,5 +1,107 @@
 ---
 name: review-perps-pr
-description: Review perps PRs with cross-repo awareness
+description: >-
+  Pre-flight self-review gate for perps PRs. A perps dev runs it on their OWN PR to drive a
+  looping double-agentic cross-review — two different model CLIs (Claude, Codex, Cursor)
+  review independently because each catches different issues — until all APPROVE the same
+  commit with zero findings. Reviewers are deliberately strict: every perps anti-pattern and
+  every nit is a blocker. Loops fix → re-review until the PR meets perps standard, then says
+  it is ready for an external human reviewer. Use for "review my perps PR", "cross review my
+  perps branch", "is my perps PR ready", or self-review before requesting review. Self-gate:
+  does not push, merge, or open the PR.
 maturity: stable
 ---
+
+# Review Perps PR — Cross-Review Self-Gate
+
+Perps dev runs this on their OWN PR before requesting a human reviewer. Drives a looping
+**double-agentic** cross-review: ≥2 different model CLIs review independently (each catches a
+different bug class), you fix, re-review, until all APPROVE the same SHA with **zero**
+findings. Self-gate: never pushes, merges, or opens the PR.
+
+## Reviewer bar
+
+Every perps anti-pattern AND every nit = **BLOCKER**. APPROVE only at zero findings.
+"APPROVE with N nits" is a FAIL — forward them as work. Require ≥2 distinct providers; one
+alone is advisory, not a passed gate.
+
+## Step 0 — ask first (use AskUserQuestion), if not already given
+
+- **Target** — branch/PR (default: current branch)
+- **Reviewers** — `claude,codex` (default) / `claude,cursor` / all three (min 2)
+- **Autonomy** — auto-fix+loop (default) / per-round approval / advisory (dev fixes)
+- **Rounds** — default 3, cap 5
+
+Echo the resolved contract in one line, then loop.
+
+## Reviewer CLIs — install all (company allows it; each finds different bugs)
+
+| CLI | one-shot review | install |
+|---|---|---|
+| Claude | `claude -p "<prompt>"` | `npm i -g @anthropic-ai/claude-code` |
+| Codex | `codex exec "<prompt>"` | `npm i -g @openai/codex` |
+| Cursor | `cursor-agent --print --mode ask --output-format text --workspace <wt> "<prompt>"` | `curl https://cursor.com/install -fsSL \| bash`, then `cursor-agent login` |
+
+Missing a CLI → recommend installing it; don't silently drop to one reviewer. For a long
+loop, run each CLI as a live tmux pane instead of one-shot, and `/clear` between rounds.
+
+## Safety (env rules — bypass agents ignore prompt-level "read-only"; this broke a repo once)
+
+1. Reviewers run in an **isolated read-only worktree pinned at the SHA**, never the live
+   checkout: `git worktree add /tmp/perps-review-<sha> <sha>`. A reviewer `git checkout` on
+   the live tree detaches HEAD and orphans your fix commits.
+2. Fixes are **local commits only — never push**. This skill pushes/merges/opens nothing.
+3. After every round: `git symbolic-ref -q HEAD` must show the branch (not detached) and the
+   branch must point at the latest fix SHA — else STOP and report.
+
+## Perps standard (reviewers must load and enforce as blockers)
+
+From the perps `knowledge/` dir: **review-antipatterns** (core checklist), architecture,
+connection-architecture, caching-architecture, formatting-rules, mobile-extension-map,
+shared-package-analysis, feature-flags, screens. Check both repos when a shared util/screen
+changes.
+
+## Reviewer prompt (force a fresh full review every round)
+
+```
+Fresh full review of perps changes in <PR/branch> at <SHA> vs <base>. No prior context.
+Load perps knowledge (review-antipatterns + the rest). You gate this before any human sees it.
+Every perps anti-pattern AND every nit (naming, magic number, missing testID, weak test,
+.toFixed, fallback-display vs 0) = BLOCKER. APPROVE only if nothing is left to improve.
+Return:
+VERDICT: APPROVE | REQUEST_CHANGES
+COMMIT: <sha>
+BLOCKERS: - <file:line> — <issue> — <fix>
+NITS:     - ...        (any entry ⇒ VERDICT must be REQUEST_CHANGES)
+EVIDENCE: - <files/commands inspected>
+```
+
+Reviewers run independently — don't show one's findings to another until both have a verdict.
+
+## Loop
+
+1. Capture HEAD SHA; make the read-only worktree at it.
+2. Run all reviewers independently on that SHA.
+3. Any non-empty BLOCKERS/NITS from any reviewer = work (even on APPROVE).
+4. All APPROVE, zero findings, same SHA, validation green → Exit GREEN.
+5. Else consolidate findings (reviewer, file:line, fix). Per autonomy: auto-fix / ask dev / hand off.
+6. Fix as local commits → run validation → new SHA → verify branch state → reset reviewers → repeat.
+
+## Validation each round (show results; no "fixed" without proof)
+
+Lint + typecheck + `jest` on touched perps paths. If `app/controllers/perps/` changed:
+`scripts/perps/validate-core-sync.sh` (controller must stay platform-agnostic for the
+`@metamask/perps-controller` publish).
+
+## Pause / escalate
+
+Round cap hit with findings open · reviewers disagree on product/scope · same blocker
+survives a round · a fix expands scope · HEAD detached or branch lags · only one provider
+available.
+
+## Exit
+
+**GREEN** — report approved SHA, all reviewers APPROVE / 0 findings, validation pass, round
+count, branch on-track and unpushed → "ready to request an external human reviewer" (this
+skill pushed nothing). **Not green** — list open findings, current SHA, and what the dev must
+decide or do. Don't claim ready.


### PR DESCRIPTION
## What

Replaces the empty `review-perps-pr` stub with a looping **double-agentic cross-review self-gate** a perps developer runs on their own PR **before** requesting a human reviewer.

## Why

A single reviewer (one model, or the author) gives false confidence. Claude, Codex, and Cursor each surface a different class of issue. This gate makes a perps PR clear an ambitious bar on its own first.

## How it works

- **Two+ independent model CLIs** review the diff in isolation each round; require ≥2 distinct providers.
- **Every perps anti-pattern and every nit is a blocker** — `APPROVE` only at zero findings; "approve with N nits" is a fail.
- **Loop**: review → consolidate → fix → re-review at the new SHA until all reviewers approve the same commit with nothing left.
- **Interactive Step 0** resolves target, reviewer pair, autonomy (auto / per-round / advisory), and round cap.
- Reviewers load the perps `knowledge/` docs (review-antipatterns + architecture/connection/caching/formatting/etc.) and enforce them.

## Safety

- Reviewers run in an **isolated read-only worktree pinned at the SHA**, never the live checkout.
- Fixes are **local commits only — never pushed**; the skill pushes/merges/opens nothing.
- Detached-HEAD / branch-lag check after every round.

## Tooling

Vendor CLIs only (`claude`, `codex`, `cursor-agent`) with install one-liners; recommends installing all three rather than degrading to a single reviewer.

Self-gate by design: when green it tells the dev the PR is ready to request an external human reviewer — it does not request, push, or open anything itself.