### PR TITLE
feat(testing): add mobile integration test skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Or use the installer to drop all `web3-tools/` skills at once:
 metamask-skills list          # discover installable skills for the current repo
 metamask-skills search test   # search skill names and descriptions
 metamask-skills describe testing/component-view-test
+metamask-skills describe testing/integration-test
 metamask-skills describe testing/unit-testing
 metamask-skills sync          # infer repo + target, refresh cache, install skills
 metamask-skills postinstall   # refresh cache; run sync only when SKILLS_AUTO_UPDATE=1
@@ -61,14 +62,15 @@ metamask-skills install       # lower-level installer wrapper
 
 The discovery commands make opt-in selection self-serve. Developers can find a
 skill, inspect it, then save their selection. On Mobile, prefer installing
-**component-view-test** and **unit-testing** together (CV is the default view
-layer; unit is the peer fallback — see `domains/testing/knowledge/testing-layers.md`):
+**component-view-test**, **integration-test**, and **unit-testing** together
+(see `domains/testing/knowledge/testing-layers.md` for layer selection):
 
 ```bash
 metamask-skills list --domain testing
 metamask-skills describe testing/component-view-test
+metamask-skills describe testing/integration-test
 metamask-skills describe testing/unit-testing
-metamask-skills sync --include testing/component-view-test --include testing/unit-testing --save
+metamask-skills sync --include testing/component-view-test --include testing/integration-test --include testing/unit-testing --save
 ```
 
 Consumer repos should prefer this CLI over copying sync/postinstall scripts.

--- a/domains/coding/skills/coding-guidelines/repos/metamask-mobile.md
+++ b/domains/coding/skills/coding-guidelines/repos/metamask-mobile.md
@@ -22,10 +22,11 @@ parent: coding-guidelines
 
 **Testing layers** (Mobile — canonical policy: testing domain `knowledge/testing-layers.md`, installed beside testing skills):
 1. **Component-view** (`*.view.test.tsx`) — **default** for screen/view UI behavior via real app state (`component-view-test` skill)
-2. **Unit** (`*.test.ts(x)`) — pure helpers, narrow contracts, or cases CV cannot cover yet (`unit-testing` skill)
-3. **E2E** — full device / multi-screen Appium flows (`e2e-test` skill)
+2. **Integration** (`*.integration.test.ts`) — app-to-controller flows with real controllers/providers/services and only the I/O boundary mocked (`integration-test` skill)
+3. **Unit** (`*.test.ts(x)`) — pure helpers, narrow contracts, or cases CV cannot cover yet (`unit-testing` skill)
+4. **E2E** — full device / multi-screen Appium flows (`e2e-test` skill)
 
