### PR TITLE
chore: Update design system UI skills

### DIFF
--- a/domains/ui/skills/ui-development/repos/metamask-extension.md
+++ b/domains/ui/skills/ui-development/repos/metamask-extension.md
@@ -17,16 +17,15 @@ Always prioritize `@metamask/design-system-react` components and Tailwind CSS pa
 **Before writing any new component or choosing what to use, ask: "Does `@metamask/design-system-react` have this?"**
 
 1. **FIRST**: Use `@metamask/design-system-react` components
-   - **Always use for**: Box (layout), Text (typography), Button/ButtonIcon, Icon, Checkbox
-   - **Always use for**: Avatar variants (AvatarAccount, AvatarBase, AvatarFavicon, AvatarGroup, AvatarIcon, AvatarNetwork, AvatarToken)
-   - **Always use for**: Badge variants (BadgeCount, BadgeIcon, BadgeNetwork, BadgeStatus, BadgeWrapper)
+   - **Availability is dynamic**: read the installed package export index before deciding a component is unavailable.
+   - **Rule**: If the installed package exports the component, you MUST use it.
+   - **Common examples**: Box, Text, Button/ButtonBase/ButtonIcon/TextButton, Icon, Checkbox, Avatar variants, Badge variants, ModalOverlay, ModalBody, ModalFocus, ModalFooter, BannerAlert/BannerBase, ButtonFilter, ButtonHero, Input.
    - **ButtonBase**: Only for highly custom button patterns (prefer Button component)
-   - **Rule**: If it exists in the design system, you MUST use it
 
 2. **SECOND**: Use `ui/components/component-library` ONLY if design system lacks it
-   - **Navigation Components** Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody ,ModalFooter, Popover, PopoverHeader
+   - **Navigation Components**: Modal, ModalContent, ModalHeader, Popover, PopoverHeader
    - **Form Components**: FormTextField, TextFieldSearch, TextField, TextArea, Label, HelpText, SelectButton, SelectWrapper, SelectOption
-   - **Utility Components**: Skeleton, SensitiveText, Tag, BannerAlert,
+   - **Utility Components**: Skeleton, SensitiveText, Tag
    - **Rule**: These are MetaMask-specific implementations not (yet) in the design system
    - **Avoid "Base" components**: Components with "Base" in the name generally should not be used unless for custom implementations. We use the base/variant pattern for component development.
 
@@ -45,10 +44,10 @@ Always prioritize `@metamask/design-system-react` components and Tailwind CSS pa
 
 ```
 Need a component?
-  ├─ Is it Box, Text, Button, Icon, Avatar, Badge, or Checkbox?
+  ├─ Does the installed @metamask/design-system-react package export it?
   │  └─ YES → Use @metamask/design-system-react [STOP]
   │
-  ├─ Is it Modal, Banner, Popover, Input, Label, Tag, Textarea, etc?
+  ├─ Is it Modal shell/content/header, Popover, Label, Tag, Textarea, Select, or another component not exported by @metamask/design-system-react?
   │  └─ YES → Use ui/components/component-library [STOP]
   │
   ├─ Is it feature-specific UI (e.g., ConnectAccountsModal, AssetPicker)?
@@ -71,6 +70,17 @@ Need a component?
 - **Performance**: Optimized components reduce bundle size
 - **No SASS**: Reduces CSS file size and build complexity
 
+## Required Availability Check
+
+Before choosing `ui/components/component-library` or building custom UI, inspect the consumer repo's installed package. Do not rely on this skill's examples as a complete component list.
+
+1. Check `node_modules/@metamask/design-system-react/dist/components/index.d.cts` for exported components and enums.
+2. If the package uses a different build layout, inspect `node_modules/@metamask/design-system-react/dist/components/index.d.ts` or `node_modules/@metamask/design-system-react/src/components/index.ts`.
+3. Read the matching component type file before writing usage, for example `dist/components/<Component>/<Component>.types.d.cts`.
+4. If `node_modules` is unavailable, check `package.json`/lockfile for the installed package version and inspect the package source only as a fallback.
+
+This lookup costs a few file reads, but it prevents stale skill guidance from overriding the version actually installed in Extension. The package version is the source of truth.
+
 ## Required Imports for Extension
 
 ```tsx
