### PR TITLE
feat(skills): add Core perps integration

### DIFF
--- a/.targets.local.example
+++ b/.targets.local.example
@@ -2,7 +2,7 @@
 # Format: <consumer-repo-name>=<path-or-glob>
 #
 # - LHS is the value passed to `tools/install --repo`. Must match a name
-#   the install CLI knows (e.g. metamask-extension, metamask-mobile).
+#   the install CLI knows (e.g. metamask-extension, metamask-mobile, core).
 # - RHS is a path to the consumer checkout. Globs are expanded, so one
 #   line can hit many worktrees at once.
 # - $HOME and ~ are expanded.
@@ -11,7 +11,9 @@
 # Worktree fan-out (one line, matches all checkouts of that repo):
 metamask-extension=$HOME/dev/metamask/metamask-extension*
 metamask-mobile=$HOME/dev/metamask/metamask-mobile*
+core=$HOME/dev/metamask/core*
 
 # Or list individual paths explicitly (e.g. only one worktree, or non-default name):
 # metamask-extension=$HOME/dev/metamask/metamask-extension-4
 # metamask-mobile=$HOME/work/mobile
+# core=$HOME/dev/metamask/core-4

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Two audiences share this repo:
    editor/agent and it will operate the tooling correctly.
 2. **MetaMask product engineers** — skills under `domains/perps/`,
    `domains/testing/`, `domains/pr-workflow/`, `domains/agentic/`, etc. carry the conventions
-   and review heuristics for `metamask-extension` and `metamask-mobile`.
+   and review heuristics for `metamask-extension`, `metamask-mobile`, and `core`.
    These install into consumer repos via a small CLI.
 
 Single source of truth, multi-operator output (Claude Code, Cursor,
@@ -45,22 +45,25 @@ Or use the installer to drop all `web3-tools/` skills at once:
   --repo metamask-extension --target . --domain web3-tools
 ```
 
-### For engineers in `metamask-extension` / `metamask-mobile`
+### For engineers in `metamask-extension` / `metamask-mobile` / `core`
+
+From inside an integrated consumer repo:
 
 ```bash
-# One time:
-git clone https://github.com/MetaMask/skills ~/dev/metamask/skills
-export METAMASK_SKILLS_DIR=~/dev/metamask/skills
-
-# Then, from inside the consumer repo:
 yarn skills
 
 # To opt into experimental ADR-58 recipe skills:
 yarn skills --domain agentic --maturity experimental
 ```
 
-`yarn skills` runs `tools/sync`, which pulls the latest skills and writes
-them into `.claude/skills/`, `.cursor/rules/`, and `.agents/skills/`.
+The consumer repo wrapper keeps a public `MetaMask/skills` checkout in
+`.skills-cache/metamask-skills` (via `yarn install`/`yarn setup` integration,
+and Core also auto-clones it on `yarn skills` if missing). `yarn skills` then
+runs `tools/sync`, pulls the latest skills, and writes them into
+`.claude/skills/`, `.cursor/rules/`, and `.agents/skills/`.
+
+Optional: set `METAMASK_SKILLS_DIR=~/dev/metamask/skills` in `.skills.local` or
+your shell if you want to use a separate local checkout instead of the cache.
 
 ### For cloud agents (Cursor cloud, Codex cloud, etc.)
 
@@ -69,6 +72,10 @@ No SSH key, no env var — one curl pipe to bash inside the consumer repo:
 ```bash
 curl -fsSL https://raw.githubusercontent.com/MetaMask/skills/main/tools/bootstrap | \
   bash -s -- --repo metamask-extension
+curl -fsSL https://raw.githubusercontent.com/MetaMask/skills/main/tools/bootstrap | \
+  bash -s -- --repo metamask-mobile
+curl -fsSL https://raw.githubusercontent.com/MetaMask/skills/main/tools/bootstrap | \
+  bash -s -- --repo core
 
 # To opt into experimental ADR-58 recipe skills:
 curl -fsSL https://raw.githubusercontent.com/MetaMask/skills/main/tools/bootstrap | \
@@ -124,6 +131,8 @@ consumer checkouts.
 
 ```bash
 tools/install --repo metamask-extension --target ~/dev/metamask/metamask-extension
+# Core monorepo:
+tools/install --repo core --target ~/dev/metamask/core
 ```
 
 **All configured targets:**
@@ -154,11 +163,14 @@ SKILLS_MATURITY=experimental yarn skills             # non-interactive maturity 
 METAMASK_SKILLS_DIR=/some/path yarn skills           # override location
 ```
 
-`yarn skills` calls `tools/sync`, which pulls the source repos, then
-execs `tools/install` with each as `--source`.
+`yarn skills` calls the consumer repo wrapper, which locates a configured source
+(or the repo-local `.skills-cache/metamask-skills` cache), then delegates to
+`tools/sync`. `tools/sync` pulls the source repos and execs `tools/install` with
+each as `--source`.
 
-If neither env var is set, the script prints setup instructions and exits.
-**No silent auto-clone** — engineers see the path they're opting into.
+When calling `tools/sync` directly, at least one source env var is still
+required. Integrated consumer repos provide the zero-config cache wrapper so
+engineers do not need a manual clone for the default public skills.
 
 ## Manual install (the primitive)
 
@@ -295,6 +307,7 @@ domains/<area>/
     adapters/                     # optional runtime payloads used by scripts
     repos/metamask-extension.md   # optional repo overlay
     repos/metamask-mobile.md      # optional repo overlay
+    repos/core.md                 # optional Core monorepo overlay
 ```
 
 ### `skill.md` frontmatter
@@ -315,7 +328,7 @@ homepage) are preserved through install — only `name`, `description`,
 
 ```yaml
 ---
-repo: metamask-extension
+repo: metamask-extension  # or metamask-mobile / core
 parent: <skill-name>
 ---
 ```

