### PR TITLE
fix(cli): warn when postinstall auto-update sync fails

### DIFF
--- a/bin/metamask-skills.mjs
+++ b/bin/metamask-skills.mjs
@@ -751,7 +751,10 @@ function postinstall(args) {
     }
     const repo = resolveRepo(target, repoOverride);
     const result = delegate('sync', target, repo, passthrough);
-    return result === 0 ? 0 : 0;
+    if (result !== 0) {
+      warn(`auto-update failed with exit code ${result}`);
+    }
+    return 0;
   } catch (error) {
     warn(`auto-update failed: ${error instanceof Error ? error.message : String(error)}`);
     return 0;


### PR DESCRIPTION
## Description

In `postinstall()` in `bin/metamask-skills.mjs`, the exit code from the auto-update sync delegate was discarded by a ternary that returns `0` on both branches:

```js
const result = delegate('sync', target, repo, passthrough);
return result === 0 ? 0 : 0;
```

So when the delegated `sync` script exits non-zero (e.g. the bash delegate fails, or `spawnSync` can't start it and `delegate` returns `1`), the failure is silently ignored — while thrown errors in the same path do emit a warning via the `catch` block.

This change keeps the intentional never-fail contract of postinstall (a failed auto-update should not break `npm install`, so it still returns `0`), but surfaces the failure the same way the `catch` path does:

```js
const result = delegate('sync', target, repo, passthrough);
if (result !== 0) {
  warn(`auto-update failed with exit code ${result}`);
}
return 0;
```

## Testing

- `node --test test/*.test.mjs` — 36/36 pass
- `node bin/metamask-skills.mjs --help` smoke check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)