### PR TITLE
docs: clarify skill contributions and ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,23 @@
-# GitHub code ownership for MetaMask skills.
-# ADR-58/recipe skills are experimental but owned by Perps during rollout.
-/domains/agentic/ @MetaMask/perps
+# Code owners for MetaMask skills.
+#
+# Domain teams maintain their skills. Platform teams own shared tooling,
+# documentation, and anything without a more specific owner.
+
+*                        @MetaMask/extension-platform @MetaMask/mobile-platform
+
+/.github/                @MetaMask/extension-platform @MetaMask/mobile-platform
+/bin/                    @MetaMask/extension-platform @MetaMask/mobile-platform
+/docs/                   @MetaMask/extension-platform @MetaMask/mobile-platform
+/test/                   @MetaMask/extension-platform @MetaMask/mobile-platform
+/tools/                  @MetaMask/extension-platform @MetaMask/mobile-platform
+/README.md               @MetaMask/extension-platform @MetaMask/mobile-platform
+/CONTRIBUTING.md         @MetaMask/extension-platform @MetaMask/mobile-platform
+
+/domains/coding/         @MetaMask/extension-platform @MetaMask/mobile-platform @MetaMask/core-platform
+/domains/general/        @MetaMask/extension-platform @MetaMask/mobile-platform
+/domains/performance/    @MetaMask/extension-platform @MetaMask/mobile-platform
+/domains/perps/          @MetaMask/perps
+/domains/pr-workflow/    @MetaMask/extension-platform @MetaMask/mobile-platform
+/domains/swaps/          @MetaMask/swaps-engineers
+/domains/testing/        @MetaMask/qa
+/domains/ui/             @MetaMask/design-system-engineers

--- a/.github/SKILL_TEMPLATE.md
+++ b/.github/SKILL_TEMPLATE.md
@@ -1,97 +1,103 @@
 # Skill Template
 
-Use this template when creating a new `SKILL.md` file for your skill.
+Use this template when creating a new skill under `domains/<area>/skills/<skill-name>/skill.md`.
+
+Copy the block below into `skill.md` and replace the placeholders.
 
 ---
 
-# [Skill Name]
+```markdown
+---
+name: example-skill
+description: >-
+  One or two sentences: what the skill does, plus when_to_use cues
+  (e.g. "Use when asked to …, or for …"). Keep the full description
+  within 1,536 characters.
+maturity: stable
+---
 
-> Brief one-line description of what this skill does.
+# Example Skill
 
-## Overview
+Brief overview of purpose and who it is for (dApp builders vs MetaMask product eng).
 
-A more detailed explanation of the skill's purpose and capabilities. What problem does it solve? Who is it for?
+## When to use
+
+- Trigger phrases / tasks this skill owns
+- Out of scope (what it should not do)
 
 ## Prerequisites
 
-List any requirements before using this skill:
-
-- Required tools (e.g., Node.js, Python, specific CLI tools)
-- Required API keys or environment variables
-- Required knowledge or context
+- Required tools (Node, `gh`, device/browser, etc.)
+- Required env vars or access
+- Required knowledge or related skills
 
 ## Instructions
 
-Provide clear, step-by-step instructions for the AI agent to follow.
+Step-by-step guidance the agent should follow.
 
-### Step 1: [Action Name]
-
-Detailed instructions for the first step.
+### Step 1: …
 
 ```bash
 # Example command if applicable
 example-command --flag value
 ```
 
-### Step 2: [Action Name]
-
-Detailed instructions for the second step.
-
-### Step 3: [Action Name]
-
-Continue with additional steps as needed.
+### Step 2: …
 
 ## Examples
 
-### Example 1: [Use Case Name]
+### Example 1: …
 
 ```
-User: "Help me [do something specific]"
-Agent: [Expected behavior or response]
+User: "…"
+Agent: …
 ```
-
-### Example 2: [Another Use Case]
-
-Provide additional examples to clarify usage.
-
-## Configuration
-
-If the skill requires configuration, document it here:
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `param1` | string | Yes | — | Description of param1 |
-| `param2` | number | No | `10` | Description of param2 |
 
 ## Troubleshooting
 
-### Common Issue 1
+### Common issue
 
-**Problem:** Description of the issue.
+**Problem:** …
 
-**Solution:** How to resolve it.
+**Solution:** …
 
-### Common Issue 2
+## Security considerations
 
-**Problem:** Another common issue.
+- Permissions required
+- Risks or data accessed
+```
 
-**Solution:** Resolution steps.
+## Optional repo overlay
 
-## Security Considerations
+If the skill only applies to specific consumer repos, add overlays:
 
-Document any security implications:
+```
+domains/<area>/skills/<skill-name>/repos/metamask-mobile.md
+```
 
-- What permissions does this skill require?
-- Are there any risks users should be aware of?
-- What data is accessed or transmitted?
+```yaml
+---
+repo: metamask-mobile
+parent: example-skill
+---
 
-## References
+# Mobile-specific guidance
 
-- [Link to official documentation](https://example.com)
-- [Link to related resources](https://example.com)
+Content here merges into the base skill body at install time for that repo.
+```
 