--- a/domains/perps/skills/fix-perps-bug/repos/core.md
+++ b/domains/perps/skills/fix-perps-bug/repos/core.md
@@ -1,0 +1,31 @@
+---
+repo: core
+parent: fix-perps-bug
+---
+
+## File Paths
+
+| Area | Path |
+|---|---|
+| Package | `packages/perps-controller/` |
+| Controller | `packages/perps-controller/src/PerpsController.ts` |
+| Providers | `packages/perps-controller/src/providers/` |
+| Services | `packages/perps-controller/src/services/` |
+| Types | `packages/perps-controller/src/types/` |
+| Utils | `packages/perps-controller/src/utils/` |
+| Tests | `packages/perps-controller/tests/` |
+
+## Core-Specific Workflow
+
+1. **Classify the bug as shared controller behavior.** If the issue is UI-only, fix it in Mobile or Extension instead. Core fixes should affect provider/service logic, controller state, selectors, formatting utilities, calculations, or package exports.
+2. **Preserve the package boundary.** Do not import Mobile/Extension UI/runtime helpers into `@metamask/perps-controller`; keep the implementation platform-agnostic and dependency-light.
+3. **Fix the smallest shared contract.** Prefer targeted changes in providers, services, selectors, or utils. Avoid broad refactors that make downstream Mobile/Extension sync harder.
+4. **Add package tests.** Cover the failing behavior in `packages/perps-controller/tests/` or colocated package test structure. Formatting/calculation bugs must include edge cases from the shared perps formatting rules.
+5. **Check downstream impact.** If the fix changes state shape, exported types, selectors, provider semantics, or public package exports, note the required Mobile/Extension follow-up or compatibility behavior.
+
+## Validation
+
+1. `yarn workspace @metamask/perps-controller test`
+2. `yarn workspace @metamask/perps-controller build`
+3. `yarn workspace @metamask/perps-controller messenger-action-types:check` when controller messenger actions/types changed
+4. Relevant lint/changelog checks for touched files and public package changes

