### PR TITLE
Release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0]
+## [0.1.1]
 
 ### Added
 
@@ -16,5 +16,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `metamask-skills` CLI with `sync`, `postinstall`, and `install` commands.
 - Add repo inference, repo-local skills cache support, bundled package fallback, and `SKILLS_AUTO_UPDATE=1` handling for consumer repos.
 
-[Unreleased]: https://github.com/MetaMask/skills/compare/@metamask/skills@0.1.0...HEAD
-[0.1.0]: https://github.com/MetaMask/skills/releases/tag/@metamask/skills@0.1.0
+[Unreleased]: https://github.com/MetaMask/skills/compare/@metamask/skills@0.1.1...HEAD
+[0.1.1]: https://github.com/MetaMask/skills/releases/tag/@metamask/skills@0.1.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/skills",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Shared MetaMask agent skills installer and sync CLI.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
First publication of `@metamask/skills` to npm — `0.1.0`.

## What
- `package.json`: `0.0.0` → `0.1.0`.
- `CHANGELOG.md`: move `[Unreleased]` entries into `[0.1.0]`.

Builds on #29 (which reset the premature `0.1.0` bump back to a `0.0.0` baseline), so this is the genuine first release at `0.1.0`.

## On merge
Squash-merge with subject `Release 0.1.0`. `is-release` sees `0.0.0 → 0.1.0` → `publish-release.yml` runs → `action-publish-release` creates the GitHub release/tag, then `action-npm-publish` publishes (gated by the `npm-publish` environment).

## Validation (local)
- `yarn changelog:validate` (normal + `--rc`) ✓
- `yarn build` ✓ · `yarn test` 33/33 ✓ · `yarn pack:dry-run` → `metamask-skills-0.1.0.tgz` ✓

## Note
Tag-prefix follow-up: CHANGELOG/`validate-changelog.sh` use `--tag-prefix '@metamask/skills@'`, but `action-publish-release@v3` (polyrepo) creates `v0.1.0` tags. npm publish is unaffected; only the changelog release hyperlink would point at a non-existent scoped tag. Worth a small follow-up to align to `v`.