### PR TITLE
chore: reset version to 0.0.0 baseline before first release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0]
-
 ### Added
 
 - Add CLI discovery commands: `list`, `search`, and `describe`.
@@ -16,5 +14,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `metamask-skills` CLI with `sync`, `postinstall`, and `install` commands.
 - Add repo inference, repo-local skills cache support, bundled package fallback, and `SKILLS_AUTO_UPDATE=1` handling for consumer repos.
 
-[Unreleased]: https://github.com/MetaMask/skills/compare/@metamask/skills@0.1.0...HEAD
-[0.1.0]: https://github.com/MetaMask/skills/releases/tag/@metamask/skills@0.1.0
+[Unreleased]: https://github.com/MetaMask/skills/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/skills",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "Shared MetaMask agent skills installer and sync CLI.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Reverts #24's premature version bump so the first real release can be cut as `0.1.0`.

## What
- `package.json`: `0.1.0` → `0.0.0`.
- `CHANGELOG.md`: move the `0.1.0` entries back under `[Unreleased]`.

## Why
#24 set the package to `0.1.0` and wrote a `0.1.0` CHANGELOG section, but it was never published — no npm release, no tag, no GitHub release. Resetting to a `0.0.0` baseline lets the normal release flow produce `0.1.0` as the genuine first release (per discussion with @Mrtenz).

## ⚠️ Merge order — requires `RELEASE_COMMIT_PREFIX` to be set first
`action-is-release` triggers a publish on **any** `package.json` version change, and the `RELEASE_COMMIT_PREFIX` repo variable is currently **unset**. If this revert (`0.1.0 → 0.0.0`) merges while the variable is unset, it would trigger a bogus **`0.0.0` publish**.

**Please set the `RELEASE_COMMIT_PREFIX` repo variable (e.g. `Release [version]`) before merging this.** Then only a PR whose squash commit starts with `Release <version>` publishes — this `chore:` PR stays inert, and the follow-up `Release 0.1.0` PR does the actual publish.

## Next
Follow-up PR `Release 0.1.0` (`0.0.0 → 0.1.0`) once this lands. Supersedes #27 (will close).