@@ -80,8 +90,16 @@ import {
   Text,
   Button,
   ButtonBase,
+  ButtonFilter,
+  ButtonHero,
   ButtonIcon,
+  TextButton,
   Icon,
+  ModalOverlay,
+  ModalBody,
+  ModalFocus,
+  ModalFooter,
+  ButtonsAlignment,
   TextVariant,
   IconName,
   IconColor,
@@ -90,6 +108,9 @@ import {
   TextColor,
   ButtonVariant,
   ButtonSize,
+  ButtonBaseSize,
+  BannerAlert,
+  BannerBase,
   // Avatar components
   AvatarAccount,
   AvatarBase,
@@ -124,6 +145,10 @@ All `@metamask/design-system-react` components have comprehensive TypeScript def
 - **Box**: `/node_modules/@metamask/design-system-react/dist/components/Box/*.d.cts`
 - **Text**: `/node_modules/@metamask/design-system-react/dist/components/Text/*.d.cts`
 - **Button**: `/node_modules/@metamask/design-system-react/dist/components/Button/*.d.cts`
+- **ModalOverlay**: `/node_modules/@metamask/design-system-react/dist/components/ModalOverlay/*.d.cts`
+- **ModalBody**: `/node_modules/@metamask/design-system-react/dist/components/ModalBody/*.d.cts`
+- **ModalFocus**: `/node_modules/@metamask/design-system-react/dist/components/ModalFocus/*.d.cts`
+- **ModalFooter**: `/node_modules/@metamask/design-system-react/dist/components/ModalFooter/*.d.cts`
 
 When unsure about component APIs:
 
@@ -250,6 +275,33 @@ const MyComponent = () => {
   <Icon name={IconName.Bank} />
   <Text fontWeight={FontWeight.Medium}>Custom Button</Text>
 </ButtonBase>
+```
+
+### Modal Sections:
+
+```tsx
+import {
+  ModalOverlay,
+  ModalBody,
+  ModalFooter,
+  ButtonsAlignment,
+} from '@metamask/design-system-react';
+import { Modal, ModalContent, ModalHeader } from 'ui/components/component-library';
+
+<Modal isOpen onClose={handleClose}>
+  <ModalOverlay />
+  <ModalContent>
+    <ModalHeader onClose={handleClose}>Title</ModalHeader>
+    <ModalBody>
+      <Text variant={TextVariant.BodyMd}>Content</Text>
+    </ModalBody>
+    <ModalFooter
+      buttonsAlignment={ButtonsAlignment.Horizontal}
+      primaryButtonProps={{ children: 'Confirm', onClick: handleConfirm }}
+      secondaryButtonProps={{ children: 'Cancel', onClick: handleClose }}
+    />
+  </ModalContent>
+</Modal>
 ```
 
 ### Using Avatars and Badges:
@@ -420,6 +472,7 @@ Use `div` with `className` when:
 | `<div>` (for layout)                 | `<Box>`                                                  |
 | `<span>`, `<p>`, `<h1>`, etc.        | `<Text variant={TextVariant.BodyMd}>`                    |
 | `<button>` (styled)                  | `<Button variant={ButtonVariant.Primary}>`               |
+| component-library ModalOverlay/Body/Focus/Footer | `@metamask/design-system-react` ModalOverlay/Body/Focus/Footer |
 | SASS files (`.scss`)                 | Design system props + Tailwind `className`               |
 | `style={{ backgroundColor: 'red' }}` | Box: `backgroundColor={BoxBackgroundColor.ErrorDefault}` |
 | `style={{ display: 'flex' }}`        | Box: `flexDirection={BoxFlexDirection.Row}`              |
@@ -450,10 +503,11 @@ Use `div` with `className` when:
 
 1. Replace `div` → `Box` from design system
 2. Replace text elements → `Text` with appropriate `TextVariant`
-3. Convert SASS styles → Tailwind `className` props
-4. Convert arbitrary colors → design system color tokens
-5. Delete `.scss` files after migration
-6. Test thoroughly - layout can shift during migration
+3. Replace migrated component-library imports with design system exports when available
+4. Convert SASS styles → Tailwind `className` props
+5. Convert arbitrary colors → design system color tokens
+6. Delete `.scss` files after migration
+7. Test thoroughly - layout can shift during migration
 
 ### Example Migration
 
@@ -514,6 +568,7 @@ import {
 
 - [ ] No SASS files (`.scss`) created or modified
 - [ ] Design system components used when appropriate (prefer over raw elements)
+- [ ] ModalOverlay, ModalBody, ModalFocus, and ModalFooter imported from `@metamask/design-system-react`
 - [ ] Variant components used before base components (Button > ButtonBase, BannerAlert > BannerBase)
 - [ ] If using base component: confirmed no variant component works
 - [ ] If using base component: considered if this indicates design inconsistency
@@ -531,6 +586,7 @@ import {
 
 - Any `.scss` file → Design system components + Tailwind utilities
 - Any custom CSS → Design system props + Tailwind utilities
+- Any `ui/components/component-library/modal-overlay`, `modal-body`, `modal-focus`, or `modal-footer` import → equivalent `@metamask/design-system-react` export
 - Any arbitrary color values → Design system semantic tokens
 - Static `className="bg-*"` on **Box** → `backgroundColor` prop with `BoxBackgroundColor` enum
 - Static `className="border-*"` color on **Box** → `borderColor` prop with `BoxBorderColor` enum

--- a/domains/ui/skills/ui-development/repos/metamask-mobile.md
+++ b/domains/ui/skills/ui-development/repos/metamask-mobile.md
@@ -16,13 +16,12 @@ Always prioritize @metamask/design-system-react-native components and Tailwind C
 **Before writing any new component or choosing what to use, ask: "Does @metamask/design-system-react-native have this?"**
 
 1. **FIRST**: Use `@metamask/design-system-react-native` components
-   - **Always use for**: Box (layout), Text (typography), Button/ButtonBase/ButtonIcon, Icon, Checkbox
-   - **Always use for**: Avatar variants (Account, Base, Favicon, Group, Icon, Network, Token)
-   - **Always use for**: Badge variants (Count, Icon, Network, Status, Wrapper)
-   - **Rule**: If it exists in the design system, you MUST use it
+   - **Availability is dynamic**: read the installed package export index before deciding a component is unavailable.
+   - **Rule**: If the installed package exports the component, you MUST use it.
+   - **Common examples**: Box/BoxRow/BoxColumn, Text, Button/ButtonBase/ButtonIcon/TextButton, Icon, Checkbox, Avatar variants, Badge variants, BottomSheet components, HeaderBase/HeaderRoot/HeaderSearch/HeaderStandard, Input/TextField/TextFieldSearch/Label, ListItem, Skeleton, Tag, Toast.
 
 2. **SECOND**: Use `app/component-library` ONLY if design system lacks it
-   - **Use for**: BottomSheet, Tabs, Headers, ListItems, Skeleton, Tags, Modal, Overlay, Toast, RadioButton, etc.
+   - **Use for**: MetaMask-specific or not-yet-migrated components such as Tabs and feature-owned modal wrappers
    - **Rule**: These are MetaMask-specific implementations not (yet) in the design system
    - **Important**: component-library components should themselves use design system primitives internally
 
@@ -39,10 +38,10 @@ Always prioritize @metamask/design-system-react-native components and Tailwind C
 ### Decision Tree
 ```
 Need a component?
-  ├─ Is it Box, Text, Button, Icon, Avatar, Badge, or Checkbox?
+  ├─ Does the installed @metamask/design-system-react-native package export it?
   │  └─ YES → Use @metamask/design-system-react-native [STOP]
   │
-  ├─ Is it BottomSheet, Tabs, Header, ListItem, Skeleton, Tag, Modal, etc?
+  ├─ Is it Tabs or a MetaMask-specific component that is not exported by @metamask/design-system-react-native?
   │  └─ YES → Use app/component-library [STOP]
   │
   ├─ Is it feature-specific UI (e.g., BridgeInputSelector, StakeInputView)?
@@ -63,6 +62,17 @@ Need a component?
 - **Performance**: Optimized implementations tested at scale
 - **Type Safety**: Full TypeScript support with JSDoc documentation
 
+## Required Availability Check
+
+Before choosing `app/component-library` or building custom UI, inspect the consumer repo's installed package. Do not rely on this skill's examples as a complete component list.
+
+1. Check `node_modules/@metamask/design-system-react-native/dist/components/index.d.cts` for exported components and enums.
+2. If the package uses a different build layout, inspect `node_modules/@metamask/design-system-react-native/dist/components/index.d.ts` or `node_modules/@metamask/design-system-react-native/src/components/index.ts`.
+3. Read the matching component type file before writing usage, for example `dist/components/<Component>/<Component>.types.d.cts`.
+4. If `node_modules` is unavailable, check `package.json`/lockfile for the installed package version and inspect the package source only as a fallback.
+
+This lookup costs a few file reads, but it prevents stale skill guidance from overriding the version actually installed in Mobile. The package version is the source of truth.
+
 ## Required Imports for React Native
 
 ```tsx
@@ -73,8 +83,30 @@ import {
   Text,
   Button,
   ButtonBase,
+  ButtonFilter,
+  ButtonHero,
+  ButtonIcon,
+  ButtonSemantic,
+  BottomSheet,
+  BottomSheetDialog,
+  BottomSheetHeader,
+  BottomSheetFooter,
+  BottomSheetOverlay,
+  ButtonsAlignment,
+  HeaderBase,
+  HeaderRoot,
+  HeaderSearch,
+  HeaderStandard,
   Icon,
+  IconAlert,
+  MainActionButton,
+  TabEmptyState,
   TextVariant,
+  FontWeight,
+  ButtonBaseSize,
+  TitleHub,
+  TitleStandard,
+  TitleSubpage,
   BoxFlexDirection,
   BoxAlignItems,
   BoxJustifyContent,
@@ -90,6 +122,13 @@ All @metamask/design-system-react-native components have comprehensive TypeScrip
 - **Box**: `/node_modules/@metamask/design-system-react-native/dist/components/Box/Box.types.d.cts`
 - **Text**: `/node_modules/@metamask/design-system-react-native/dist/components/Text/Text.types.d.cts`
 - **Button**: `/node_modules/@metamask/design-system-react-native/dist/components/Button/Button.types.d.cts`
+- **BottomSheet**: `/node_modules/@metamask/design-system-react-native/dist/components/BottomSheet/BottomSheet.types.d.cts`
+- **BottomSheetDialog**: `/node_modules/@metamask/design-system-react-native/dist/components/BottomSheetDialog/BottomSheetDialog.types.d.cts`
+- **BottomSheetHeader**: `/node_modules/@metamask/design-system-react-native/dist/components/BottomSheetHeader/BottomSheetHeader.types.d.cts`
+- **BottomSheetFooter**: `/node_modules/@metamask/design-system-react-native/dist/components/BottomSheetFooter/BottomSheetFooter.types.d.cts`
+- **HeaderBase**: `/node_modules/@metamask/design-system-react-native/dist/components/HeaderBase/HeaderBase.types.d.cts`
+- **HeaderSearch**: `/node_modules/@metamask/design-system-react-native/dist/components/HeaderSearch/HeaderSearch.types.d.cts`
+- **HeaderStandard**: `/node_modules/@metamask/design-system-react-native/dist/components/HeaderStandard/HeaderStandard.types.d.cts`
 
 When unsure about component APIs:
 1. Read the `.types.d.cts` files for complete prop documentation
@@ -179,6 +218,29 @@ const MyComponent = () => {
 >
 ```
 
+### Bottom Sheet:
+
+```tsx
+import {
+  BottomSheet,
+  BottomSheetFooter,
+  BottomSheetHeader,
+  ButtonsAlignment,
+} from '@metamask/design-system-react-native';
+
+<BottomSheet ref={sheetRef} goBack={navigation.goBack}>
+  <BottomSheetHeader onClose={handleClose}>Title</BottomSheetHeader>
+  <Box twClassName="px-4 py-3">
+    <Text variant={TextVariant.BodyMd}>Content</Text>
+  </Box>
+  <BottomSheetFooter
+    buttonsAlignment={ButtonsAlignment.Horizontal}
+    primaryButtonProps={{ children: 'Confirm', onPress: handleConfirm }}
+    secondaryButtonProps={{ children: 'Cancel', onPress: handleClose }}
+  />
+</BottomSheet>
+```
+
 ## Box Component Best Practices
 
 ### Prefer Props Over twClassName for Layout
@@ -231,6 +293,7 @@ Always use semantic color tokens:
 | ------------------------------------ | -------------------------------------- |
 | `<View>`                             | `<Box>`                                |
 | `<Text style={...}>`                 | `<Text variant={TextVariant.BodyMd}>`  |
+| `app/component-library` BottomSheets | `@metamask/design-system-react-native` BottomSheet components |
 | `StyleSheet.create()`                | `twClassName="..."`                    |
 | `style={{ backgroundColor: 'red' }}` | `twClassName="bg-error-default"`       |
 | `flexDirection: 'row'`               | `flexDirection={BoxFlexDirection.Row}` |
@@ -267,10 +330,11 @@ import { ScrollView } from 'react-native';
 ### Migration Steps
 1. Replace `View` → `Box` from design system
 2. Replace `Text` → `Text` with appropriate `TextVariant`
-3. Convert `StyleSheet.create()` styles → `twClassName` props or `tw.style()`
-4. Convert arbitrary colors → design system color tokens
-5. Delete `.styles.ts` files after migration
-6. Test thoroughly - layout can shift during migration
+3. Replace migrated component-library imports with design system exports when available
+4. Convert `StyleSheet.create()` styles → `twClassName` props or `tw.style()`
+5. Convert arbitrary colors → design system color tokens
+6. Delete `.styles.ts` files after migration
+7. Test thoroughly - layout can shift during migration
 
 ### Example Migration
 
@@ -321,6 +385,7 @@ const tw = useTailwind();
 - [ ] No `import tw from 'twrnc'` (must use `useTailwind()` hook)
 - [ ] No raw `View` components (use `Box`)
 - [ ] No raw `Text` without variants (use `Text` with `TextVariant`)
+- [ ] No component-library BottomSheet imports when design system exports cover the use case
 - [ ] No `StyleSheet.create()` (use `twClassName` or `tw.style()`)
 - [ ] No arbitrary color values (use design system tokens)
 - [ ] No separate `.styles.ts` files for new components
@@ -331,6 +396,7 @@ const tw = useTailwind();
 ### When You See These Patterns, IMMEDIATELY Suggest Alternatives:
 - Any `import tw from 'twrnc'` → `import { useTailwind } from '@metamask/design-system-twrnc-preset'`
 - Any `View` component → `Box` from design system
+- Any `app/component-library/components/BottomSheets/*` import → equivalent `@metamask/design-system-react-native` BottomSheet export
 - Any `StyleSheet` usage → Tailwind classes
 - Any arbitrary color values → Design system tokens
 - Any manual flex properties → Box component props + twClassName


### PR DESCRIPTION
## Summary
- update Mobile and Extension UI development skills for migrated design-system components
- make installed package exports the source of truth before falling back to component-library
- add Modal and BottomSheet examples plus migration checklist guidance

## Impact
Agents should stop relying on stale hard-coded component inventories and instead check the installed @metamask/design-system packages in each consumer repo.

## Validation
- node --test test/*.test.mjs
- git diff --check
- tools/install --repo metamask-mobile --target /Users/georgemarshall/Sites/skills --domain ui --dry-run
- tools/install --repo metamask-extension --target /Users/georgemarshall/Sites/skills --domain ui --dry-run