### PR TITLE
fix: broken links in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,8 +22,8 @@
 
 <!-- Mark completed items with an "x" -->
 
-- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
-- [ ] My skill follows the [SKILL_TEMPLATE.md](.github/SKILL_TEMPLATE.md) format
+- [ ] I have read the [CONTRIBUTING.md](https://github.com/MetaMask/skills/blob/main/CONTRIBUTING.md) guidelines
+- [ ] My skill follows the [SKILL_TEMPLATE.md](https://github.com/MetaMask/skills/blob/main/.github/SKILL_TEMPLATE.md) format
 - [ ] I have tested this skill with an AI agent
 - [ ] My skill does not contain any secrets, private keys, or sensitive data
 - [ ] I have added appropriate documentation


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

Fix broken links in the PR template (from relative path to absolute URLS):

<img width="1019" height="463" alt="image" src="https://github.com/user-attachments/assets/6ea45cbe-e96b-4b7f-bd56-64ad92605a29" />



## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] New skill
- [ ] Skill improvement/update
- [x] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## Skill Details (if adding a new skill)

**Provider Name:** 
**Skill Name:** 
**Brief Description:** 

## Checklist

<!-- Mark completed items with an "x" -->

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] My skill follows the [SKILL_TEMPLATE.md](.github/SKILL_TEMPLATE.md) format
- [x] I have tested this skill with an AI agent
- [x] My skill does not contain any secrets, private keys, or sensitive data
- [x] I have added appropriate documentation
- [x] My changes don't break existing skills

## Testing

<!-- Describe how you tested this skill -->

## Additional Context

<!-- Add any other context or screenshots about the PR here -->