-Do **not** default to broad RTL unit tests that render a whole screen and mock hooks/selectors. Load **component-view-test** and **unit-testing** as peer skills (same documentation level); choose by layer, not by which skill is more familiar.
+Do **not** default to broad RTL unit tests that render a whole screen and mock hooks/selectors. Load **component-view-test**, **integration-test**, and **unit-testing** as peer skills (same documentation level); choose by layer, not by which skill is more familiar.
 
 **File Organization**:
 ```
@@ -33,6 +34,7 @@ ComponentName/
 ├── ComponentName.{constants,stories,styles,types}.ts(x)
 ├── ComponentName.tsx
 ├── ComponentName.view.test.tsx   # preferred for screen/view behavior
+├── ComponentName.integration.test.ts # app-to-controller flow (see testing-layers)
 ├── ComponentName.test.ts(x)      # focused unit only (see testing-layers)
 ├── README.md
 └── index.ts
@@ -47,8 +49,9 @@ ComponentName/
 **External**: [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) • [TypeScript Guidelines](https://github.com/MetaMask/contributor-docs/blob/main/docs/typescript.md)
 
 **Testing (Mobile, peer layers)**:
-- Layers policy: testing domain `knowledge/testing-layers.md` (beside `component-view-test` / `unit-testing` when installed)
+- Layers policy: testing domain `knowledge/testing-layers.md` (beside `component-view-test` / `integration-test` / `unit-testing` when installed)
 - Component-view (default for views): `component-view-test` skill
+- Integration (app-to-controller flows): `integration-test` skill
 - Unit (helpers / CV fallback): `unit-testing` skill • [Contributor unit testing docs](https://github.com/MetaMask/contributor-docs/blob/main/docs/testing/unit-testing.md)
 - E2E (device journeys): `e2e-test` skill
 
@@ -58,6 +61,6 @@ ComponentName/
 
 **Commands**: ONLY use `.claude/commands/` + yarn command
 
-**Testing**: CV default for views → unit for allowed fallback → e2e for Appium. Load `component-view-test` and `unit-testing` as peers (plus `e2e-test` when needed); follow testing domain `knowledge/testing-layers.md` when those skills are installed.
+**Testing**: CV default for views → integration for app-to-controller flows → unit for allowed fallback → e2e for Appium. Load `component-view-test`, `integration-test`, and `unit-testing` as peers (plus `e2e-test` when needed); follow testing domain `knowledge/testing-layers.md` when those skills are installed.
 
 **Forbidden**: ❌ npm/npx commands

--- a/domains/perps/knowledge/review-antipatterns.md
+++ b/domains/perps/knowledge/review-antipatterns.md
@@ -106,12 +106,13 @@ PRs that touch UI components must include testIDs so agentic recipes and E2E tes
 - **testID missing from the element that holds the value** — adding testID to a wrapper View instead of the `TextInput` or Text that actually contains the value. CDP fiber-walk reads `value` from the React element with the matching testID — the testID must be on the element that owns the state.
 - **TP/SL price inputs without testID** — the trigger price `TextInput` components in `PerpsTPSLView` (and similar order-form screens) frequently lack testIDs, making it impossible to assert the accepted decimal precision agentically. Any PR touching these screens must add `testID` to both the Take Profit and Stop Loss price inputs.
 
-## Component View Test Coverage
+## Test Layer Coverage
 
-**Same rule as testing domain `knowledge/testing-layers.md` (Mobile; installed beside testing skills):** screen/view behavior through rendered UI and app state defaults to `*.view.test.tsx`; unit tests only for pure logic, narrow contracts, or when CV cannot cover (smallest focused test + reason). Broad unit tests that render a page and mock hooks/selectors are a review smell.
+**Same rule as testing domain `knowledge/testing-layers.md` (Mobile; installed beside testing skills):** cover every test in its best-fit layer. Screen/view behavior through rendered UI and app state defaults to `*.view.test.tsx`; app-to-controller flows (real `HyperLiquidProvider` / `TradingService` behavior with only the I/O boundary mocked) belong in `*.integration.test.ts` via the perps harnesses; unit tests only for pure logic, narrow contracts, or when the higher layers cannot cover (smallest focused test + reason). Broad unit tests that render a page and mock hooks/selectors, or that mock the controller to fake a flow, are a review smell.
 
 Perps-specific enforcement:
 
 - **Component-view behavior tested as a unit test** — files such as `ui/pages/perps/**/index.test.tsx` or `app/components/UI/Perps/**/*.test.tsx` that render a whole page/view and assert UI behavior should be converted to `*.view.test.tsx` using the component-view test framework/skill.
+- **Controller/provider flow faked with mocks** — order/close/flip/validation flows that mock `HyperLiquidProvider` or `TradingService` to simulate behavior should be covered by `*.integration.test.ts` through the perps harnesses (`tests/integration/harnesses/perps*`), which run the real controller code with only the I/O boundary mocked. See the `integration-test` skill.
 - **Hook/selector mocking in a page behavior test** — mocking selectors, hooks, or service modules to force page state bypasses the real state wiring. Drive behavior through framework state presets/renderers instead. If the framework cannot cover the case yet, keep the unit test focused and link a follow-up for the missing framework support.
-- **Coverage drops during conversion** — converting to component-view tests must preserve the same coverage intent. If a scenario cannot move to component-view, document why and retain the smallest focused unit test needed to keep coverage.
+- **Coverage drops during conversion** — converting to component-view or integration tests must preserve the same coverage intent. If a scenario cannot move layer, document why and retain the smallest focused unit test needed to keep coverage.

--- a/domains/perps/skills/perps-review-pr/skill.md
+++ b/domains/perps/skills/perps-review-pr/skill.md
@@ -59,9 +59,10 @@ loop, run each CLI as a live tmux pane instead of one-shot, and `/clear` between
 From the installed `knowledge/` dir: **review-antipatterns** (core checklist), architecture,
 connection-architecture, caching-architecture, formatting-rules, mobile-extension-map,
 shared-package-analysis, feature-flags, screens. Check both repos when a shared util/screen
-changes. For page/view test changes, enforce **review-antipatterns** § Component View Test
+changes. For test changes, enforce **review-antipatterns** § Test Layer
 Coverage (same Mobile rule as testing `knowledge/testing-layers.md`): broad rendered UI
-behavior tests belong in the component-view framework/skill unless a focused unit test is
+behavior tests belong in the component-view framework/skill, and controller/provider flows
+belong in `*.integration.test.ts` via the perps harnesses, unless a focused unit test is
 explicitly justified.
 
 ## Reviewer prompt (force a fresh full review every round)
@@ -70,7 +71,7 @@ explicitly justified.
 Fresh full review of perps changes in <PR/branch> at <SHA> vs <base>. No prior context.
 Load installed perps knowledge (`knowledge/`, review-antipatterns + the rest). You gate this before any human sees it.
 Every perps anti-pattern AND every nit (naming, magic number, missing testID, weak test,
-component-view behavior left as broad unit tests, .toFixed, fallback-display vs 0) = BLOCKER.
+component-view behavior left as broad unit tests, controller/provider flows faked with mocks instead of integration tests, .toFixed, fallback-display vs 0) = BLOCKER.
 APPROVE only if nothing is left to improve.
 Return:
 VERDICT: APPROVE | REQUEST_CHANGES

--- a/domains/pr-workflow/skills/pr-guidelines/repos/metamask-mobile.md
+++ b/domains/pr-workflow/skills/pr-guidelines/repos/metamask-mobile.md
@@ -89,7 +89,7 @@ Use `.github/pull-request-template.md` - fill ALL sections:
   - Labels applied
 - Target `main` branch
 - Keep focused (single feature/fix)
-- Include tests in preference order: **Component-view** (default for views) → **unit** (pure logic / CV fallback) → **e2e** (device journeys). Canonical policy: testing domain `knowledge/testing-layers.md` (beside `component-view-test` / `unit-testing` when installed).
+- Include tests in the best-fit layer: **Component-view** (default for views) → **integration** (app-to-controller flows) → **unit** (pure logic / CV fallback) → **e2e** (device journeys). Canonical policy: testing domain `knowledge/testing-layers.md` (beside `component-view-test` / `integration-test` / `unit-testing` when installed).
 - Update TSDoc when relevant
 
 **⚠️ Force Push Policy**:

--- a/domains/pr-workflow/skills/pr-readiness-check/repos/metamask-mobile.md
+++ b/domains/pr-workflow/skills/pr-readiness-check/repos/metamask-mobile.md
@@ -21,13 +21,14 @@ Scan the current branch diff for common issues that could be flagged during PR r
 
    For each new or modified source file with non-trivial logic changes (not just config, docs, or styles), check whether a corresponding test file was added or updated.
 
-   Prefer layers per the Mobile testing-layers policy (testing domain `knowledge/testing-layers.md`, installed beside `component-view-test` / `unit-testing`):
+   Prefer layers per the Mobile testing-layers policy (testing domain `knowledge/testing-layers.md`, installed beside `component-view-test` / `integration-test` / `unit-testing`):
 
    - **Screens / views / UI behavior via app state** → prefer `Foo.view.test.tsx` (component-view). Warn if the only new coverage is a broad `Foo.test.tsx` that renders the whole screen and mocks hooks/selectors.
+   - **App-to-controller flows / controller behavior with I/O isolated** → prefer `Foo.integration.test.ts` (integration) exercised through a domain harness. Warn if such a flow is only covered by mocking the controller in a CV or unit test.
    - **Pure logic / helpers / narrow contracts** → `Foo.test.ts(x)` is appropriate.
    - **CV cannot cover yet** → accept a focused unit test, but warn if the PR does not note why CV was not used.
 
-   Heuristic: a source file `Foo.ts(x)` should have matching `Foo.view.test.tsx` (for screens/views) and/or `Foo.test.ts(x)` (for allowed unit cases). Warn if:
+   Heuristic: a source file `Foo.ts(x)` should have matching `Foo.view.test.tsx` (for screens/views), `Foo.integration.test.ts` (for app-to-controller flows), and/or `Foo.test.ts(x)` (for allowed unit cases). Warn if:
    - New exported functions/components have no corresponding test file changes
    - Existing test files were not updated despite significant logic changes in the source
    - A new or significantly changed screen only gained a broad unit screen test instead of a component-view test

--- a/domains/testing/knowledge/testing-layers.md
+++ b/domains/testing/knowledge/testing-layers.md
@@ -4,7 +4,7 @@
 
 Use this decision tree whenever adding or reviewing tests for Mobile code.
 
-**Peer skills:** `component-view-test` and `unit-testing` are documented at the same level. Choose by this tree — do not treat unit-testing as the primary testing guide.
+**Peer skills:** `component-view-test`, `integration-test`, and `unit-testing` are documented at the same level. Choose by this tree — do not treat unit-testing as the primary testing guide.
 
 ## Decision tree
 
@@ -14,6 +14,10 @@ What are you testing?
 │  → Write or update ComponentName.view.test.tsx (component-view-test skill)
 │  → If the CV framework cannot cover the case yet:
 │     → Smallest focused unit test + note why CV cannot
+│
+├─ App-to-controller seam / controller flow with I/O isolated
+│  → Write or update *.integration.test.ts (integration-test skill)
+│  → Exercise real controllers/providers/services through a domain harness
 │
 ├─ Pure logic / helpers / narrow component contracts
 │  → Focused unit test (unit-testing skill)
@@ -29,6 +33,15 @@ Page/view behavior exercised through rendered UI and real Redux/app state belong
 - Drive state through presets/renderers — do **not** mock hooks or selectors to force UI state.
 - Only the Engine and native modules may be mocked.
 - How to write/run: load the **component-view-test** skill.
+
+## Integration tests
+
+Behavior that crosses the app-to-controller seam belongs in **`*.integration.test.ts`** using the `tests/integration/` framework.
+
+- Run real controller, provider, service, validation, and state-transition code.
+- Mock only the I/O boundary; Shape B/C harnesses may also mock documented app-shell glue while preserving the real target chain.
+- Reuse a per-domain harness. Test files must not add one-off `jest.mock(...)` declarations.
+- How to write/run: load the **integration-test** skill.
 
 ## Unit tests (allowed cases)
 

--- a/domains/testing/skills/component-view-test/repos/metamask-mobile.md
+++ b/domains/testing/skills/component-view-test/repos/metamask-mobile.md
@@ -6,7 +6,7 @@ parent: component-view-test
 
 # Component View Testing Guidelines
 
-Peer of **unit-testing** for MetaMask Mobile. Create, update, and fix component view tests (`*.view.test.tsx`) using the `tests/component-view/` framework.
+Peer of **integration-test** and **unit-testing** for MetaMask Mobile. Create, update, and fix component view tests (`*.view.test.tsx`) using the `tests/component-view/` framework.
 
 ## When to use
 
@@ -23,7 +23,7 @@ If the case is pure logic / helpers, or CV cannot cover it yet, use **unit-testi
 
 ## Testing layers (read first)
 
-Follow installed `knowledge/testing-layers.md` for the full decision tree (CV → unit fallback → e2e). This skill and **unit-testing** are peers — choose by layer, not by which doc is longer.
+Follow installed `knowledge/testing-layers.md` for the full decision tree (CV vs integration vs unit vs E2E). These testing skills are peers — choose by layer, not by which doc is longer.
 
 Your job is to figure out whether the user needs to **write a new test**, **fix a failing test**, or **update tests after a component/preset change**, then follow the corresponding path and open the relevant reference when that path indicates.
 

--- a/domains/testing/skills/component-view-test/skill.md
+++ b/domains/testing/skills/component-view-test/skill.md
@@ -1,8 +1,8 @@
 ---
 name: component-view-test
 description: >
-  Peer of unit-testing for MetaMask Mobile. Default test layer for screen/view
-  UI behavior through real Redux state (*.view.test.tsx). Use when writing,
-  updating, or fixing component view tests. See knowledge/testing-layers.md for
-  when to choose CV vs unit vs e2e.
+  Peer of integration-test and unit-testing for MetaMask Mobile. Default test
+  layer for screen/view UI behavior through real Redux state (*.view.test.tsx).
+  Use when writing, updating, or fixing component view tests. See
+  knowledge/testing-layers.md for layer choice.
 ---

--- a/domains/testing/skills/integration-test/references/harness-extension.md
+++ b/domains/testing/skills/integration-test/references/harness-extension.md
@@ -1,0 +1,224 @@
+# Harness Extension
+
+Reference: [SKILL.md](../SKILL.md) · [Writing Tests](writing-tests.md) · [Reference](reference.md)
+
+How to add a new domain harness, or extend an existing one. **Most integration test work doesn't need this** — open the existing harness and write a test. Open this reference only when the harness pattern itself doesn't fit what you need to test.
+
+---
+
+## When to extend a harness vs add a one-off mock
+
+**Extend the harness when:**
+
+- Multiple tests will need the same setup
+- A controller dependency was added, removed, or renamed
+- An existing mock's default return needs to change for a class of tests
+- A new helper would simplify many tests (e.g. `setupOpenPosition()`)
+
+**Don't add a one-off mock to the test file.** If a test seems to need its own `jest.mock(...)` call, extend the harness. Tests in `*.integration.test.ts` files do not contain `jest.mock` declarations.
+
+**Use `mockReturnValueOnce` for per-test customisation:**
+
+```ts
+const { mocks } = buildPerpsIntegrationHarness();
+mocks.subscription.getCachedPrice.mockReturnValueOnce('60000');
+```
+
+This is the right tool when one test needs a different mock behaviour from the others. It doesn't pollute the harness for other tests.
+
+---
+
+## Harness anatomy
+
+Every domain harness file (`tests/integration/harnesses/<domain>.ts`) has the same structure, in this order:
+
+1. **Header comment** — the REAL/MOCKED split + USAGE example
+2. **`jest.mock(...)` declarations** — for the I/O boundary services
+3. **Imports** — the real production code (controller, services, types)
+4. **Default option constants** — sane defaults for cached prices, asset mappings, etc.
+5. **Type definitions** — the harness's return type and options type
+6. **Factory function** — `build<Domain>IntegrationHarness(options) → harness`
+
+```ts
+/**
+ * <Domain> integration-test harness.
+ *
+ * Owns the standard jest.mock(...) declarations for the <domain> I/O boundary
+ * AND a build<Domain>IntegrationHarness() factory.
+ *
+ * REAL (runs production code paths):
+ *   - <Controller / Provider class>
+ *
+ * MOCKED (the I/O boundary):
+ *   - <ServiceA>
+ *   - <ServiceB>
+ *   - <ModuleSingleton>
+ *   - <UtilityModule>
+ *
+ * USAGE:
+ *
+ *     import { build<Domain>IntegrationHarness }
+ *       from '<relative path>/tests/integration/harnesses/<domain>';
+ *
+ *     const { instance } = build<Domain>IntegrationHarness();
+ *     await instance.someAction(...);
+ */
+
+jest.mock('<relative path>/app/controllers/<domain>/services/ServiceA');
+jest.mock('<relative path>/app/controllers/<domain>/services/ServiceB');
+// ... full set of jest.mock declarations for the I/O boundary
+
+import { ControllerClass } from '<relative path>/app/controllers/<domain>/...';
+import { ServiceA } from '<relative path>/app/controllers/<domain>/services/ServiceA';
+// ... real production code imports
+
+const DEFAULT_OPTIONS = { /* sane defaults */ };
+
+export interface <Domain>IntegrationHarness {
+  instance: ControllerClass;
+  mocks: { /* mocked services */ };
+  // helpers like setX, withY, etc.
+}
+
+export interface <Domain>HarnessOptions {
+  // overrides for the defaults
+}
+
+export function build<Domain>IntegrationHarness(
+  options: <Domain>HarnessOptions = {},
+): <Domain>IntegrationHarness {
+  // 1. reset module-level singletons
+  // 2. build the mocked services with defaults + overrides
+  // 3. wire mocks to MockedClass via .mockImplementation()
+  // 4. instantiate the real controller, passing mocked deps
+  // 5. return { instance, mocks, helpers }
+}
+```
+
+The perps harness at `tests/integration/harnesses/perps.ts` is the canonical reference. Copy its shape when adding a new domain.
+
+---
+
+## The REAL/MOCKED split — drawing the line
+
+The line between REAL and MOCKED is the **I/O boundary**. Real: anything that's pure logic, state, validation, or transitions. Mocked: anything that talks to the network, the disk, the keyring, native modules, or websockets.
+
+| Component                                        | REAL or MOCKED? | Why                                                       |
+| ------------------------------------------------ | --------------- | --------------------------------------------------------- |
+| Controller class                                 | REAL            | Production code; integration tests' job is to exercise it |
+| Provider class (`HyperLiquidProvider`, etc.)     | REAL            | Same                                                      |
+| Validation methods on the class                  | REAL            | Where seam bugs live                                      |
+| State reducers / `update()` calls                | REAL            | Same                                                      |
+| Selectors                                        | REAL            | Read state, derive UI props — pure                        |
+| SDK client wrappers (`HyperLiquidClientService`) | MOCKED          | Network I/O                                               |
+| Wallet / keyring service                         | MOCKED          | Native module I/O                                         |
+| WebSocket subscription service                   | MOCKED          | Network + timing I/O                                      |
+| Module-level caches that hit storage             | MOCKED          | Disk I/O                                                  |
+| Stream managers / orchestrators                  | MOCKED          | UI subscription/runtime plumbing — different concern      |
+| Validation utility functions in separate files   | MOCKED          | Existing pattern in codebase; class methods stay real     |
+| App-shell glue for hook/rendered harnesses        | MOCKED in B/C   | Engine/navigation/runtime plumbing, documented in harness |
+
+When in doubt, ask: **does this code talk to the outside world (network, disk, keyring, native module, websocket)?** If yes, mock it. If no, leave it real.
+
+For Shape B/C, also ask: **is this app-shell glue required only to mount the hook/screen while the real controller/service/provider chain still runs?** If yes, the harness may mock it, but the header must list the mock and explain which real chain remains covered.
+
+---
+
+## Adding a new domain harness
+
+1. **Create** `tests/integration/harnesses/<domain>.ts`. Copy the perps harness as the template.
+
+2. **Identify the I/O boundary** for the domain. Read the controller's constructor and method bodies. List every dependency that does I/O.
+
+3. **Write the `jest.mock(...)` block** at the top — one entry per I/O dependency. For services that have a complex API, use the pattern from perps where the mock is replaced with `.mockImplementation(() => mockedService)` at runtime in the factory. For utility modules, use a factory `() => ({ ... })` to provide the mock shape inline.
+
+4. **Define the harness's return type** — what the test will use:
+   - `instance` — the real controller / provider
+   - `mocks` — a record of the mocked services for per-test customisation
+   - Helpers like `setCachedPrice`, `setupOpenPosition`, `setupTradingReady` — anything that simplifies common test setup
+
+5. **Implement the factory.** Inside:
+   - Reset any module-level singleton state (caches, in-flight markers, etc.)
+   - Build the mocked services with sane defaults + caller overrides
+   - Wire `MockedClass.mockImplementation(() => instance)` so `new ServiceClass()` calls inside the controller return your mock
+   - Construct the real controller / provider with the mocked services injected (or via the messenger pattern if that's what the controller uses)
+   - Return `{ instance, mocks, ...helpers }`
+
+6. **Write the header comment.** REAL/MOCKED split + a USAGE block showing one example. Future readers (including your future self) need to understand the seam at a glance.
+
+7. **Update `tests/integration/AGENTS.md`.** Add a section under "Per-domain harnesses" listing the domain, what's real, what's mocked, the factory signature, and (optionally) a link to a per-domain use-case file if one exists.
+
+8. **Smoke test.** Write one happy-path integration test for the simplest action on the controller. Verify it runs and the assertion passes. If setup is painful at this stage, the harness needs more helpers — add them now, before writing more tests.
+
+---
+
+## Extending an existing harness
+
+Smaller surface; same discipline. Cases:
+
+### A new mock service has been added to the controller
+
+The controller now depends on `NewService`. To extend the harness:
+
+1. Add `jest.mock('<path>/NewService');` to the top of the harness file.
+2. Import `NewService` near the other real-code imports.
+3. Add a typed mocked instance to the factory: `const newService = { ... } as unknown as jest.Mocked<NewService>;` with sane defaults for every method the controller calls.
+4. Wire it: `(NewService as jest.MockedClass<typeof NewService>).mockImplementation(() => newService);`
+5. Add it to the `mocks` field of the return value.
+6. Update the REAL/MOCKED header comment.
+
+### A new helper would simplify many tests
+
+E.g. `setupOpenPosition({ symbol, side, size })` to put the harness into a state where a position is already open. To add it:
+
+1. Build the helper as a function inside the factory's closure, so it has access to `instance` and `mocks`.
+2. Document it on the harness's return type interface.
+3. Reference it in `tests/integration/AGENTS.md` under the domain's section.
+
+```ts
+const setupOpenPosition = async (params: {
+  symbol: string;
+  side: 'long' | 'short';
+  size: number;
+}) => {
+  await instance.placeOrder({
+    symbol: params.symbol,
+    isBuy: params.side === 'long',
+    size: params.size.toString(),
+    orderType: 'market',
+    currentPrice: 50_000,
+  });
+};
+
+return { instance, mocks, setCachedPrice, setupOpenPosition };
+```
+
+### An existing default needs to change
+
+E.g. the cached price for BTC was `'50000'`; we want it to vary per test.
+
+1. **Don't** change the default itself — that breaks every existing test.
+2. **Do** add an option: `cachedPrices?: Record<string, string>` (if not already present), with the existing value as the default.
+3. Update the helper / factory to merge caller-provided prices with defaults.
+4. Tests that need the new behaviour pass the option; existing tests are unchanged.
+
+---
+
+## What NOT to put in a harness
+
+- **Test-specific scenarios.** A helper called `setupReversePositionThatFailsValidation` is too specific. Build small composable helpers (`setupOpenPosition`, `setCachedPrice`) and let tests compose them.
+- **Assertions.** The harness builds the world; the test asserts. If the harness is asserting, the test boundary is wrong.
+- **Hardcoded test data that's only used by one test.** Inline that data in the test.
+- **Non-mocked services that aren't part of the I/O boundary.** Pure-logic services should run real. If a "service" is being mocked, ask whether it actually does I/O.
+
+---
+
+## When to split a harness
+
+Split a single-domain harness into multiple files when:
+
+- One file exceeds ~250 lines AND it covers genuinely separate concerns (e.g. trading vs subscriptions vs deposits)
+- Multiple test areas need very different default configurations
+- Two parts of the controller have non-overlapping mocked dependencies
+
+Otherwise, keep the harness in one file. Splitting prematurely makes the test author hunt for the right harness.

--- a/domains/testing/skills/integration-test/references/reference.md
+++ b/domains/testing/skills/integration-test/references/reference.md
@@ -1,0 +1,287 @@
+# Running Tests, Self-Review, and Diagnosing Failures
+
+Use this reference when you need to **run** integration tests, **self-review** after tests pass, or **diagnose and fix** failures. Also covers assertion patterns and What NOT to Do.
+
+Reference: [SKILL.md](../SKILL.md) · [Writing Tests](writing-tests.md) · [Harness Extension](harness-extension.md)
+
+---
+
+## Table of contents
+
+- [Run the Tests](#run-the-tests)
+- [Self-Review Checklist](#self-review-checklist)
+- [Diagnosing Failures](#diagnosing-failures)
+- [Assertion Patterns](#assertion-patterns)
+- [Module-Level Singleton State](#module-level-singleton-state)
+- [What NOT to Do](#what-not-to-do)
+- [Quick Reference](#quick-reference)
+
+---
+
+## Run the Tests
+
+**Always use `jest.config.integration.js`** — the default Jest config excludes integration tests.
+
+```bash
+# Run a single file
+yarn jest -c jest.config.integration.js \
+  app/components/UI/Perps/hooks/usePerpsFlipPosition.integration.test.ts \
+  --runInBand --silent --coverage=false
+
+# Run a specific test by name
+yarn jest -c jest.config.integration.js <file> -t "rejects a market order" --runInBand --silent --coverage=false
+
+# Watch mode
+yarn jest -c jest.config.integration.js <file> --watch
+
+# Coverage on the controller / provider you're exercising (NOT on the test file)
+yarn jest -c jest.config.integration.js <test-path> \
+  --coverage \
+  --collectCoverageFrom="app/controllers/perps/providers/HyperLiquidProvider.ts"
+
+# All integration tests
+yarn jest -c jest.config.integration.js
+```
+
+**Why `--collectCoverageFrom` is needed for focused coverage:** Point coverage at the controller / provider / service whose behavior the test exercises, rather than at the test file.
+
+---
+
+## Self-Review Checklist
+
+Before declaring the task done, go through this checklist for every test written or modified. If any item fails, fix it and re-run.
+
+| #   | Check                                                                                                                                                      | What to do if it fails                                                          |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| 1   | **No `jest.mock` in the test file** — only the harness owns mocks                                                                                          | Move the mock into the harness; use `mockReturnValueOnce` for per-test override |
+| 2   | **Every test calls a real method on the harness's instance** — no harness-only tests                                                                       | Add a real action call; if there's nothing meaningful to call, delete the test  |
+| 3   | **Assertions on observable outcomes** — return value, post-call state, selector output. Mock-call assertions only when verifying a side effect             | Replace internal-state assertions with public-API assertions                    |
+| 4   | **No fake timers** — no `jest.useFakeTimers()`, `jest.advanceTimersByTime()`, or `jest.useRealTimers()`                                                    | Use `await` and `waitFor` for async settlement                                  |
+| 5   | **No snapshots** — no `toMatchSnapshot()` or `toMatchInlineSnapshot()`                                                                                     | Replace with explicit value assertions                                          |
+| 6   | **Each test maps to a use case** — every `it` traces back to a row in the per-domain use-case file (or to a clear public-method + scenario)                | Either add the missing use case to the matrix, or delete / rescope the test     |
+| 7   | **AAA formatting** — blank lines between Arrange, Act, Assert in every test                                                                                | Add the blank line separators                                                   |
+| 8   | **Module-level singletons reset by the harness, not by the test** — no per-test `mockedSingleton.method.mockReset()` for known singletons                  | Add the reset to the harness's factory; the harness owns lifecycle              |
+| 9   | **Customisation uses `mockReturnValueOnce`, not `mockReturnValue`** — for per-test mock variations                                                         | Switch to `Once` so the next test sees the harness defaults                     |
+| 10  | **Test file imports are minimal** — harness import + types + assertion helpers only. No imports of real production services that the harness already wires | Remove the redundant imports                                                    |
+
+---
+
+## Diagnosing Failures
+
+### Identify the error type first
+
+| Error pattern                                              | Likely cause                                               | Fix                                                                               |
+| ---------------------------------------------------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `Cannot find module '<service>'` or `is not a constructor` | The harness's `jest.mock` declarations missed a dependency | Add the missing `jest.mock` to the harness file, or check the relative path       |
+| `<Method> is not a function`                               | Mocked service is missing a method the controller calls    | Add the missing method (with a sane default return) to the harness's mock builder |
+| `priceForValidation is undefined` (or similar)             | Real validation logic running against incomplete params    | Pass the missing param to the action under test, or fix the production code       |
+| `Cannot read properties of undefined`                      | Controller reading state set up by a different test (leak) | Add the missing reset to the harness's factory; check module-level singletons     |
+| Test passes alone, fails in the suite                      | Module-level singleton state leaking between tests         | See [Module-Level Singleton State](#module-level-singleton-state)                 |
+| Test passes in isolation, fails with `--coverage`          | Coverage instrumentation interacting with native modules   | Run without coverage; coverage already isn't useful on the test file              |
+| `forceExit` warning or hanging tests                       | An async subscription / timer wasn't torn down             | Ensure the harness exposes a teardown helper, or wrap state in `try / finally`    |
+| `expect(jest.fn()).toHaveBeenCalledWith(...)` mismatch     | Production code call signature changed                     | Update the assertion; if production-only change, fix the production code          |
+| Many tests fail after a controller change                  | Controller refactor affected the seam many tests assert on | This is integration tests doing their job. Update the harness, then update tests  |
+
+### Inspect the harness state
+
+```ts
+// Add temporarily inside a failing test
+const { provider, mocks } = buildPerpsIntegrationHarness();
+console.log('initial state:', JSON.stringify(provider.state, null, 2));
+console.log(
+  'cached prices via mock:',
+  mocks.subscription.getCachedPrice('BTC'),
+);
+```
+
+### Inspect what the controller called on the mocks
+
+```ts
+const { provider, mocks } = buildPerpsIntegrationHarness();
+await provider.placeOrder({
+  /* ... */
+});
+console.log('client.someMethod calls:', mocks.client.someMethod.mock.calls);
+```
+
+### Check that the real production code path actually ran
+
+If a test passes too easily, you may have stubbed something the harness shouldn't have. Add a temporary `console.log` inside the controller method you expect to run; if it doesn't print, the harness is short-circuiting too aggressively. Check the harness's factory and the `jest.mock` factories.
+
+---
+
+## Assertion Patterns
+
+```ts
+// Return-value happy path
+const result = await provider.placeOrder({
+  /* ... */
+});
+expect(result.success).toBe(true);
+
+// Return-value rejection
+const result = await provider.validateOrder({
+  /* ... */
+});
+expect(result.isValid).toBe(false);
+expect(result.error).toBe(PERPS_ERROR_CODES.ORDER_PRICE_REQUIRED);
+
+// Throwing rejection
+await expect(
+  provider.flipPosition({ symbol: 'BTC', size: 2, orderType: 'market' }),
+).rejects.toThrow(/ORDER_PRICE_REQUIRED/);
+
+// Post-call state
+await provider.placeOrder({
+  /* ... */
+});
+expect(provider.state.positions.BTC).toMatchObject({
+  side: 'long',
+  size: 1,
+});
+
+// Selector over state
+import { selectPosition } from 'app/controllers/perps/selectors';
+expect(selectPosition(provider.state, 'BTC')?.size).toBe(1);
+
+// Side-effect on mocked SDK (only when verifying the call IS the point)
+await provider.placeOrder({
+  /* ... */
+});
+expect(mocks.client.someExchangeCall).toHaveBeenCalledWith(
+  expect.objectContaining({ asset: 0, isBuy: true }),
+);
+
+// Multi-step flow assertion
+await provider.placeOrder({
+  /* open */
+});
+await provider.closePosition({
+  /* close */
+});
+expect(provider.state.positions.BTC).toBeUndefined();
+```
+
+---
+
+## Module-Level Singleton State
+
+Many controllers depend on module-level singletons that survive between tests within a file (jest doesn't reset module state per test by default). Common examples in perps: `TradingReadinessCache`, stream managers, in-flight markers.
+
+The harness handles this for known singletons — its factory resets their state on every call. **Always call the harness in `beforeEach` or at the top of each `it`**, never construct it once at the `describe` level.
+
+```ts
+// ✅ Build the harness inside each it (or in beforeEach)
+describe('flow', () => {
+  it('does A', async () => {
+    const { provider } = buildPerpsIntegrationHarness();
+    await provider.actionA();
+  });
+
+  it('does B', async () => {
+    const { provider } = buildPerpsIntegrationHarness();
+    await provider.actionB();
+  });
+});
+
+// ❌ Build once and reuse — singleton state from test 1 leaks into test 2
+describe('flow', () => {
+  const { provider } = buildPerpsIntegrationHarness();
+
+  it('does A', async () => {
+    await provider.actionA();
+  });
+  it('does B', async () => {
+    await provider.actionB();
+  }); // may see leftover state from A
+});
+```
+
+If you discover a new singleton not handled by the harness — symptom: tests pass alone but fail in the suite — add the reset to the harness's factory. See [`harness-extension.md`](harness-extension.md).
+
+---
+
+## What NOT to Do
+
+```ts
+// ❌ jest.mock in the test file — blocked, owns belong to the harness
+jest.mock('../../../../controllers/perps/services/HyperLiquidClientService');
+
+// ❌ Instantiate the controller directly
+const provider = new HyperLiquidProvider({
+  /* ... */
+});
+
+// ❌ Harness-only test — no real method called
+it('builds the harness', () => {
+  const { provider } = buildPerpsIntegrationHarness();
+  expect(provider).toBeDefined();
+});
+
+// ❌ Snapshot assertion
+const result = await provider.someAction();
+expect(result).toMatchSnapshot();
+
+// ❌ Fake timers
+jest.useFakeTimers();
+await provider.someAsyncAction();
+jest.advanceTimersByTime(5000);
+
+// ❌ mockReturnValue (without `Once`) for per-test customisation — leaks to other tests
+mocks.subscription.getCachedPrice.mockReturnValue('60000');
+
+// ✅ Per-test customisation
+mocks.subscription.getCachedPrice.mockReturnValueOnce('60000');
+
+// ❌ Mocking selectors or pure helpers
+jest.mock('../../../../controllers/perps/selectors', () => ({
+  selectPosition: jest.fn(),
+}));
+
+// ✅ Real selectors over real state
+import { selectPosition } from '../../../../controllers/perps/selectors';
+expect(selectPosition(provider.state, 'BTC')?.size).toBe(1);
+
+// ❌ Reaching into controller internals
+(provider as any).#privateField = 'test value';
+
+// ✅ Drive state through real actions
+await provider.someAction(/* params that produce the desired state */);
+
+// ❌ Asserting on internal state shape (private fields)
+expect((provider as any).#cachedThing).toBe('value');
+
+// ✅ Assert on public API
+expect(provider.state.publicField).toBe('value');
+```
+
+---
+
+## Quick Reference
+
+```bash
+# Run a single integration test
+yarn jest -c jest.config.integration.js <path> --runInBand --silent --coverage=false
+
+# Run all integration tests
+yarn jest -c jest.config.integration.js
+
+# Coverage on the controller / provider exercised
+yarn jest -c jest.config.integration.js <test-path> \
+  --coverage --collectCoverageFrom="<production-path>"
+
+# Lint check
+yarn eslint <path/to/test.ts>
+```
+
+**Key locations:**
+
+| What                                           | Where                                                       |
+| ---------------------------------------------- | ----------------------------------------------------------- |
+| Framework rules + per-domain harness inventory | `tests/integration/AGENTS.md`                               |
+| Strategy + comparison tables + rollout plan    | `tests/integration/STRATEGY.md`                             |
+| Coverage targets + bug-tracking mechanisms     | `tests/integration/coverage-and-tracking.md`                |
+| Per-domain use case → layer matrix             | `tests/integration/perps-use-cases.md` (others as added)    |
+| Per-domain harnesses                           | `tests/integration/harnesses/<domain>.ts`                   |
+| Jest config                                    | `jest.config.integration.js`                                |
+| Skill source                                   | `MetaMask/skills/domains/testing/skills/integration-test/`  |

--- a/domains/testing/skills/integration-test/references/writing-tests.md
+++ b/domains/testing/skills/integration-test/references/writing-tests.md
@@ -1,0 +1,291 @@
+# Writing Tests
+
+Reference: [SKILL.md](../SKILL.md) · [Harness Extension](harness-extension.md) · [Reference](reference.md)
+
+---
+
+## Read Before Writing
+
+Before writing any test, read:
+
+- The controller / provider / service file under test
+- Any existing `*.integration.test.ts` for the same area (look beside the file and across the feature folder)
+- The matching harness in `tests/integration/harnesses/<domain>.ts` — what it returns, what it mocks, what helpers it exposes
+- The per-domain use-case file if one exists (e.g. `tests/integration/perps-use-cases.md`) — the authoritative list of what should be tested at this layer
+
+If the harness for the domain doesn't exist yet, stop and read [`harness-extension.md`](harness-extension.md) first.
+
+---
+
+## Enumerate Use Cases
+
+**Do this before writing a single test line.** Build a candidate list scoped and deduplicated against existing tests.
+
+### 1. Pull from the use-case matrix (preferred)
+
+If a per-domain use-case file exists (e.g. `tests/integration/perps-use-cases.md`), the rows assigned to **Integration** as the primary layer are the canonical list. Each row is a use case you may need to cover; pick the ones not yet implemented.
+
+### 2. Or list user-facing actions for the area
+
+If no use-case file exists, derive the list from the controller's public surface:
+
+- Every public method on the controller / provider that has user-visible state effects → at least one happy-path test
+- Every error code or rejection branch reachable from user input → at least one rejection test
+- Every multi-step user flow that crosses methods → one end-to-end test
+
+Ask: "What can a user **do** that touches this controller?" — open / close / edit / cancel an order, deposit / withdraw funds, change leverage, set TP/SL, switch testnet, etc.
+
+### 3. Map each use case to a test pattern
+
+| User action / system event                               | Valid pattern                                                                |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Public action on happy path → state changes correctly    | `await provider.X(...)` → assert on `provider.state` or selector             |
+| Public action on rejection path → returns error code     | `await provider.X(...)` → assert on `result.error === ERROR_CODE`            |
+| Public action that throws → throws correct error         | `await expect(provider.X(...)).rejects.toThrow(...)`                         |
+| Multi-step user flow → final state correct               | sequential `await provider.X(); await provider.Y();` → assert on final state |
+| Subscription event → state updates                       | invoke harness's subscription helper → assert state                          |
+| State transition (loading flag, etc.) → correct ordering | hold a mocked I/O promise, assert intermediate state, then resolve it        |
+| Side-effecting call to mocked SDK → SDK called correctly | call action → `expect(mocks.client.method).toHaveBeenCalledWith(...)`        |
+
+Drop anything that only exercises the harness defaults — every test must call at least one real method on the real instance.
+
+### 4. Pick the narrowest harness shape
+
+Use the lightest harness that proves the use case:
+
+| Shape | Harness | Use when |
+| ----- | ------- | -------- |
+| A | `buildPerpsIntegrationHarness` | Direct provider/service behavior is enough: validation, order placement, close/cancel branches, mocked SDK side effects. |
+| B | `buildPerpsFlowHarness` | The risk includes hook wiring or the `TradingService` -> provider seam, but rendering UI is not part of the behavior. |
+| C | `buildPerpsComponentHarness` | A rendered user interaction must prove it reaches real perps trading code. Do not use for pure UI variants. |
+
+Shape B/C may mock app-shell glue in the harness (Engine shim, network hook, native runtime providers, confirmation/pay plumbing). Those mocks must stay harness-owned and documented in the REAL/MOCKED header; test files still never add `jest.mock(...)`.
+
+### 5. Deduplicate against existing tests
+
+Read the existing `*.integration.test.ts` for the area (if any) and remove candidates already covered. Look at the test bodies, not just titles, since one `it` might cover several rows of the matrix.
+
+### 6. Run coverage on the file you're exercising and prioritise
+
+```bash
+yarn jest -c jest.config.integration.js <test-path> \
+  --coverage \
+  --collectCoverageFrom="app/controllers/perps/providers/HyperLiquidProvider.ts"
+```
+
+Coverage on the test file is always near 0% (the test exercises a different file); always point `--collectCoverageFrom` at the controller / provider you're testing.
+
+Focus on uncovered branches in the controller. Prioritise candidates that cover the most uncovered paths. Proceed directly to writing.
+
+---
+
+## Write a New Test File
+
+### File naming
+
+```
+<feature>.integration.test.ts   ← always *.integration.test.ts(x)
+```
+
+Live next to the code under test. Same folder as the unit / CV test file if one exists. Examples:
+
+```
+app/components/UI/Perps/hooks/usePerpsFlipPosition.integration.test.ts
+app/controllers/perps/services/TradingService.integration.test.ts
+```
+
+### File structure
+
+```ts
+/**
+ * Integration test — <one-line description of the user flow>.
+ *
+ * Brief description of the seam being exercised, with file:line refs into
+ * the controller / provider if you're testing a specific code site.
+ */
+
+import { build<Domain>IntegrationHarness } from '<relative path>/tests/integration/harnesses/<domain>';
+import { /* error codes, types */ } from '<relative path>/app/controllers/<domain>/...';
+
+describe('<Feature> — <flow>', () => {
+  describe('<happy or rejection scenario group>', () => {
+    it('<does the thing or rejects on the bad input>', async () => {
+      // Arrange
+      const { provider, mocks } = build<Domain>IntegrationHarness();
+
+      // Act
+      const result = await provider.someAction({ /* real params */ });
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(provider.state.someField).toBe(expected);
+    });
+  });
+});
+```
+
+### Use the harness; don't bypass it
+
+```ts
+// ✅ Use the harness
+const { provider, mocks, setCachedPrice } = buildPerpsIntegrationHarness();
+setCachedPrice('BTC', '60000');
+const result = await provider.placeOrder({ ... });
+
+// ❌ Do not add jest.mock calls in the test file
+jest.mock('../../../../controllers/perps/services/HyperLiquidClientService');
+
+// ❌ Do not instantiate the controller directly
+const provider = new HyperLiquidProvider({ /* ... */ });
+```
+
+If the harness doesn't expose what you need, **extend it** — see [`harness-extension.md`](harness-extension.md). Tests should not contain harness-shaped setup code.
+
+### One test = one use case
+
+Each `it` should map to exactly one row from the per-domain use-case matrix. If you find yourself writing a test that covers two rows, split it. If you find yourself writing a test that doesn't fit any row, ask whether the use case is missing from the matrix or the test belongs in a different layer (Unit / CV / E2E).
+
+### AAA (Arrange / Act / Assert) — strict
+
+```ts
+it('rejects a market order with no currentPrice', async () => {
+  // Arrange
+  const { provider } = buildPerpsIntegrationHarness();
+
+  // Act
+  const result = await provider.validateOrder({
+    symbol: 'BTC',
+    isBuy: false,
+    size: '0.2',
+    orderType: 'market',
+  });
+
+  // Assert
+  expect(result.isValid).toBe(false);
+  expect(result.error).toBe(PERPS_ERROR_CODES.ORDER_PRICE_REQUIRED);
+});
+```
+
+Blank lines between Arrange / Act / Assert. The reader should be able to spot the three sections at a glance.
+
+### Multi-step flows
+
+A single `it` can cover a multi-step user journey if the journey is one logical use case:
+
+```ts
+it('opens a long, partial-closes it, then closes the rest', async () => {
+  // Arrange
+  const { provider } = buildPerpsIntegrationHarness();
+
+  // Act + intermediate assertion
+  await provider.placeOrder({
+    symbol: 'BTC',
+    isBuy: true,
+    size: '1',
+    orderType: 'market',
+    currentPrice: 50_000,
+  });
+  expect(provider.state.positions.BTC?.size).toBe(1);
+
+  await provider.closePosition({
+    symbol: 'BTC',
+    size: '0.4',
+    orderType: 'market',
+    currentPrice: 50_000,
+  });
+  expect(provider.state.positions.BTC?.size).toBeCloseTo(0.6);
+
+  await provider.closePosition({
+    symbol: 'BTC',
+    orderType: 'market',
+    currentPrice: 50_000,
+  }); // full close
+
+  // Assert (final)
+  expect(provider.state.positions.BTC).toBeUndefined();
+});
+```
+
+Multi-step is fine when the steps are one user journey. Multi-step is wrong when you're using it to dodge writing separate tests for separate use cases.
+
+### Rendered component flows
+
+Use the rendered-component harness only when the rendered interaction is part of the integration surface. The component should still reach a real method through the harness chain; do not use Shape C for pure UI variants that belong in component-view tests.
+
+```tsx
+import { fireEvent, screen, waitFor } from '@testing-library/react-native';
+
+import { buildPerpsComponentHarness } from '../../../../../tests/integration/harnesses/perps-component';
+import PerpsOrderView from '../Views/PerpsOrderView/PerpsOrderView';
+import { PerpsOrderViewSelectorsIDs } from '../Perps.testIds';
+
+it('places an order from the rendered order screen', async () => {
+  // Arrange
+  const perps = buildPerpsComponentHarness();
+  try {
+    perps.harness.setupTradingReady();
+    perps.renderScreenWithFlow(PerpsOrderView, {
+      routeName: 'PerpsOrder',
+      initialParams: {
+        asset: 'BTC',
+        direction: 'long',
+        amount: '100',
+        leverage: 3,
+        defaultSzDecimals: 3,
+        defaultMaxLeverage: 50,
+      },
+    });
+
+    const placeOrderButton = await screen.findByTestId(
+      PerpsOrderViewSelectorsIDs.PLACE_ORDER_BUTTON,
+    );
+
+    // Act
+    fireEvent.press(placeOrderButton);
+
+    // Assert
+    await waitFor(() => {
+      expect(perps.mocks.exchangeClient.order).toHaveBeenCalledTimes(1);
+    });
+    expect(perps.mocks.showToast).toHaveBeenCalled();
+  } finally {
+    perps.teardown();
+  }
+});
+```
+
+Shape C tests still follow the normal rules: no `jest.mock(...)` in test files, assert on observable UI/side effects, and use `waitFor(...)` for async settlement.
+
+### Customise mocks per test
+
+```ts
+it('handles the SDK returning a stale price', async () => {
+  const { provider, mocks } = buildPerpsIntegrationHarness();
+  mocks.subscription.getCachedPrice.mockReturnValueOnce('1');
+
+  const result = await provider.validateOrder({
+    symbol: 'BTC',
+    isBuy: true,
+    size: '0.2',
+    orderType: 'market',
+    currentPrice: 1, // matches the stale cached value
+  });
+
+  expect(result.isValid).toBe(true);
+});
+```
+
+Use `mockReturnValueOnce` for per-test customisation so the harness defaults aren't permanently changed for the rest of the suite.
+
+---
+
+## Updating tests after a controller change
+
+When the controller's public surface changes (new method, renamed method, new field on result, new error code):
+
+1. **Run the existing tests.** Multiple tests will fail. That's the integration suite doing its job.
+2. **Audit the failures.** Each failure tells you about a use case affected by the change.
+3. **Update the harness if needed.** If the controller's constructor signature changed, or a new service dependency was added, update `tests/integration/harnesses/<domain>.ts` first. See [`harness-extension.md`](harness-extension.md).
+4. **Update the tests.** Adjust assertions / parameters to match the new behaviour. Keep the test names and use-case mapping stable.
+5. **Add tests for new use cases.** If the change introduces new public actions or new rejection paths, add tests for them.
+6. **Run the self-review checklist.** See [`reference.md`](reference.md).

--- a/domains/testing/skills/integration-test/repos/metamask-mobile.md
+++ b/domains/testing/skills/integration-test/repos/metamask-mobile.md
@@ -1,0 +1,152 @@
+---
+repo: metamask-mobile
+parent: integration-test
+---
+
+# Integration Testing Guidelines
+
+Create, update, and fix controller-app integration tests (`*.integration.test.ts`) using the MetaMask Mobile `tests/integration/` framework.
+
+Use this skill whenever you need to:
+
+- Write a new integration test file
+- Update tests after a controller / service / harness has changed
+- Diagnose and fix a failing integration test
+- Add a new per-domain harness or extend an existing one
+
+Your job is to figure out whether the user needs to **write a new test**, **fix a failing test**, **update tests after a controller change**, or **add/extend a harness**, then follow the corresponding path and open the relevant reference when that path indicates.
+
+## Testing layers (read first)
+
+Follow installed `knowledge/testing-layers.md` before choosing integration vs component-view vs unit vs E2E. Use integration tests when the behavior crosses the app-to-controller seam and must exercise real controller, provider, or service code. Pure UI variants belong in component-view tests; pure logic belongs in unit tests; full native-device journeys belong in E2E.
+
+**Decision tree — which reference to use:**
+
+```
+Task → What do you need?
+├─ Write new test or update after change
+│  → Read controller/service + existing tests
+│  → Open references/writing-tests.md (use cases, harness selection, file structure, assertions)
+│  → If the harness doesn't fit → also open references/harness-extension.md
+│  → After writing: run tests, then open references/reference.md for self-review
+│
+├─ Fix failing test
+│  → Run: yarn jest -c jest.config.integration.js <path> --runInBand --silent --coverage=false
+│  → Identify error type → Open references/reference.md (Diagnosing Failures)
+│
+├─ Add a new domain harness or extend an existing one
+│  → Open references/harness-extension.md (when to extend, structure, REAL/MOCKED split, AGENTS.md updates)
+│
+└─ Run tests or self-review after tests pass
+   → Open references/reference.md (Run the Tests, Self-Review Checklist)
+```
+
+Do not read the full reference files until the decision tree or workflow sends you there.
+
+---
+
+## What Are Integration Tests?
+
+Integration tests are **controller-app integration** tests that exercise real controller / provider / service code with the I/O boundary mocked. They live alongside the code as `<feature>.integration.test.ts` and use a dedicated framework in `tests/integration/`.
+
+Key constraint: **only the I/O boundary may be mocked** (SDK clients, wallet, subscription services, native modules, keyring). Shape B/C harnesses may also mock documented app-shell glue when the real target chain still runs. The controller, its services, validation logic, and state transitions all run for real at the chosen boundary. The harness for each domain owns the standard `jest.mock(...)` declarations; tests don't add their own.
+
+Before changing tests, read `tests/integration/AGENTS.md`. For the full four-layer strategy and rollout plan, also read `tests/integration/STRATEGY.md`.
+
+---
+
+## The Framework at a Glance
+
+```
+tests/integration/
+├── AGENTS.md                  ← framework rules + per-domain harness inventory
+├── STRATEGY.md                ← four-layer strategy + comparison tables + rollout plan
+├── coverage.svg               ← diagram (which test type runs real code at which layer)
+├── coverage-and-tracking.md   ← coverage targets + bug-tracking mechanisms
+├── perps-use-cases.md         ← every perps use case → primary test layer
+└── harnesses/
+    ├── perps.ts               ← Shape A: provider-level harness
+    ├── perps-flow.ts          ← Shape B: hook-flow harness
+    └── perps-component.tsx    ← Shape C: rendered-component harness
+```
+
+Tests live next to the code they test, named `<feature>.integration.test.ts`. They run via `yarn jest -c jest.config.integration.js`.
+
+---
+
+## Workflow (summary)
+
+- **Write new test**: Read controller / service and existing tests → list use cases (or pull from per-domain use-case file) and map to test patterns → check coverage and deduplicate → choose Shape A/B/C based on the boundary under test → call the matching harness factory → write test (call real action, assert on state / selector output / return value). Every test must call at least one real method on the real instance returned by the harness — no harness-only setup. Run tests, then run the self-review checklist in `references/reference.md`.
+- **Fix failing test**: Run with `jest.config.integration.js` → identify error type from the table in `references/reference.md` (Diagnosing Failures) → apply the fix (extend harness, override mock for one test, await async settlement, reset module-level singleton state, etc.) → re-run.
+- **Update after change**: Same as write — review existing tests, update the harness if shape changed, update tests, run and self-review.
+- **Add or extend a harness**: Open `references/harness-extension.md` → identify whether you're adding a new domain or extending an existing one → follow the structure (jest.mock + factory + REAL/MOCKED header) → update `tests/integration/AGENTS.md` if it's a new domain.
+
+For full detail, use the reference files when the decision tree sends you there.
+
+---
+
+## Run the tests
+
+Always use `jest.config.integration.js` — the default Jest config excludes integration tests.
+
+**Run a single test (no coverage):**
+
+```bash
+yarn jest -c jest.config.integration.js <path> --runInBand --silent --coverage=false
+```
+
+Example: `yarn jest -c jest.config.integration.js app/components/UI/Perps/hooks/usePerpsFlipPosition.integration.test.ts --runInBand --silent --coverage=false`
+
+**Run the full integration suite:**
+
+```bash
+yarn jest -c jest.config.integration.js
+```
+
+**Coverage for a feature folder** (run with `--collectCoverageFrom` pointed at the controller / provider you're exercising — coverage on the test file itself will always be near zero):
+
+```bash
+yarn jest -c jest.config.integration.js <test-path> \
+  --coverage \
+  --collectCoverageFrom="app/controllers/perps/providers/HyperLiquidProvider.ts"
+```
+
+For run-by-name, watch mode, or other options, see `references/reference.md` (Run the Tests).
+
+---
+
+## Golden Rules (Enforced)
+
+1. **Only the harness mocks the I/O boundary** — no arbitrary `jest.mock()` in `*.integration.test.ts` files. The harness file (`tests/integration/harnesses/<domain>.ts`) owns the full set; tests just import it. Shape B/C may also mock documented app-shell glue inside the harness when the real target chain still runs. If you find yourself wanting a new mock, extend the harness instead.
+
+2. **Drive behaviour through real method calls on the real instance** — call `provider.placeOrder(...)`, `controller.flipPosition(...)`, etc. The harness returns the real instance; the test exercises it. No simulating state transitions by reaching inside the controller's internals.
+
+3. **Assert on observable outcomes** — return values, post-call state, selector output. Mock-call assertions are allowed only when verifying a side effect (e.g. that the SDK was called with the right args) is the explicit point of the test.
+
+4. **Reuse harnesses** — never rebuild the controller setup from scratch in a test. If the harness doesn't expose what you need, extend it.
+
+5. **No fake timers** — never use `jest.useFakeTimers()`, `jest.advanceTimersByTime()`, or `jest.useRealTimers()`. Use `await` and `waitFor` for async settlement.
+
+6. **No snapshot tests** — assert on specific values. State shape changes are caught by integration tests that exercise the relevant flow, not by snapshotting the controller output.
+
+7. **Follow AAA** — Arrange (build harness, set mocks) → Act (call real method) → Assert (check return value / state). Blank lines between sections. One test = one user flow or one rejection path; multiple chained calls in one test are fine when they represent one user journey.
+
+8. **No harness-only tests** — every test must call at least one real method on the harness's instance. Tests that only construct the harness and assert on default state are not integration tests; they're testing the harness defaults, which is wasted effort.
+
+9. **One test = one use case from the matrix** — each `it` should map to a row in the per-domain use-case file (e.g. `perps-use-cases.md`). If a test doesn't fit any use case, ask whether the use case is missing from the matrix or the test is in the wrong layer.
+
+10. **Module-level singleton state is reset per test** — the harness handles this for known singletons (`TradingReadinessCache`, etc.). If you depend on a new singleton, add its reset to the harness; don't rely on test-order.
+
+---
+
+## Reference files (when to use)
+
+Documentation is split by **action**. Open only the reference that matches what you are doing.
+
+| Action                                          | File                                                                 | When to open it                                                                                                                                |
+| ----------------------------------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Writing or updating integration tests**       | [`references/writing-tests.md`](references/writing-tests.md)         | New test file, new use case, updated controller. Read before writing, use cases and matrix, file structure, harness usage, assertion patterns. |
+| **Adding or extending a harness**               | [`references/harness-extension.md`](references/harness-extension.md) | New domain, new mock, new helper, new option. REAL/MOCKED split, factory shape, AGENTS.md updates.                                             |
+| **Running tests, self-review, fixing failures** | [`references/reference.md`](references/reference.md)                 | Run the Tests, Self-Review Checklist, Diagnosing Failures, assertion patterns, module-singleton state, What NOT to Do, Quick Reference.        |
+
+**Where self-review and What NOT to Do live:** Both are in `references/reference.md`. Self-review is the checklist you run after tests pass. What NOT to Do is the antipatterns section in the same file. Keeping them there means when you run tests or fix failures you have run commands, the checklist, the failure table, and the antipatterns in one place — open that reference for any run/fix/review task.

--- a/domains/testing/skills/integration-test/skill.md
+++ b/domains/testing/skills/integration-test/skill.md
@@ -1,0 +1,8 @@
+---
+name: integration-test
+description: >
+  Controller-app integration testing for MetaMask Mobile using real controllers,
+  providers, and services with only the I/O boundary mocked
+  (*.integration.test.ts). Use when writing, fixing, or reviewing integration
+  tests or per-domain harnesses. See knowledge/testing-layers.md for layer choice.
+---

--- a/domains/testing/skills/unit-testing/repos/metamask-mobile.md
+++ b/domains/testing/skills/unit-testing/repos/metamask-mobile.md
@@ -8,7 +8,7 @@ Reference: [MetaMask Unit Testing Guidelines](https://github.com/MetaMask/contri
 
 # Unit Testing Guidelines
 
-Peer of **component-view-test** for MetaMask Mobile. Choose the layer first; this skill is not the default for screen/view UI behavior.
+Peer of **component-view-test** and **integration-test** for MetaMask Mobile. Choose the layer first; this skill is not the default for screen/view UI behavior or app-to-controller flows.
 
 ## When to use
 
@@ -22,7 +22,7 @@ Do **not** use this skill as the default for full-screen / view UI behavior — 
 
 ## Testing layers (read first)
 
-Follow installed `knowledge/testing-layers.md` before choosing unit vs component-view vs e2e.
+Follow installed `knowledge/testing-layers.md` before choosing unit vs component-view vs integration vs E2E.
 
 - **Default for screen/view behavior:** `*.view.test.tsx` via the **component-view-test** skill — not a broad RTL unit test that mocks hooks/selectors.
 - **This skill applies when:** pure helpers, local utilities, narrow component contracts, or the CV framework cannot cover the case yet (smallest focused unit test + note why).

--- a/domains/testing/skills/unit-testing/skill.md
+++ b/domains/testing/skills/unit-testing/skill.md
@@ -1,9 +1,8 @@
 ---
 name: unit-testing
 description: >
-  Peer of component-view-test for MetaMask Mobile. Focused Jest unit tests for
-  pure logic, helpers, and narrow contracts — or as fallback when component-view
-  tests cannot cover a case. For screen/view UI behavior, prefer
-  component-view-test and knowledge/testing-layers.md first; do not use this
-  skill as the default for full-screen RTL tests.
+  Peer of component-view-test and integration-test for MetaMask Mobile. Focused
+  Jest unit tests for pure logic, helpers, and narrow contracts — or as fallback
+  when component-view tests cannot cover a case. Follow
+  knowledge/testing-layers.md before choosing this skill.
 ---


### PR DESCRIPTION
## Description

Centralizes the MetaMask Mobile `integration-test` skill that was originally checked into Mobile by [MetaMask/metamask-mobile#29749](https://github.com/MetaMask/metamask-mobile/pull/29749).

The skill follows the existing `component-view-test` source layout:

- a small discoverable base `skill.md`
- a `repos/metamask-mobile.md` overlay with Mobile-specific workflow and rules
- bundled writing, harness-extension, and run/fix references
- shared testing-layer guidance that distinguishes integration tests from component-view, unit, and E2E tests

The README and peer CV/unit skills now include integration testing in their layer-selection guidance.

## Type of Change

- [x] New skill
- [x] Skill improvement/update
- [ ] Bug fix
- [x] Documentation update
- [ ] Other (please describe):

## Skill Details (if adding a new skill)

**Provider Name:** MetaMask  
**Skill Name:** integration-test  
**Brief Description:** Write, fix, and review MetaMask Mobile controller-app integration tests using real controller code with the I/O boundary mocked.

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/MetaMask/skills/blob/main/CONTRIBUTING.md) guidelines
- [x] My skill follows the [SKILL_TEMPLATE.md](https://github.com/MetaMask/skills/blob/main/.github/SKILL_TEMPLATE.md) format
- [x] I have tested this skill with an AI agent
- [x] My skill does not contain any secrets, private keys, or sensitive data
- [x] I have added appropriate documentation
- [x] My changes don't break existing skills

## Testing

- `node --test test/*.test.mjs` — 41/41 passing
- `node bin/metamask-skills.mjs describe testing/integration-test --repo metamask-mobile`
- `tools/install --repo metamask-mobile --target <mobile-checkout> --domain testing --dry-run`
- Verified generation targets for Claude, Cursor, and Agents under `mms-integration-test`

## Additional Context

A coordinated MetaMask Mobile PR removes the repository-owned `.agents/skills/integration-test` copy and points framework documentation at this canonical source.

Made with [Cursor](https://cursor.com)

Coordinated cleanup: [MetaMask/metamask-mobile#33864](https://github.com/MetaMask/metamask-mobile/pull/33864).