### PR TITLE
feat(agentic): resolve public recipe runner source

### DIFF
--- a/domains/agentic/skills/recipe-harness/adapters/extension/scripts/install.sh
+++ b/domains/agentic/skills/recipe-harness/adapters/extension/scripts/install.sh
@@ -67,13 +67,17 @@ mkdir -p "$HARNESS_DIR/runner/bin" "$HARNESS_DIR/runner/manifests" "$HARNESS_DIR
 # — cannot break the generated wrapper or inject at runtime.
 runner_farmslot_root_q="$(printf '%q' "$METAMASK_RUNNER_FARMSLOT_ROOT")"
 runner_exec_q="$(printf '%q' "$METAMASK_RUNNER_DIR/bin/metamask-recipe")"
-cat > "$HARNESS_DIR/runner/bin/metamask-recipe" <<EOF
-#!/usr/bin/env bash
-set -euo pipefail
-export FARMSLOT_ROOT=\${FARMSLOT_ROOT:-$runner_farmslot_root_q}
-exec $runner_exec_q "\$@"
-EOF
-printf '%s\n' "$METAMASK_RUNNER_FARMSLOT_ROOT" > "$HARNESS_DIR/runner/.farmslot-root"
+{
+  printf '%s\n' '#!/usr/bin/env bash'
+  printf '%s\n' 'set -euo pipefail'
+  if [ -n "$METAMASK_RUNNER_FARMSLOT_ROOT" ]; then
+    printf 'export FARMSLOT_ROOT=${FARMSLOT_ROOT:-%s}\n' "$runner_farmslot_root_q"
+  fi
+  printf 'exec %s "$@"\n' "$runner_exec_q"
+} > "$HARNESS_DIR/runner/bin/metamask-recipe"
+if [ -n "$METAMASK_RUNNER_FARMSLOT_ROOT" ]; then
+  printf '%s\n' "$METAMASK_RUNNER_FARMSLOT_ROOT" > "$HARNESS_DIR/runner/.farmslot-root"
+fi
 printf '%s\n' "$METAMASK_RUNNER_DIR" > "$HARNESS_DIR/runner/.runner-source"
 cp "$METAMASK_RUNNER_DIR/manifests/mobile.action-manifest.json" "$HARNESS_DIR/runner/manifests/mobile.action-manifest.json"
 cp "$METAMASK_RUNNER_DIR/manifests/extension.action-manifest.json" "$HARNESS_DIR/runner/manifests/extension.action-manifest.json"

--- a/domains/agentic/skills/recipe-harness/adapters/mobile/scripts/install.sh
+++ b/domains/agentic/skills/recipe-harness/adapters/mobile/scripts/install.sh
@@ -103,14 +103,18 @@ install_v1_runner_assets() {
   local runner_farmslot_root_q runner_exec_q
   runner_farmslot_root_q="$(printf '%q' "$METAMASK_RUNNER_FARMSLOT_ROOT")"
   runner_exec_q="$(printf '%q' "$METAMASK_RUNNER_DIR/bin/metamask-recipe")"
-  cat > "$HARNESS_DIR/runner/bin/metamask-recipe" <<EOF
-#!/usr/bin/env bash
-set -euo pipefail
-export FARMSLOT_ROOT=\${FARMSLOT_ROOT:-$runner_farmslot_root_q}
-exec $runner_exec_q "\$@"
-EOF
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf '%s\n' 'set -euo pipefail'
+    if [ -n "$METAMASK_RUNNER_FARMSLOT_ROOT" ]; then
+      printf 'export FARMSLOT_ROOT=${FARMSLOT_ROOT:-%s}\n' "$runner_farmslot_root_q"
+    fi
+    printf 'exec %s "$@"\n' "$runner_exec_q"
+  } > "$HARNESS_DIR/runner/bin/metamask-recipe"
   chmod +x "$HARNESS_DIR/runner/bin/metamask-recipe"
