### PR TITLE
feat(testing): add Mobile test-layer-placement skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,17 @@ metamask-skills install       # lower-level installer wrapper
 The discovery commands make opt-in selection self-serve. Developers can find a
 skill, inspect it, then save their selection. On Mobile, prefer installing
 **component-view-test**, **integration-test**, and **unit-testing** together
-(see `domains/testing/knowledge/testing-layers.md` for layer selection):
+(see `domains/testing/knowledge/testing-layers.md` for layer selection). For
+cross-layer audits (inventory → disposition → Jira/PR report), also install
+experimental **test-layer-placement**:
 
 ```bash
 metamask-skills list --domain testing
 metamask-skills describe testing/component-view-test
 metamask-skills describe testing/integration-test
 metamask-skills describe testing/unit-testing
-metamask-skills sync --include testing/component-view-test --include testing/integration-test --include testing/unit-testing --save
+metamask-skills describe testing/test-layer-placement
+metamask-skills sync --include testing/component-view-test --include testing/integration-test --include testing/unit-testing --include testing/test-layer-placement --maturity experimental --save
 ```
 
 Consumer repos should prefer this CLI over copying sync/postinstall scripts.

--- a/domains/testing/knowledge/testing-layers.md
+++ b/domains/testing/knowledge/testing-layers.md
@@ -6,6 +6,8 @@ Use this decision tree whenever adding or reviewing tests for Mobile code.
 
 **Peer skills:** `component-view-test`, `integration-test`, and `unit-testing` are documented at the same level. Choose by this tree — do not treat unit-testing as the primary testing guide.
 
