### PR TITLE
chore(pr-workflow): add social-ai team to MetaMask Mobile codeowners overlay

### DIFF
--- a/domains/pr-workflow/skills/pr-codeowners/repos/metamask-mobile.md
+++ b/domains/pr-workflow/skills/pr-codeowners/repos/metamask-mobile.md
@@ -40,6 +40,7 @@ parent: pr-codeowners
 | ramp                    | ramp-team                    |
 | predict                 | predict-team                 |
 | rewards                 | rewards-team                 |
+| social-ai               | social-ai-team               |
 | design-system-engineers | metamask-design-system-team  |
 | core-platform           | core-platform-team           |
 | supply-chain            | mm-supply-chain-reviewers    |


### PR DESCRIPTION
## Description

Adds the `social-ai` team entry to the MetaMask Mobile pr-codeowners overlay, mapping the `social-ai` label to `social-ai-team` for automated reviewer assignment.

## Type of Change

- [ ] New skill
- [x] Skill improvement/update
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## Skill Details (if adding a new skill)

**Provider Name:** N/A
**Skill Name:** pr-codeowners
**Brief Description:** N/A — updating existing overlay

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My skill follows the [SKILL_TEMPLATE.md](.github/SKILL_TEMPLATE.md) format
- [x] I have tested this skill with an AI agent
- [x] My skill does not contain any secrets, private keys, or sensitive data
- [x] I have added appropriate documentation
- [x] My changes don't break existing skills

## Testing

Verified the entry follows the existing table format in `domains/pr-workflow/skills/pr-codeowners/repos/metamask-mobile.md` and is correctly placed in alphabetical-ish order between `rewards` and `design-system-engineers`.

## Additional Context

This mirrors the pattern of all other team entries in the overlay table.

Made with [Cursor](https://cursor.com)