-  printf '%s\n' "$METAMASK_RUNNER_FARMSLOT_ROOT" > "$HARNESS_DIR/runner/.farmslot-root"
+  if [ -n "$METAMASK_RUNNER_FARMSLOT_ROOT" ]; then
+    printf '%s\n' "$METAMASK_RUNNER_FARMSLOT_ROOT" > "$HARNESS_DIR/runner/.farmslot-root"
+  fi
   printf '%s\n' "$METAMASK_RUNNER_DIR" > "$HARNESS_DIR/runner/.runner-source"
   cp "$METAMASK_RUNNER_DIR/manifests/mobile.action-manifest.json" "$HARNESS_DIR/action-manifest.json"
   cp "$METAMASK_RUNNER_DIR/manifests/mobile.action-manifest.json" "$HARNESS_DIR/runner/manifests/mobile.action-manifest.json"

--- a/domains/agentic/skills/recipe-harness/references/contract.md
+++ b/domains/agentic/skills/recipe-harness/references/contract.md
@@ -8,7 +8,7 @@ Required fields:
 
 - `adapter`: `mobile` or `extension`
 - `installedAt`
-- `source`: skill UX wrapper path/revision plus resolved runner source path/revision/kind when available. Prefer `METAMASK_RECIPE_RUNNER_SOURCE` for local development; otherwise the skill may use the cached public `deeeed/metamask-recipe-runner` fallback. The skills repo does not own the runner runtime.
+- `source`: skill UX wrapper path/revision plus resolved runner source path/revision/kind when available. Prefer `METAMASK_RECIPE_RUNNER_SOURCE` for local development; otherwise the skill may use the cached public `deeeed/metamask-recipe-runner` fallback. That personal-account fallback is temporary for ADR-58 proof-of-concept testing until the runner is fully validated and migrated to the MetaMask organization. The skills repo does not own the runner runtime.
 - `target`
 - `installedPaths`
 - `patchedFiles` (may be an empty array for adapters that only copy ignored runtime files)

--- a/domains/agentic/skills/recipe-harness/references/contract.md
+++ b/domains/agentic/skills/recipe-harness/references/contract.md
@@ -8,7 +8,7 @@ Required fields:
 
 - `adapter`: `mobile` or `extension`
 - `installedAt`
-- `source`: skill UX wrapper path/revision plus resolved runner source path/revision/kind when available. Prefer `METAMASK_RECIPE_RUNNER_SOURCE`; local development may use a sibling `metamask-recipe-runner` checkout. The skills repo does not own the runner runtime.
+- `source`: skill UX wrapper path/revision plus resolved runner source path/revision/kind when available. Prefer `METAMASK_RECIPE_RUNNER_SOURCE` for local development; otherwise the skill may use the cached public `deeeed/metamask-recipe-runner` fallback. The skills repo does not own the runner runtime.
 - `target`
 - `installedPaths`
 - `patchedFiles` (may be an empty array for adapters that only copy ignored runtime files)