+**Orchestrator:** For a code area / Jira / PR audit across all layers (inventory → disposition → optional implement → Jira + PR report), use **`test-layer-placement`**. Default mode is analyze-only. Unit↔CV overlap migrate/delete is a sub-pass of that skill.
+
 ## Decision tree
 
 ```

--- a/domains/testing/skills/test-layer-placement/references/inventory.md
+++ b/domains/testing/skills/test-layer-placement/references/inventory.md
@@ -1,0 +1,62 @@
+# Inventory across layers (Mobile)
+
+Run from the metamask-mobile repo root. Scope `ROOT` to the ticket/path (e.g. `app/components/UI/Perps`).
+
+## Find sibling unit + CV pairs
+
+```bash
+ROOT="${ROOT:-app}"
+python3 - <<PY
+from pathlib import Path
+root = Path("$ROOT")
+for vt in sorted(root.rglob("*.view.test.tsx")):
+    base = vt.name.replace(".view.test.tsx", "")
+    unit = vt.parent / f"{base}.test.tsx"
+    if unit.exists():
+        print(f"{unit} | {vt}")
+PY
+```
+
+Also list shallow screen units **without** CV (candidates for ADD CV):
+
+```bash
+# Heuristic: *.test.tsx next to a .tsx component, excluding *.view.test.tsx / *.integration.test.*
+find "$ROOT" -name '*.test.tsx' ! -name '*.view.test.tsx' | head -200
+```
+
+## Integration
+
+```bash
+find "$ROOT" -name '*.integration.test.ts' -o -name '*.integration.test.tsx'
+# Domain harnesses often live under tests/integration/
+ls tests/integration 2>/dev/null | head
+```
+
+## E2E
+
+Search Detox/Appium specs and page objects that mention the feature screen names / testIDs:
+
+```bash
+rg -l "FeatureName|ScreenName" e2e/ appium/ 2>/dev/null | head -50
+```
+
+Prefer existing e2e skill conventions for exact folders in this checkout.
+
+## Count `it(` for metrics
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+import re, sys
+paths = [Path(p) for p in sys.argv[1:]]
+for p in paths:
+    if not p.exists():
+        continue
+    n = len(re.findall(r"\bit\s*\(", p.read_text()))
+    print(f"{n}\t{p}")
+PY
+```
+
+## Coverage snapshot (diagnostic only)
+
+Coverage does **not** decide deletes. Optional before/after for risk diagnosis — same commands as unit↔CV overlap reference.

--- a/domains/testing/skills/test-layer-placement/references/pr-description-template.md
+++ b/domains/testing/skills/test-layer-placement/references/pr-description-template.md
@@ -1,0 +1,52 @@
+# PR description template (always update)
+
+Create or update the PR body on every run (ANALYZE and IMPLEMENT). Describe every task.
+
+```markdown
+## Summary
+<1–3 lines: ticket + scope + mode (analyze plan vs implemented)>
+
+Jira: <TICKET-URL>
+Report: <link to Jira comment or “see ticket comment”>
+
+## Test layer placement
+
+**Scope:** <paths>
+**Mode:** Analyze (proposed) | Implement (applied)
+
+### Inventory
+- Unit: …
+- CV: …
+- Integration: …
+- E2E: …
+
+### Tasks
+- [ ] <ADD CV: Component — scenario>
+- [ ] <MIGRATE unit→CV: Component — scenario>
+- [ ] <DELETE shallow unit: Component — scenario (covered by CV)>
+- [ ] <KEEP / add pure unit: helper — scenario>
+- [ ] <EXTRACT+UNIT: extract \`foo\` + unit matrix>  <!-- only if needed -->
+- [ ] <ADD integration: …>  <!-- if applicable -->
+- [ ] <E2E: document gap / no change / add>  <!-- if applicable -->
+- [ ] Post final Jira report + canvas
+- [ ] Re-run unit/CV (integration) for touched files
+
+### App code
+- None | Pure extract only: \`path\` — why
+
+### Residual / follow-ups
+- [ ] …
+
+## Test plan
+- [ ] \`yarn jest …\` (touched unit files)
+- [ ] \`yarn jest -c jest.config.view.js …\` (touched CV)
+- [ ] Integration command if touched
+- [ ] Confirm no intentional product UX change
+```
+
+### Agent rules
+
+- ANALYZE: leave all placement tasks unchecked; title/body may say “plan”.
+- IMPLEMENT: check completed items; leave residuals unchecked.
+- Prefer editing the existing PR linked from the ticket; create a draft PR if the user expects one and none exists.
+- Do not commit spike-only markdown dumps into the mobile repo.

--- a/domains/testing/skills/test-layer-placement/references/report-template.md
+++ b/domains/testing/skills/test-layer-placement/references/report-template.md
@@ -1,0 +1,58 @@
+# Jira report template (markdown mirror of canvas)
+
+Post as a comment on the ticket after ANALYZE (proposed) or IMPLEMENT (final).
+Also create a Cursor canvas with the same numbers when useful.
+
+```markdown
+## Test layer placement report — <TICKET>
+
+**Mode:** Analyze | Implement
+**Scope:** <folders / components>
+**PR:** <url or number>
+**Verdict:** Improved | Improved with gaps | Needs follow-up | Plan ready (analyze)
+
+### App / production code
+- **Changed?** Yes / No / Proposed only
+- **Files:** …
+- **Why:** (required if Yes — e.g. extract pure feedback helper so toast matrix stays unit-owned without shallow screen mocks)
+
+### Inventory (what was in place)
+| Module | Unit | CV | Integration | E2E |
+| --- | --- | --- | --- | --- |
+| … | … | … | … | … |
+
+### Volume
+| Layer | Before | After / Proposed | Δ |
+| --- | ---: | ---: | ---: |
+| Shallow unit `it`s |  |  |  |
+| CV `it`s |  |  |  |
+| Pure unit `it`s (helpers) |  |  |  |
+| Integration `it`s |  |  |  |
+| E2E cases |  |  |  |
+
+**Ratio (overlap passes):** unit removed / CV added ≈ …
+
+### Disposition
+| Scenario | Decision | Target layer / file | Note |
+| --- | --- | --- | --- |
+| … | KEEP / ADD / MIGRATE / DELETE / EXTRACT+UNIT / GAP | … | … |
+
+### Residual risks
+| Risk | Status |
+| --- | --- |
+| … | Closed / Accepted / Open |
+
+### Tasks
+Mirror the PR checklist (done vs proposed).
+
+### How to re-run
+Follow skill `test-layer-placement`. Overlap sub-pass: `references/unit-cv-overlap.md` / personal `test-layer-overlap-audit`.
+Canvas path: `~/.cursor/projects/<workspace>/canvases/<ticket>-test-layer-placement.canvas.tsx`
+```
+
+## Canvas checklist
+
+- Stats: adds/migrates/deletes per layer
+- Before/after volumes
+- Disposition table
+- Callout if any production code changed or proposed (why)

--- a/domains/testing/skills/test-layer-placement/references/unit-cv-overlap.md
+++ b/domains/testing/skills/test-layer-placement/references/unit-cv-overlap.md
@@ -1,0 +1,48 @@
+# Unit ↔ CV overlap sub-pass (Approach A)
+
+Reuse when shallow `ComponentName.test.tsx` and/or `ComponentName.view.test.tsx` exist for screen UI. Prefer loading personal Cursor skill `test-layer-overlap-audit` if present; otherwise follow this condensed Approach A.
+
+**Goal:** Prefer **CV** for screen UI driven by Redux; keep **unit** for pure functions, selectors, utils, toast *copy builders*. Remove shallow screen units that only re-assert what CV covers.
+
+## Reason → best layer
+
+| If the test’s reason is… | Best layer | Action when wrong file |
+| --- | --- | --- |
+| Screen UI, button visibility, press → destination, disabled/empty/loading from Redux/streams | **CV** (`*.view.test.tsx`) | **MIGRATE** then delete unit `it` |
+| Pure function / resolver / util / reducer / selector math | **Unit** | **KEEP** |
+| Toast *copy/options* builders | **Unit** | **KEEP** |
+| Same journey already asserted in CV | — | **DELETE** shallow unit |
+
+**Hard rule:** UI / screen-behavior tests in unit files with mocked hooks/selectors/navigation are in the **wrong layer** — migrate to CV; do not improve mocks in place.
+
+## Steps
+
+1. Inventory siblings (see `inventory.md`).
+2. Optional coverage snapshot (diagnostic only):
+
+```bash
+yarn jest ./path/Component.test.tsx -c jest.config.js \
+  --coverage --coverageDirectory=test-reports/<ticket>/before/unit \
+  --collectCoverageFrom='path/Component.{ts,tsx}' \
+  --coverageReporters=json-summary --coverageReporters=text-summary --runInBand --silent
+
+yarn jest -c jest.config.view.js ./path/Component.view.test.tsx \
+  --coverage --coverageDirectory=test-reports/<ticket>/before/cv \
+  --collectCoverageFrom='path/Component.{ts,tsx}' \
+  --coverageReporters=json-summary --coverageReporters=text-summary --runInBand --silent
+```
+
+3. Classify each unit `it(...)`: reason → best layer → DELETE | MIGRATE | KEEP.
+4. Apply (IMPLEMENT mode only): add CV for MIGRATE → delete DELETE/migrated unit its → residual toast matrices via pure helper + unit (**EXTRACT+UNIT**) when user accepts → re-run unit + CV.
+5. Record metrics: unit its removed, CV its added, ratio, app LOC + why, residual gaps.
+
+## In-repo docs (keep minimal)
+
+PR / main should only carry short guards in:
+
+- `docs/testing/unit-testing.md`
+- `docs/testing/component-view-tests.md`
+- `tests/component-view/AGENTS.md`
+- Optional playbook: `docs/testing/unit-vs-component-view-overlap.md`
+
+Do **not** commit spike-only classification dumps into the mobile repo.

--- a/domains/testing/skills/test-layer-placement/repos/metamask-mobile.md
+++ b/domains/testing/skills/test-layer-placement/repos/metamask-mobile.md
@@ -1,0 +1,165 @@
+---
+repo: metamask-mobile
+parent: test-layer-placement
+---
+
+# Test layer placement (Mobile)
+
+Orchestrate **analyze → (optional) implement → report** for a Mobile code area so
+tests land in the right layer: unit, component-view (CV), integration, or e2e.
+
+**Pilot reference:** [MMQA-2100](https://consensyssoftware.atlassian.net/browse/MMQA-2100)
+(Approach A, WalletActions + PerpsCancelAllOrdersView, PR
+[#33793](https://github.com/MetaMask/metamask-mobile/pull/33793)).
+
+## Modes
+
+| Mode | When | What you do |
+| --- | --- | --- |
+| **ANALYZE** (default) | User did not say implement / go / apply | Inventory, classify, disposition plan, metrics estimate, report + Jira + PR checklist as **proposed** |
+| **IMPLEMENT** | User explicitly asks to implement / apply / go | Execute disposition: write/migrate/delete tests, allow minimal pure extracts, re-run, then final report + Jira + PR |
+
+Do **not** implement in ANALYZE mode. Present the plan and wait.
+
+## Flexible intake
+
+Accept any of: **Jira key**, **code path/folder**, **PR URL/number**. Resolve scope from what is given.
+
+1. **Jira** — fetch issue + comments + links (Atlassian MCP / browse URL). Pull linked PRs and follow-up tickets. Prefer scope from description / AC / comments.
+2. **PR** — `gh pr view` for files changed, body, linked issues. Scope = touched production + sibling test files under those folders.
+3. **Path** — treat as the audit root (e.g. `app/components/UI/Perps`).
+4. If only one input is given, derive the others when possible (ticket ↔ PR links, PR files ↔ paths). If scope is still ambiguous, ask one clarifying question.
+
+Record: ticket key (if any), PR number (if any), scoped paths.
+
+## Prerequisites — load peer skills / knowledge
+
+Before classifying or writing tests, load as needed (do not reinvent layer rules):
+
+| Concern | Load |
+| --- | --- |
+| Layer decision tree | installed `knowledge/testing-layers.md` |
+| Screen UI via Redux | `component-view-test` |
+| Pure helpers / CV fallback | `unit-testing` |
+| App↔controller seam | `integration-test` |
+| Full device journeys | `e2e-test` (or `e2e-testing` mobile overlay) |
+| Unit↔CV overlap migrate/delete | [`references/unit-cv-overlap.md`](../references/unit-cv-overlap.md) — if personal Cursor skill `test-layer-overlap-audit` is available, load it too and prefer its process for that sub-pass |
+
+## Workflow checklist
+
+Copy and track:
+
+```
+Test layer placement:
+- [ ] 1. Intake (ticket / path / PR)
+- [ ] 2. Inventory all layers
+- [ ] 3. Classify reason → layer → decision
+- [ ] 4. Unit↔CV overlap sub-pass (if siblings exist)
+- [ ] 5. Disposition plan (ANALYZE stop here unless asked to implement)
+- [ ] 6. IMPLEMENT (only if asked): apply + re-run
+- [ ] 7. Report (canvas + Jira comment)
+- [ ] 8. Always update PR description with task checklist
+```
+
+### 1. Intake
+
+Resolve ticket/PR/path as above. Read MMQA-2100-style comments on the ticket if present (verdict, volume table, residual risks).
+
+### 2. Inventory
+
+For the scoped paths, find what exists. See [`references/inventory.md`](../references/inventory.md).
+
+Summarize per component/module:
+
+| Module | Unit | CV | Integration | E2E | Notes |
+| --- | --- | --- | --- | --- | --- |
+| … | `Foo.test.tsx` (N its) | `Foo.view.test.tsx` (M) | none / path | none / spec | … |
+
+### 3. Classify (reason first)
+
+For each meaningful scenario (especially each `it(...)` in shallow screen units, and each gap in production behavior):
+
+1. **What does this protect?** (UI visibility, nav destination, pure math, controller seam, multi-screen device journey, …)
+2. **Best layer?** Use `knowledge/testing-layers.md`.
+3. **Decision:**
+
+| Decision | Meaning |
+| --- | --- |
+| **KEEP** | Already in the correct layer |
+| **ADD** | Missing coverage → add at best layer |
+| **MIGRATE** | Wrong layer (usually shallow unit UI → CV); add target first, then remove source |
+| **DELETE** | Duplicate of coverage already owned by a better layer |
+| **EXTRACT+UNIT** | Toast/wiring matrix (etc.) needs a **minimal pure helper** + unit tests; do not invent product UX |
+| **GAP / ACCEPT** | Intentionally uncovered or blocked (document why) |
+
+**Hard rules**
+
+- Screen UI / Redux-driven visibility / press→nav belonging in unit files with mocked hooks → **MIGRATE** to CV, do not “fix” mocks in place.
+- E2E is not a substitute for single-view CV.
+- Integration owns app↔controller seams, not full-screen RTL with mocked Engine internals unless the integration skill says otherwise.
+- Production changes: **tests + minimal pure extracts only**. No intentional product UX change. Call out any app LOC in the report.
+
+### 4. Unit↔CV overlap sub-pass
+
+When `ComponentName.test.tsx` and `ComponentName.view.test.tsx` both exist (or shallow screen units mock hooks for UI), run Approach A from
+[`references/unit-cv-overlap.md`](../references/unit-cv-overlap.md).
+
+### 5. Disposition plan (ANALYZE output)
+
+Present a concise plan:
+
+- Scope + ticket/PR
+- Inventory table
+- Disposition table (scenario → decision → target layer/file)
+- Estimated volume deltas (unit/CV/integration/e2e `it`s)
+- Residual risks / open questions
+- Proposed PR task checklist (unchecked)
+
+Then: post **analysis** Jira comment + **always** write/update the PR description with that checklist (see templates). **Stop** unless IMPLEMENT was requested.
+
+### 6. IMPLEMENT (only when asked)
+
+1. Apply ADD / MIGRATE / DELETE / EXTRACT+UNIT per plan.
+2. For MIGRATE: add CV (or other target) **before** deleting source assertions.
+3. Pure extracts only when otherwise a toast/wiring matrix would be uncovered and CV cannot own it (MMQA-2100 CancelAll pattern).
+4. Re-run affected unit / CV / integration commands for touched files.
+5. Refresh metrics (before/after `it` counts).
+6. Final report + Jira + PR (mark completed tasks).
+
+### 7. Report
+
+1. Cursor canvas summarizing verdict, volume, disposition, residual risks, app-code note (see canvas skill if producing `.canvas.tsx`).
+2. Markdown mirror as Jira comment — [`references/report-template.md`](../references/report-template.md).
+3. Tell the user the canvas path (MCP may not upload attachments).
+
+### 8. PR description (always)
+
+Whether ANALYZE or IMPLEMENT, create or update the PR body so it describes **every task** with a checklist.
+Use [`references/pr-description-template.md`](../references/pr-description-template.md).
+
+- ANALYZE: all items unchecked, labeled proposed.
+- IMPLEMENT: check off done items; leave residual / follow-ups unchecked.
+- Link the Jira ticket and the report comment when available.
+- Prefer `gh pr edit` / `gh pr create` as appropriate; do not force-push.
+
+## Out of scope
+
+- Broad production refactors unrelated to making a scenario unit-testable via a pure extract
+- Committing spike-only dumps (`mmqa-*-classification.md`, inventory snapshots) into the mobile repo — keep those on Jira/canvas/skill
+- Replacing peer skills — this skill **orchestrates**; writing tests still follows `component-view-test` / `unit-testing` / `integration-test` / `e2e-test`
+
+## Examples
+
+**ANALYZE**
+
+```
+User: Analyze app/components/UI/Predict for test layers — MMQA-2104
+Agent: Inventory → classify → disposition plan → Jira analysis comment → PR body with proposed checklist. Stop.
+```
+
+**IMPLEMENT**
+
+```
+User: Implement the disposition for MMQA-2102 / path Perps
+Agent: Apply plan → re-run → final report on Jira → update PR checklist.
+```

--- a/domains/testing/skills/test-layer-placement/skill.md
+++ b/domains/testing/skills/test-layer-placement/skill.md
@@ -1,0 +1,15 @@
+---
+name: test-layer-placement
+description: >
+  MetaMask Mobile orchestrator: given a code area, Jira ticket, and/or PR,
+  inventory existing unit / component-view / integration / e2e coverage, classify
+  each scenario by reason → best layer (knowledge/testing-layers.md), produce a
+  disposition plan, and (only when asked) implement tests plus minimal pure
+  extracts. Always post a MMQA-2100-style report to Jira and keep the PR
+  description updated with a task checklist. Use when placing or auditing tests
+  for a screen/folder, working MMQA unit↔CV overlap follow-ups (MMQA-2102+),
+  reducing wrong-layer coverage, or when the user mentions test layer placement,
+  coverage audit across layers, or “analyze this area for unit/CV/integration/e2e”.
+  Default mode is analyze-only; do not implement until the user explicitly asks.
+maturity: experimental
+---


### PR DESCRIPTION
## Summary
- Add experimental **`test-layer-placement`** skill for MetaMask Mobile: flexible intake (Jira / path / PR), analyze-first disposition across unit / CV / integration / e2e, optional implement (tests + minimal pure extracts), Jira report, and always-updated PR task checklist.
- Reuse Approach A unit↔CV overlap as a sub-pass (`references/unit-cv-overlap.md`) and peer testing skills via `knowledge/testing-layers.md`.
- Document discovery/install in README and cross-link from `testing-layers.md`.

## Test plan
- [ ] `metamask-skills describe testing/test-layer-placement`
- [ ] Sync into a Mobile checkout with `--include testing/test-layer-placement --maturity experimental`
- [ ] Confirm Mobile overlay installs (`repos/metamask-mobile.md`) and skill is skipped for Extension/Core
- [ ] Smoke: ask agent to analyze a path/ticket in analyze-only mode (no code changes)


Made with [Cursor](https://cursor.com)