### PR TITLE
ci: Bump `action-npm-publish` to `v6` and enable OIDC publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,7 @@ jobs:
     if: needs.is-release.outputs.IS_RELEASE == 'true'
     permissions:
       contents: write
+      id-token: write
     uses: ./.github/workflows/publish-release.yml
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,8 +7,6 @@ on:
         required: false
       SLACK_WEBHOOK_URL:
         required: true
-      PUBLISH_DOCS_TOKEN:
-        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -14,30 +14,8 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v3
-        with:
-          is-high-risk-environment: true
-          ref: ${{ github.sha }}
-      - name: Build
-        run: yarn build
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: publish-release-artifacts-${{ github.sha }}
-          retention-days: 4
-          include-hidden-files: true
-          path: |
-            ./dist
-            ./node_modules/.yarn-state.yml
-
   publish-npm-dry-run:
     name: Publish to NPM (dry run)
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout and setup environment
@@ -83,42 +61,6 @@ jobs:
           # token in the `npm-publish` environment, and delete it after the
           # initial publish.
           npm-token: ${{ secrets.NPM_TOKEN }}
-
-  get-release-version:
-    name: Get release version
-    needs: publish-npm
-    runs-on: ubuntu-latest
-    outputs:
-      RELEASE_VERSION: ${{ steps.get-release-version.outputs.RELEASE_VERSION }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.sha }}
-      - id: get-release-version
-        shell: bash
-        run: ./scripts/get.sh ".version" "RELEASE_VERSION"
-
-  publish-release-to-gh-pages:
-    name: Publish docs to `${{ needs.get-release-version.outputs.RELEASE_VERSION }}` directory of `gh-pages` branch
-    needs: get-release-version
-    permissions:
-      contents: write
-    uses: ./.github/workflows/publish-docs.yml
-    with:
-      destination_dir: ${{ needs.get-release-version.outputs.RELEASE_VERSION }}
-    secrets:
-      PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}
-
-  publish-release-to-latest-gh-pages:
-    name: Publish docs to `latest` directory of `gh-pages` branch
-    needs: publish-npm
-    permissions:
-      contents: write
-    uses: ./.github/workflows/publish-docs.yml
-    with:
-      destination_dir: latest
-    secrets:
-      PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}
 
   publish-release:
     name: Publish to GitHub

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,43 +4,53 @@ on:
   workflow_call:
     secrets:
       NPM_TOKEN:
-        required: true
+        required: false
       SLACK_WEBHOOK_URL:
         required: true
+      PUBLISH_DOCS_TOKEN:
+        required: true
 
-concurrency:
-  group: publish-release
-  queue: max
+permissions:
+  contents: read
 
 jobs:
-  publish-release:
-    permissions:
-      contents: write
+  build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
-        with:
-          is-high-risk-environment: true
-          node-version: 24.x
-      - name: Publish GitHub release
-        uses: MetaMask/action-publish-release@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: yarn build
-
-  publish-npm-dry-run:
-    name: Dry run publish to NPM
-    runs-on: ubuntu-latest
-    needs: publish-release
-    steps:
-      - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
           ref: ${{ github.sha }}
-          node-version: 24.x
-      - name: Dry run publish to NPM
+      - name: Build
+        run: yarn build
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: publish-release-artifacts-${{ github.sha }}
+          retention-days: 4
+          include-hidden-files: true
+          path: |
+            ./dist
+            ./node_modules/.yarn-state.yml
+
+  publish-npm-dry-run:
+    name: Publish to NPM (dry run)
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v3
+        with:
+          is-high-risk-environment: true
+          ref: ${{ github.sha }}
+      - name: Restore build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: publish-release-artifacts-${{ github.sha }}
+      - name: Dry Run Publish
+        # omit npm-token token to perform dry run publish
         uses: MetaMask/action-npm-publish@v5
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -48,17 +58,80 @@ jobs:
 
   publish-npm:
     name: Publish to NPM
-    environment: npm-publish
-    runs-on: ubuntu-latest
     needs: publish-npm-dry-run
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
           ref: ${{ github.sha }}
-          node-version: 24.x
-      - name: Publish to NPM
-        uses: MetaMask/action-npm-publish@v5
+      - name: Restore build artifacts
+        uses: actions/download-artifact@v8
         with:
+          name: publish-release-artifacts-${{ github.sha }}
+      - name: Publish
+        uses: MetaMask/action-npm-publish@v6
+        with:
+          # This `NPM_TOKEN` needs to be manually set to publish a package for
+          # the first time only.
+          # Look in the repository settings under "Environments", and set this
+          # token in the `npm-publish` environment, and delete it after the
+          # initial publish.
           npm-token: ${{ secrets.NPM_TOKEN }}
+
+  get-release-version:
+    name: Get release version
+    needs: publish-npm
+    runs-on: ubuntu-latest
+    outputs:
+      RELEASE_VERSION: ${{ steps.get-release-version.outputs.RELEASE_VERSION }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+      - id: get-release-version
+        shell: bash
+        run: ./scripts/get.sh ".version" "RELEASE_VERSION"
+
+  publish-release-to-gh-pages:
+    name: Publish docs to `${{ needs.get-release-version.outputs.RELEASE_VERSION }}` directory of `gh-pages` branch
+    needs: get-release-version
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-docs.yml
+    with:
+      destination_dir: ${{ needs.get-release-version.outputs.RELEASE_VERSION }}
+    secrets:
+      PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}
+
+  publish-release-to-latest-gh-pages:
+    name: Publish docs to `latest` directory of `gh-pages` branch
+    needs: publish-npm
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-docs.yml
+    with:
+      destination_dir: latest
+    secrets:
+      PUBLISH_DOCS_TOKEN: ${{ secrets.PUBLISH_DOCS_TOKEN }}
+
+  publish-release:
+    name: Publish to GitHub
+    needs: publish-npm
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v3
+        with:
+          is-high-risk-environment: true
+          ref: ${{ github.sha }}
+      - uses: MetaMask/action-publish-release@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           name: publish-release-artifacts-${{ github.sha }}
       - name: Dry Run Publish
-        # omit npm-token token to perform dry run publish
         uses: MetaMask/action-npm-publish@v5
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Description

This aligns the publish workflow with the module template, enabling OIDC publishing to NPM.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] New skill
- [ ] Skill improvement/update
- [ ] Bug fix
- [ ] Documentation update
- [x] Other (please describe): CI-related changes.

## Skill Details (if adding a new skill)

n/a

## Checklist

<!-- Mark completed items with an "x" -->

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] My skill follows the [SKILL_TEMPLATE.md](.github/SKILL_TEMPLATE.md) format
- [ ] I have tested this skill with an AI agent
- [ ] My skill does not contain any secrets, private keys, or sensitive data
- [ ] I have added appropriate documentation
- [ ] My changes don't break existing skills

## Testing

<!-- Describe how you tested this skill -->

## Additional Context

<!-- Add any other context or screenshots about the PR here -->