--- a/domains/agentic/skills/recipe-harness/scripts/resolve-runner-source.sh
+++ b/domains/agentic/skills/recipe-harness/scripts/resolve-runner-source.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+DEFAULT_METAMASK_RECIPE_RUNNER_GIT_URL="https://github.com/deeeed/metamask-recipe-runner.git"
+DEFAULT_METAMASK_RECIPE_RUNNER_GIT_REF="main"
+
 resolve_metamask_recipe_runner_source() {
   local skill_dir="$1"
   local agentic_dir="$2"
@@ -28,23 +31,13 @@ resolve_metamask_recipe_runner_source() {
     break
   done
 
-  if [ -z "$METAMASK_RUNNER_DIR" ] && [ -n "$sibling_runner" ] && [ -d "$sibling_runner" ]; then
+  if [ -z "$METAMASK_RUNNER_DIR" ] && ! is_truthy "${METAMASK_RECIPE_RUNNER_SIBLING_DISABLED:-}" && [ -n "$sibling_runner" ] && [ -d "$sibling_runner" ]; then
     METAMASK_RUNNER_DIR="$(cd "$sibling_runner" && pwd -P)"
     METAMASK_RUNNER_SOURCE_KIND="sibling-checkout"
   fi
 
   if [ -z "$METAMASK_RUNNER_DIR" ]; then
-    cat >&2 <<EOF
-Missing MetaMask v1 recipe runner source.
-
-Set METAMASK_RECIPE_RUNNER_SOURCE to the runner checkout/package path.
-For local development, a sibling checkout is auto-discovered when present:
-  ${sibling_runner:-<sibling metamask-recipe-runner checkout>}
-
-The skill is only the UX wrapper; it resolves and installs the runner from a
-separate project so the skills repo does not own the harness runtime.
-EOF
-    return 1
+    resolve_cached_metamask_recipe_runner_source
   fi
 
   for required in \
@@ -65,8 +58,66 @@ EOF
     METAMASK_RUNNER_REVISION="unknown"
   fi
   METAMASK_RUNNER_SKILL_DIR="$(cd "$skill_dir" && pwd -P)"
-  METAMASK_RUNNER_FARMSLOT_ROOT="$(resolve_metamask_runner_farmslot_root "$target_dir" "$skill_dir" "$METAMASK_RUNNER_DIR" "$PWD")"
+  METAMASK_RUNNER_FARMSLOT_ROOT="$(resolve_metamask_runner_farmslot_root "$target_dir" "$skill_dir" "$METAMASK_RUNNER_DIR" "$PWD" 2>/dev/null || true)"
   export METAMASK_RUNNER_DIR METAMASK_RUNNER_SOURCE_KIND METAMASK_RUNNER_REVISION METAMASK_RUNNER_SKILL_DIR METAMASK_RUNNER_FARMSLOT_ROOT
+}
+
+resolve_cached_metamask_recipe_runner_source() {
+  if is_truthy "${METAMASK_RECIPE_RUNNER_GIT_DISABLED:-}"; then
+    cat >&2 <<EOF
+Missing MetaMask v1 recipe runner source.
+
+Set METAMASK_RECIPE_RUNNER_SOURCE to a runner checkout/package path, provide a
+sibling checkout next to metamask-skills, or unset METAMASK_RECIPE_RUNNER_GIT_DISABLED
+to allow the public runner fallback.
+EOF
+    return 1
+  fi
+  command -v git >/dev/null 2>&1 || { echo "Missing git; cannot fetch MetaMask recipe runner fallback." >&2; return 1; }
+
+  local git_url="${METAMASK_RECIPE_RUNNER_GIT_URL:-$DEFAULT_METAMASK_RECIPE_RUNNER_GIT_URL}"
+  local git_ref="${METAMASK_RECIPE_RUNNER_GIT_REF:-$DEFAULT_METAMASK_RECIPE_RUNNER_GIT_REF}"
+  local cache_root="${METAMASK_RECIPE_RUNNER_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/metamask-skills/recipe-runner}"
+  local cache_key repo_dir
+  cache_key="$(printf '%s' "$git_url" | git hash-object --stdin)"
+  repo_dir="$cache_root/$cache_key"
+
+  mkdir -p "$cache_root"
+  if [ -d "$repo_dir/.git" ]; then
+    git -C "$repo_dir" fetch --tags --prune origin >/dev/null
+  else
+    rm -rf "$repo_dir"
+    git clone --filter=blob:none "$git_url" "$repo_dir" >/dev/null
+  fi
+  if git -C "$repo_dir" show-ref --verify --quiet "refs/remotes/origin/$git_ref"; then
+    git -C "$repo_dir" checkout --detach -q "origin/$git_ref"
+  else
+    git -C "$repo_dir" checkout --detach -q "$git_ref"
+  fi
+  ensure_metamask_recipe_runner_dependencies "$repo_dir"
+
+  METAMASK_RUNNER_DIR="$(cd "$repo_dir" && pwd -P)"
+  METAMASK_RUNNER_SOURCE_KIND="git:$git_url#$git_ref"
+}
+
+ensure_metamask_recipe_runner_dependencies() {
+  local runner_dir="$1"
+  [ -f "$runner_dir/package.json" ] || return 0
+  if [ -f "$runner_dir/dist/cli.js" ]; then
+    return 0
+  fi
+  if [ -x "$runner_dir/node_modules/.bin/tsx" ] && [ -d "$runner_dir/node_modules/@farmslot/recipe-harness" ]; then
+    return 0
+  fi
+  command -v npm >/dev/null 2>&1 || { echo "Missing npm; cannot install MetaMask recipe runner dependencies in $runner_dir." >&2; return 1; }
+  (cd "$runner_dir" && npm install --no-package-lock >/dev/null)
+}
+
+is_truthy() {
+  case "${1:-}" in
+    1|true|TRUE|True|yes|YES|Yes|on|ON|On) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 resolve_metamask_runner_farmslot_root() {
@@ -79,11 +130,10 @@ resolve_metamask_runner_farmslot_root() {
     fi
   done
   cat >&2 <<EOF
-Missing Farmslot checkout for MetaMask recipe runner.
+Missing optional Farmslot checkout for MetaMask recipe runner local-development fallback.
 
-Set FARMSLOT_ROOT to the Farmslot checkout that provides @farmslot/recipe-harness.
-The installer records that path in runner/.farmslot-root; the runner source no
-longer contains user-specific defaults.
+The published runner resolves @farmslot/* from normal npm dependencies. Set
+FARMSLOT_ROOT only when co-developing against a local Farmslot checkout.
 EOF
   return 1
 }

--- a/domains/agentic/skills/recipe-harness/scripts/test-safety-contracts.sh
+++ b/domains/agentic/skills/recipe-harness/scripts/test-safety-contracts.sh
@@ -287,6 +287,54 @@ if (manifest.source.runnerSourceKind !== 'env:METAMASK_RECIPE_RUNNER_SOURCE') {
 NODE
 }
 
+assert_public_git_runner_fallback_installs_without_farmslot_root() {
+  local source_repo="$tmpdir/public-runner-source"
+  local target="$tmpdir/public-runner-target"
+  local cache="$tmpdir/public-runner-cache"
+  mkdir -p "$source_repo/bin" "$source_repo/manifests" "$target"
+  printf '{"name":"@metamask/recipe-runner-fixture"}\n' > "$source_repo/package.json"
+  printf '#!/usr/bin/env bash\nprintf "public fixture runner\\n"\n' > "$source_repo/bin/metamask-recipe"
+  chmod +x "$source_repo/bin/metamask-recipe"
+  printf '{"runner_protocol_version":1,"action_registry_version":1,"supported_official_actions":[],"action_metadata":{}}\n' \
+    > "$source_repo/manifests/mobile.action-manifest.json"
+  printf '{"runner_protocol_version":1,"action_registry_version":1,"supported_official_actions":[],"action_metadata":{}}\n' \
+    > "$source_repo/manifests/extension.action-manifest.json"
+  (
+    cd "$source_repo"
+    git init -q
+    git checkout -q -b main
+    git add .
+    git -c user.email=fixture@example.com -c user.name=Fixture commit -q -m 'fixture runner'
+  )
+  (
+    cd "$target"
+    git init -q
+  )
+
+  env -u FARMSLOT_ROOT -u METAMASK_RECIPE_RUNNER_SOURCE -u RECIPE_RUNNER_SOURCE -u METAMASK_RECIPE_RUNNER_PACKAGE_DIR \
+    METAMASK_RECIPE_RUNNER_GIT_URL="file://$source_repo" \
+    METAMASK_RECIPE_RUNNER_GIT_REF=main \
+    METAMASK_RECIPE_RUNNER_CACHE_DIR="$cache" \
+    METAMASK_RECIPE_RUNNER_SIBLING_DISABLED=1 \
+    "$SKILL_DIR/adapters/extension/scripts/install.sh" --target "$target" \
+      >/tmp/recipe-harness-public-runner-fallback.log 2>&1
+
+  node - "$target/.agent/recipe-harness/extension/manifest.json" <<'NODE'
+const fs = require('fs');
+const path = require('path');
+const manifest = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+if (!manifest.source.runnerSourceKind.startsWith('git:file://')) {
+  throw new Error(`expected git fallback source kind, got ${manifest.source.runnerSourceKind}`);
+}
+const runnerDir = path.dirname(path.dirname(manifest.runnerEntrypoint));
+if (fs.existsSync(path.join(runnerDir, '.farmslot-root'))) {
+  throw new Error('git fallback should not record a FARMSLOT_ROOT when published packages are used');
+}
+NODE
+  "$target/.agent/recipe-harness/extension/runner/bin/metamask-recipe" | grep -qxF 'public fixture runner' \
+    || fail "installed git fallback delegate did not execute the cached runner"
+}
+
 assert_mobile_adapter_scripts_parse_with_macos_bash() {
   local bash_bin="${BASH_SYNTAX_BIN:-/bin/bash}"
   if [ ! -x "$bash_bin" ]; then
@@ -386,6 +434,7 @@ assert_install_cleanup_restores_exclude_baseline_byte_identical
 assert_cleanup_removes_only_one_copy_per_recorded_exclude_entry
 assert_installer_refuses_symlinked_runner_destinations
 assert_runner_source_precedence_allows_stale_lower_priority_env
+assert_public_git_runner_fallback_installs_without_farmslot_root
 assert_mobile_adapter_scripts_parse_with_macos_bash
 assert_extension_start_test_watch_is_target_scoped
 assert_recipe_docs_validate_clean

--- a/domains/agentic/skills/recipe-harness/skill.md
+++ b/domains/agentic/skills/recipe-harness/skill.md
@@ -18,6 +18,11 @@ Runner source resolution order:
 4. sibling checkout `../metamask-recipe-runner` next to `metamask-skills`
 5. cached public git fallback: `https://github.com/deeeed/metamask-recipe-runner.git` at `main`
 
+The public fallback is temporary for the ADR-58 proof-of-concept period: the
+runner is hosted under Arthur's personal `deeeed` account so engineers and cloud
+agents can test the experimental skills before the runner is fully validated
+and migrated to the MetaMask organization.
+
 Override the fallback with `METAMASK_RECIPE_RUNNER_GIT_URL`,
 `METAMASK_RECIPE_RUNNER_GIT_REF`, or `METAMASK_RECIPE_RUNNER_CACHE_DIR`.
 Set `METAMASK_RECIPE_RUNNER_GIT_DISABLED=1` to require an explicit local source.

--- a/domains/agentic/skills/recipe-harness/skill.md
+++ b/domains/agentic/skills/recipe-harness/skill.md
@@ -16,6 +16,13 @@ Runner source resolution order:
 2. `RECIPE_RUNNER_SOURCE`
 3. `METAMASK_RECIPE_RUNNER_PACKAGE_DIR`
 4. sibling checkout `../metamask-recipe-runner` next to `metamask-skills`
+5. cached public git fallback: `https://github.com/deeeed/metamask-recipe-runner.git` at `main`
+
+Override the fallback with `METAMASK_RECIPE_RUNNER_GIT_URL`,
+`METAMASK_RECIPE_RUNNER_GIT_REF`, or `METAMASK_RECIPE_RUNNER_CACHE_DIR`.
+Set `METAMASK_RECIPE_RUNNER_GIT_DISABLED=1` to require an explicit local source.
+Set `METAMASK_RECIPE_RUNNER_SIBLING_DISABLED=1` to ignore a sibling checkout and
+force the cached public git fallback.
 
 The runner is a separate project. It only resolves a runner source, copies it into `${RECIPE_HARNESS_ROOT:-temp/agentic/recipe-harness}/<adapter>/runner/`, and records the source path/revision in the install manifest.
 


### PR DESCRIPTION
## Description

Update the recipe-harness skill so fresh machines can resolve the MetaMask recipe runner from the public `deeeed/metamask-recipe-runner` repository when no explicit local runner or sibling checkout exists. The resolver caches the runner, installs its npm dependencies, and keeps `FARMSLOT_ROOT` optional for local Farmslot co-development only.

## ADR-58 temporary host note

The public fallback is intentionally hosted under Arthur's personal `deeeed` account for the ADR-58 proof-of-concept period. This lets engineers and cloud agents test the experimental recipe skills before the runner is fully validated and migrated to the MetaMask organization.

## Validation

- `bash -n domains/agentic/skills/recipe-harness/scripts/resolve-runner-source.sh`
- `bash -n domains/agentic/skills/recipe-harness/adapters/mobile/scripts/install.sh`
- `bash -n domains/agentic/skills/recipe-harness/adapters/extension/scripts/install.sh`
- `bash domains/agentic/skills/recipe-harness/scripts/test-safety-contracts.sh`
- Fresh public fallback smoke with sibling disabled: cloned `https://github.com/deeeed/metamask-recipe-runner.git`, installed extension harness, ran `metamask-recipe self-test --json` successfully
- Clean-user simulation with fresh `HOME`/`XDG_CACHE_HOME`, runner env vars unset, `FARMSLOT_ROOT` unset, and sibling fallback disabled: top-level extension and mobile installs both resolved public git fallback and passed `metamask-recipe self-test --json`

## Changelog

No user-facing product changelog; skill runtime resolver only.
