### PR TITLE
ci: Fix `action-npm-publish` version in dry-run step

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           name: publish-release-artifacts-${{ github.sha }}
       - name: Dry Run Publish
-        uses: MetaMask/action-npm-publish@v5
+        uses: MetaMask/action-npm-publish@v6
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           subteam: S042S7RE4AE # @metamask-npm-publishers


### PR DESCRIPTION
## Description

Dry run should use `action-npm-publish@v6` as well.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] New skill
- [ ] Skill improvement/update
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## Skill Details (if adding a new skill)

**Provider Name:** 
**Skill Name:** 
**Brief Description:** 

## Checklist

<!-- Mark completed items with an "x" -->

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] My skill follows the [SKILL_TEMPLATE.md](.github/SKILL_TEMPLATE.md) format
- [ ] I have tested this skill with an AI agent
- [ ] My skill does not contain any secrets, private keys, or sensitive data
- [ ] I have added appropriate documentation
- [ ] My changes don't break existing skills

## Testing

<!-- Describe how you tested this skill -->

## Additional Context

<!-- Add any other context or screenshots about the PR here -->