-## Changelog
+Skills with a `repos/` directory but no overlay matching `--repo` are skipped
+for that target. Skills with no `repos/` directory install for any target.
 
-| Version | Date | Changes |
-|---------|------|---------|
-| 1.0.0 | YYYY-MM-DD | Initial release |
+## Optional supporting dirs
+
+- `references/` — deeper docs, API notes, images
+- `scripts/` — helper scripts invoked by the skill
+- `adapters/` — runtime payloads used by scripts
+
+## Notes
+
+- Source filename is **`skill.md`** (lowercase). Consumer install output uses
+  the `mms-` prefix and operator-specific names (`SKILL.md`, `RULE.md`).
+- `maturity`: `experimental` | `stable` | `deprecated` (default `stable`).
+- See [Authoring a skill](../README.md#authoring-a-skill) in the README for full details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add opt-in stale project skill pruning via `--prune-stale` and `SKILLS_PRUNE_STALE=1`.
 
-### Fixed
+### Changed
 
 - Rewrite `CONTRIBUTING.md` and skill template for MetaMask/skills layout.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add opt-in stale project skill pruning via `--prune-stale` and `SKILLS_PRUNE_STALE=1`.
 
+### Fixed
+
+- Rewrite `CONTRIBUTING.md` and skill template for MetaMask/skills layout (remove leftover OpenClaw references).
+
 ## [0.2.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Rewrite `CONTRIBUTING.md` and skill template for MetaMask/skills layout (remove leftover OpenClaw references).
+- Rewrite `CONTRIBUTING.md` and skill template for MetaMask/skills layout.
 
 ## [0.2.0]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,11 +56,18 @@ A well-crafted skill should:
    - `repos/<consuming-repo>.md` — Repo-specific overlays (`metamask-extension.md`,
      `metamask-mobile.md`, `core.md`)
 
-6. **Test your skill** — Install locally against a consumer repo before submitting:
+6. **Test your skill** — Install locally against a consumer repo before submitting.
+   `--repo` must match the repo you are installing into:
 
    ```bash
-   # From this checkout, install into a target repo:
+   # Mobile:
    ./tools/install --repo metamask-mobile --target /path/to/metamask-mobile --domain <area>
+
+   # Core:
+   ./tools/install --repo core --target /path/to/core --domain <area>
+
+   # dApp / Web3:
+   ./tools/install --repo my-dapp --target /path/to/my-dapp --domain web3-tools
 
    # Or exercise the CLI package:
    yarn smoke

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,8 @@
-# Contributing to MetaMask OpenClaw Skills
+# Contributing to MetaMask Skills
 
-Thank you for your interest in contributing to the MetaMask OpenClaw Skills repository! This document provides guidelines for contributing new skills and improving existing ones.
+Thank you for your interest in contributing to [MetaMask/skills](https://github.com/MetaMask/skills)!
+This repository is the shared source of agent skills, domain knowledge, and the
+`@metamask/skills` installer CLI for the MetaMask ecosystem.
 
 ## Code of Conduct
 
@@ -10,42 +12,66 @@ This project follows the [MetaMask Code of Conduct](https://github.com/MetaMask/
 
 A well-crafted skill should:
 
-- **Solve a real problem** — Address a genuine need for MetaMask users or Ethereum developers
-- **Be self-contained** — Include all necessary context for an AI agent to execute the skill
-- **Follow best practices** — Implement security considerations and proper error handling
-- **Be well-documented** — Include clear instructions, examples, and expected outcomes
+- **Solve a real problem** — Address a genuine need for MetaMask engineers or Web3 developers
+- **Be self-contained** — Include the context an AI agent needs to execute the skill
+- **Target the right audience** — Place it under the correct domain (`web3-tools`, `perps`, `testing`, etc.)
+- **Declare maturity** — Use `experimental`, `stable`, or `deprecated` in frontmatter
+- **Be well-documented** — Clear instructions, examples, and expected outcomes
 
 ## How to Contribute
 
 ### Adding a New Skill
 
 1. **Fork and clone** the repository:
+
    ```bash
-   git clone https://github.com/YOUR_USERNAME/openclaw-skills.git
-   cd openclaw-skills
+   git clone https://github.com/YOUR_USERNAME/skills.git
+   cd skills
    ```
 
 2. **Create a branch** for your skill:
+
    ```bash
    git checkout -b add-skill/your-skill-name
    ```
 
-3. **Create the skill directory structure**:
+3. **Create the skill under a domain**:
+
    ```bash
-   mkdir -p your-provider/your-skill-name
+   mkdir -p domains/<area>/skills/<skill-name>
    ```
 
-4. **Add your `SKILL.md`** — This is the only required file. See the [skill template](.github/SKILL_TEMPLATE.md) for the expected format.
+   Examples: `domains/testing/skills/…`, `domains/perps/skills/…`,
+   `domains/web3-tools/skills/…`.
+
+4. **Add `skill.md`** — This is the only required file. See the
+   [skill template](.github/SKILL_TEMPLATE.md) and [Authoring a skill](README.md#authoring-a-skill)
+   in the README for frontmatter and layout.
 
 5. **Add optional supporting files**:
+
    - `references/` — Additional documentation, API references, examples
    - `scripts/` — Helper scripts (bash, Python, etc.)
+   - `adapters/` — Optional runtime payloads used by scripts
+   - `repos/<consuming-repo>.md` — Repo-specific overlays (`metamask-extension.md`,
+     `metamask-mobile.md`, `core.md`)
 
-6. **Test your skill** — Ensure the skill works as expected with an AI agent before submitting.
+6. **Test your skill** — Install locally against a consumer repo before submitting:
+
+   ```bash
+   # From this checkout, install into a target repo:
+   ./tools/install --repo metamask-mobile --target /path/to/metamask-mobile --domain <area>
+
+   # Or exercise the CLI package:
+   yarn smoke
+   yarn test
+   node bin/metamask-skills.mjs list --target /path/to/consumer-repo
+   ```
 
 7. **Submit a Pull Request** with:
+
    - A clear title describing the skill
-   - A description of what the skill does
+   - What the skill does and who it is for
    - Any relevant context or use cases
 
 ### Improving Existing Skills
@@ -54,6 +80,14 @@ A well-crafted skill should:
 - Update outdated information
 - Add missing edge cases or error handling
 - Improve security considerations
+- Add or refresh repo overlays under `repos/`
+
+### CLI / tooling changes
+
+Changes under `bin/`, `tools/`, or install behavior ship via the published
+`@metamask/skills` package. Add a consumer-facing entry under
+`## [Unreleased]` in `CHANGELOG.md`, and follow
+[docs/processes/releasing.md](docs/processes/releasing.md) when cutting a release.
 
 ### Reporting Issues
 
@@ -68,35 +102,49 @@ If you find a bug or have a suggestion:
 
 ## Skill Structure
 
-Each skill should follow this structure:
+Each skill lives under a domain:
 
 ```
-provider-name/
-└── skill-name/
-    ├── SKILL.md           # Required: Main skill definition
-    ├── references/        # Optional: Supporting docs
-    │   ├── api.md
-    │   └── examples.md
-    └── scripts/           # Optional: Helper scripts
-        └── helper.sh
+domains/<area>/
+  skills/<skill-name>/
+    skill.md                    # Required: base skill definition
+    references/                 # Optional: supporting docs
+    scripts/                    # Optional: helper scripts
+    adapters/                   # Optional: runtime payloads
+    repos/<consuming-repo>.md   # Optional: repo-specific overlay
+  knowledge/                    # Optional: shared domain reference
 ```
 
-### SKILL.md Format
+### `skill.md` Format
 
-Your `SKILL.md` should include:
+Your `skill.md` should include YAML frontmatter plus body content:
 
-1. **Title and description** — What the skill does
-2. **Prerequisites** — Required tools, APIs, or setup
+```yaml
+---
+name: <slash-command-name>
+description: <≤1,536 chars including when_to_use cues>
+maturity: stable          # experimental | stable | deprecated
+---
+```
+
+Body guidance:
+
+1. **Title and purpose** — What the skill does
+2. **When to use** — Triggers and scope (also reflected in `description`)
 3. **Instructions** — Step-by-step guidance for the AI agent
 4. **Examples** — Concrete usage examples
 5. **Troubleshooting** — Common issues and solutions
+
+Source files use lowercase `skill.md`. The installer writes multi-operator
+output as `mms-<name>` (`SKILL.md` / `RULE.md` under consumer skill dirs).
+See the README for full frontmatter, overlay, and install details.
 
 ## Review Process
 
 1. A maintainer will review your PR
 2. They may request changes or clarifications
 3. Once approved, your skill will be merged
-4. Skills may be tested by the community before full approval
+4. CLI-facing changes should include changelog entries and ship in a package release
 
 ## Security Considerations
 
@@ -105,7 +153,10 @@ Your `SKILL.md` should include:
 - **Use secure defaults** for any configurations
 - **Document security implications** of the skill's actions
 
-If you discover a security issue in an existing skill, please report it privately following MetaMask's [security policy](https://github.com/MetaMask/metamask-extension/security/policy).
+If you discover a security issue in an existing skill or the installer, please
+report it privately following MetaMask's
+[security policy](https://github.com/MetaMask/metamask-extension/security/policy)
+or this repo's [SECURITY.md](SECURITY.md).
 
 ## Questions?
 


### PR DESCRIPTION
## Description

Updates the contribution guide and skill template to match the current repository layout. Adds complete domain ownership so reviews route to the responsible MetaMask teams.

Repository admins must grant listed teams explicit write access for GitHub to enforce team ownership.

## Type of Change

- [x] Documentation update
- [x] Other: CODEOWNERS coverage

## Checklist

- [x] I have read the CONTRIBUTING.md guidelines
- [x] My changes do not contain secrets or sensitive data
- [x] I have added appropriate documentation
- [x] My changes do not break existing skills

## Testing

- `yarn test` — 41 tests passed
- `yarn lint`
- `git diff --check`