--- a/domains/perps/skills/review-perps-pr/repos/core.md
+++ b/domains/perps/skills/review-perps-pr/repos/core.md
@@ -1,0 +1,40 @@
+---
+repo: core
+parent: review-perps-pr
+---
+
+## File Paths
+
+| Area | Path |
+|---|---|
+| Package | `packages/perps-controller/` |
+| Controller | `packages/perps-controller/src/PerpsController.ts` |
+| Providers | `packages/perps-controller/src/providers/` |
+| Services | `packages/perps-controller/src/services/` |
+| Types | `packages/perps-controller/src/types/` |
+| Utils | `packages/perps-controller/src/utils/` |
+| Selectors | `packages/perps-controller/src/selectors.ts` |
+| Tests | `packages/perps-controller/tests/` |
+| Package metadata | `packages/perps-controller/package.json`, `packages/perps-controller/CHANGELOG.md` |
+
+## Review Focus Areas
+
+**Shared package source of truth** — Core hosts `@metamask/perps-controller`, which is consumed by Mobile and Extension. Review API, type, state-shape, selector, event-name, and export changes as cross-client contract changes, not Core-only implementation details.
+
+**Platform-agnostic controller boundary** — controller code must not depend on Mobile or Extension UI/runtime concepts. Flag direct UI assumptions, browser/React Native APIs, test-only fixtures leaking into production, and client-specific behavior that belongs in consuming repos.
+
+**Provider/service correctness** — changes in providers, services, routing, subscriptions, or caches must preserve provider isolation, cleanup/unsubscribe behavior, error handling, and deterministic state updates. Watch for stale subscriptions, duplicated polling, shared mutable provider state, and unbounded caches.
+
+**Formatting and numeric contracts** — Core utilities such as `perpsFormatters`, `significantFigures`, order calculations, and market transforms feed both clients. Enforce the shared formatting rules; flag `.toFixed` display shortcuts, lossy number conversions, and inconsistent fallback display vs. true zero.
+
+**Generated artifacts and exports** — when controller messenger actions, exports, constants, or package surfaces change, verify generated action types, package exports, and changelog requirements are handled. A PR that changes public package behavior should include tests and release notes/changelog where Core requires them.
+
+**Client sync impact** — if a Core change requires Mobile or Extension adapter/UI changes, call that out explicitly. Do not approve a Core PR that silently changes contracts without naming the downstream migration or compatibility plan.
+
+## Validation
+
+1. `yarn workspace @metamask/perps-controller test` — package tests pass.
+2. `yarn workspace @metamask/perps-controller build` — package builds and types emit.
+3. `yarn workspace @metamask/perps-controller messenger-action-types:check` — when controller messenger actions/types changed.
+4. Focused root lint/misc checks for touched files when practical, e.g. `yarn lint:eslint --quiet packages/perps-controller` if supported by the checkout.
+5. If public API/package metadata changed, run the relevant changelog validation for `@metamask/perps-controller`.

--- a/tools/bootstrap
+++ b/tools/bootstrap
@@ -13,6 +13,9 @@
 #   curl -fsSL https://raw.githubusercontent.com/MetaMask/skills/main/tools/bootstrap \
 #     | bash -s -- --repo metamask-mobile --domain perps,testing
 #
+#   curl -fsSL https://raw.githubusercontent.com/MetaMask/skills/main/tools/bootstrap \
+#     | bash -s -- --repo core --domain perps
+#
 # Env:
 #   SKILLS_CACHE_DIR  Where to clone (default: $HOME/.cache/metamask-skills).
 #   SKILLS_REF        Git ref to checkout (default: main).
@@ -36,7 +39,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$REPO" ]]; then
-  echo "Error: --repo <name> required (e.g. metamask-extension, metamask-mobile)" >&2
+  echo "Error: --repo <name> required (e.g. metamask-extension, metamask-mobile, core)" >&2
   exit 1
 fi
 

