### PR TITLE
chore: add first-pass domain CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,31 @@
 # GitHub code ownership for MetaMask skills.
+# This is a first-pass domain mapping intended for domain-owner review.
+
+# Product/domain-specific skills.
+/domains/perps/ @MetaMask/perps
+/domains/swaps/ @MetaMask/swaps-engineers
+/domains/transactions/ @MetaMask/transactions
+/domains/api-platform/ @MetaMask/api-platform @MetaMask/wallet-api-platform-engineers
+/domains/assets/ @MetaMask/metamask-assets
+/domains/engagement/ @MetaMask/engagement
+/domains/notifications/ @MetaMask/notifications
+/domains/web3auth/ @MetaMask/web3auth @MetaMask/web3auth-platform
+/domains/card/ @MetaMask/card
+/domains/portfolio/ @MetaMask/portfolio
+
+# Domains currently present or pending in open PRs.
+/domains/analytics/ @MetaMask/performance-council
+/domains/platform/ @MetaMask/extension-platform @MetaMask/core-platform
+
+# Horizontal skills domains.
+/domains/performance/ @MetaMask/performance-council
+/domains/testing/ @MetaMask/qa
+/domains/ui/ @MetaMask/design-system-engineers @MetaMask/design-system
+/domains/coding/ @MetaMask/engineering
+/domains/pr-workflow/ @MetaMask/engineering
+/domains/general/ @MetaMask/engineering
+/domains/web3-tools/ @MetaMask/developer-relations
+
+# Legacy/experimental.
 # ADR-58/recipe skills are experimental but owned by Perps during rollout.
 /domains/agentic/ @MetaMask/perps


### PR DESCRIPTION
## Summary
- Adds a first-pass `.github/CODEOWNERS` mapping for current skills domains using MetaMask GitHub teams where obvious.
- Includes domains that are present in open PRs, such as `analytics` and `platform`, so pending work does not land ownerless.
- Preserves the existing legacy `/domains/agentic/` ownership by `@MetaMask/perps`.

## Notes for reviewers
- This is intentionally a first pass based on the domain/team spreadsheet and available GitHub team slugs.
- Please confirm or correct horizontal domain owners for `coding`, `general`, `pr-workflow`, and `web3-tools`.
- Please confirm whether `analytics` should be owned by `@MetaMask/performance-council` or another team.
- Please confirm whether `platform` should use `@MetaMask/extension-platform`, `@MetaMask/core-platform`, or a different wallet platform owner.

## Test plan
- Not run; CODEOWNERS-only change.
- Verified target team slugs with `gh api orgs/MetaMask/teams` before drafting.

Made with [Cursor](https://cursor.com)