--- a/tools/install
+++ b/tools/install
@@ -16,6 +16,7 @@
 # Usage:
 #   tools/install --repo metamask-extension --target ~/dev/metamask/metamask-extension
 #   tools/install --repo metamask-mobile --target ~/dev/metamask/metamask-mobile --dry-run
+#   tools/install --repo core --target ~/dev/metamask/core --domain perps --dry-run
 #   tools/install --repo metamask-extension --target /path --domain perps,testing
 #   tools/install --repo metamask-extension --target /path --maturity experimental
 #   tools/install --repo metamask-extension --target /path \
@@ -44,7 +45,7 @@ Required:
 Optional:
   --repo <name>       GitHub repo name (auto-detected from <target>/package.json
                       name field, falling back to basename of --target).
-                      Override e.g., --repo metamask-extension.
+                      Override e.g., --repo metamask-extension or --repo core.
   --source <dir>      Skill source repo (repeatable, ordered). Later sources
                       override earlier ones on name conflict. Defaults to the
                       repo containing this script.
@@ -66,6 +67,7 @@ Optional:
 Examples:
   $(basename "$0") --repo metamask-extension --target ~/dev/metamask/metamask-extension
   $(basename "$0") --repo metamask-mobile --target ~/dev/metamask/metamask-mobile --domain perps --dry-run
+  $(basename "$0") --repo core --target ~/dev/metamask/core --domain perps --dry-run
   $(basename "$0") --repo metamask-extension --target . \\
     --source ~/dev/metamask/skills --source ~/dev/Consensys/skills
 EOF
@@ -130,9 +132,38 @@ action() { if $DRY_RUN; then echo "  [dry-run] $1"; else echo "  $1"; fi; }
 frontmatter_value() {
   local file="$1" key="$2"
   awk -v k="$key" '
-    /^---$/ { n++; next }
-    n==1 && $0 ~ "^"k": " { sub("^"k": ", ""); print; exit }
+    /^---$/ {
+      n++
+      if (n >= 2 && in_block) { print out; printed=1; exit }
+      next
+    }
+    n==1 {
+      if (in_block) {
+        if ($0 ~ /^[[:space:]]+/) {
+          line=$0
+          sub(/^[[:space:]]+/, "", line)
+          if (line != "") out = out (out == "" ? "" : " ") line
+          next
+        }
+        print out
+        printed=1
+        exit
+      }
+
+      prefix="^" k ":[[:space:]]*"
+      if ($0 ~ prefix) {
+        sub(prefix, "")
+        if ($0 ~ /^[>|][+-]?$/) {
+          in_block=1
+          out=""
+          next
+        }
+        print
+        exit
+      }
+    }
     n>=2 { exit }
+    END { if (in_block && !printed) print out }
   ' "$file"
 }
 

--- a/tools/sync
+++ b/tools/sync
@@ -28,6 +28,7 @@
 # Usage (via `yarn skills`):
 #   tools/sync --repo metamask-extension --target /path/to/repo
 #   tools/sync --repo metamask-mobile --target . --domain perps,testing --dry-run
+#   tools/sync --repo core --target . --domain perps --dry-run
 #   tools/sync --repo metamask-mobile --target . --reset      # forget saved selection
 
 set -euo pipefail


### PR DESCRIPTION
## Summary

- Add Core repo overlays for `fix-perps-bug` and `review-perps-pr` so perps skills install into `MetaMask/core`.
- Add Core to deploy/bootstrap/install docs and target examples.
- Support folded multiline skill descriptions in `tools/install` frontmatter parsing so generated skill metadata is not blank.

## Validation

- `bash -n tools/install tools/sync tools/bootstrap`
- `./tools/install --repo core --target /Users/deeeed/dev/metamask/core-4 --source /Users/deeeed/dev/metamask/metamask-skills --domain perps --dry-run`
- `METAMASK_SKILLS_DIR=/Users/deeeed/dev/metamask/metamask-skills yarn skills --domain perps --dry-run` from Core checkout
