### PR TITLE
ci: gate skill and knowledge frontmatter keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,13 @@ Extra metadata blocks (e.g. OpenClaw-style `metadata:` with emoji and
 homepage) are preserved through install — only `name`, `description`,
 `maturity`, `mandatory`, and `scope` are read by the CLI.
 
+The permitted keys, for skills and for knowledge files, are declared in
+[`skill-frontmatter.json`](skill-frontmatter.json) and enforced by `yarn test`.
+Adding one is a deliberate decision: **a key that makes an agent eagerly load
+another file must not be added.** A body link is the agent's own choice, but a
+declared dependency is a mandatory pull, and mandatory pulls compose — so the
+context an agent must ingest stops having an upper bound.
+
 ### Overlay frontmatter
 
 ```yaml

--- a/skill-frontmatter.json
+++ b/skill-frontmatter.json
@@ -1,0 +1,28 @@
+{
+  "$comment": [
+    "Permitted top-level frontmatter keys, by file kind. This is the source of truth;",
+    "test/cli.test.mjs enforces it and README.md documents it for authors.",
+    "",
+    "Adding a key is a deliberate decision, not a formality. A key that makes an agent",
+    "EAGERLY LOAD another file must not be added: a body link is the agent's own choice,",
+    "but a declared dependency is a mandatory pull, and mandatory pulls compose (A requires",
+    "B requires C), so the context an agent must ingest stops having an upper bound.",
+    "tools/install writes `alwaysApply: false` into every Cursor rule for the same reason.",
+    "",
+    "Note `mandatory` controls whether the INSTALLER ships a skill past the domain filter.",
+    "It does not make an agent load anything, and is unrelated to the constraint above."
+  ],
+  "skill": {
+    "name": "Slash-command name, unprefixed. The installer adds the mms- prefix on write.",
+    "description": "What the skill does plus when-to-use cues, <= 1536 characters.",
+    "maturity": "experimental | stable | deprecated. Default stable.",
+    "mandatory": "Truthy installs the skill even when its domain is filtered out.",
+    "scope": "user installs to $HOME instead of the target repo; needs --include-user.",
+    "metadata": "Inert operator metadata (emoji, homepage). Preserved through install, never read."
+  },
+  "knowledge": {
+    "name": "Human-readable title for the knowledge file.",
+    "domain": "Owning domain. Knowledge is delivered per domain, so it cannot be cited across domains.",
+    "description": "One line on what the file covers."
+  }
+}

--- a/skill-frontmatter.json
+++ b/skill-frontmatter.json
@@ -12,6 +12,10 @@
     "Note `mandatory` controls whether the INSTALLER ships a skill past the domain filter.",
     "It does not make an agent load anything, and is unrelated to the constraint above."
   ],
+  "limits": {
+    "descriptionMaxChars": 1536,
+    "$why": "Frontmatter is loaded for every installed skill at agent startup, as fixed overhead that scales linearly with the catalogue. The cap is documented in README; this makes it enforced rather than advisory."
+  },
   "skill": {
     "name": "Slash-command name, unprefixed. The installer adds the mms- prefix on write.",
     "description": "What the skill does plus when-to-use cues, <= 1536 characters.",

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -306,6 +306,34 @@ describe('corpus: frontmatter cannot force a load', () => {
     );
   });
 
+  test('no description exceeds the documented budget', () => {
+    // Every installed skill's frontmatter is loaded at agent startup, so this is fixed
+    // overhead that scales linearly with the catalogue. README documents the cap; without
+    // a check it is advisory, and description is the field authors are tempted to grow.
+    //
+    // Parsed line-wise rather than by regex: descriptions use both the plain form and the
+    // folded `>-` form with indented continuation lines, and a single expression that
+    // handles the first silently misses the second — which is most of them.
+    const max = SCHEMA.limits.descriptionMaxChars;
+    const over = [];
+    for (const { kind, rel, body } of corpusFiles()) {
+      if (kind !== 'skill') continue;
+      const m = /^---\n([\s\S]*?)\n---/u.exec(body);
+      if (!m) continue;
+      const lines = m[1].split('\n');
+      const i = lines.findIndex((l) => /^description:/u.test(l));
+      if (i === -1) continue;
+      const parts = [lines[i].replace(/^description:[ \t]*(?:>-|>|\|)?[ \t]*/u, '')];
+      for (let j = i + 1; j < lines.length; j += 1) {
+        if (/^[A-Za-z_][\w-]*:/u.test(lines[j])) break; // next top-level key
+        parts.push(lines[j].trim());
+      }
+      const len = parts.join(' ').replace(/\s+/gu, ' ').trim().length;
+      if (len > max) over.push(`${rel} → ${len} chars (max ${max})`);
+    }
+    assert.deepEqual(over, [], 'description exceeds the budget set in skill-frontmatter.json');
+  });
+
   test('the schema declares every frontmatter key the installer reads', () => {
     // tools/install pulls specific keys by name. If it grows one the schema does not
     // declare, this fails rather than the installer quietly honouring an undeclared key.

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -242,18 +242,22 @@ describe('managed skill pruning', () => {
 });
 
 describe('corpus: frontmatter cannot force a load', () => {
-  // The context an agent must ingest has no upper bound if a file can *require* other
-  // files. A body link is the agent's choice — it reads what it judges relevant, and a
-  // broken one costs a failed read. A frontmatter key that declares a dependency is a
-  // mandatory pull, and mandatory pulls compose: A requires B requires C.
+  // The permitted keys live in skill-frontmatter.json, not here — they describe the skill
+  // FORMAT, so an author hitting this failure finds the list, and the reason a key is or is
+  // not allowed, in a file they would think to open.
   //
-  // `tools/install` hardcodes `alwaysApply: false` into every Cursor rule it emits, so
-  // no *installed* skill forces a load today. Nothing stops a source file declaring one.
-  //
-  // This is an ALLOWLIST, not a denylist of known-bad keys. A denylist silently exempts
-  // whatever it forgot to name — `loadAll:` invented next month passes a list that only
-  // knows about `alwaysApply:`. An unrecognized key fails until someone decides it is safe.
-  const ALLOWED_KEYS = new Set(['name', 'description', 'maturity', 'domain', 'metadata']);
+  // Allowlist rather than a denylist of known-bad keys: a denylist silently exempts whatever
+  // it did not name, so a key invented next month passes a check that knows only the old ones.
+  const SCHEMA_PATH = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '..',
+    'skill-frontmatter.json',
+  );
+  const SCHEMA = JSON.parse(readFileSync(SCHEMA_PATH, 'utf8'));
+  const ALLOWED = {
+    skill: new Set(Object.keys(SCHEMA.skill)),
+    knowledge: new Set(Object.keys(SCHEMA.knowledge)),
+  };
 
   function frontmatterKeys(body) {
     const m = /^---\n([\s\S]*?)\n---/u.exec(body);
@@ -267,38 +271,57 @@ describe('corpus: frontmatter cannot force a load', () => {
   function corpusFiles() {
     const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
     const domainsDir = path.join(repoRoot, 'domains');
-    const out = [];
+    const found = [];
     const walk = (dir) => {
       for (const entry of readdirSync(dir, { withFileTypes: true })) {
         const full = path.join(dir, entry.name);
         if (entry.isDirectory()) walk(full);
-        else if (
-          entry.name === 'skill.md'
-          || (entry.name.endsWith('.md') && full.includes(`${path.sep}knowledge${path.sep}`))
-        ) {
-          out.push({
-            rel: path.relative(repoRoot, full).split(path.sep).join('/'),
-            body: readFileSync(full, 'utf8'),
-          });
+        else if (entry.name === 'skill.md') found.push(['skill', full]);
+        else if (entry.name.endsWith('.md') && full.includes(`${path.sep}knowledge${path.sep}`)) {
+          found.push(['knowledge', full]);
         }
       }
     };
     walk(domainsDir);
-    return out;
+    return found.map(([kind, full]) => ({
+      kind,
+      rel: path.relative(repoRoot, full).split(path.sep).join('/'),
+      body: readFileSync(full, 'utf8'),
+    }));
   }
 
-  test('no unrecognized frontmatter key in any skill or knowledge file', () => {
+  test('every frontmatter key is declared in skill-frontmatter.json', () => {
     const unknown = [];
-    for (const { rel, body } of corpusFiles()) {
+    for (const { kind, rel, body } of corpusFiles()) {
       for (const key of frontmatterKeys(body)) {
-        if (!ALLOWED_KEYS.has(key)) unknown.push(`${rel} → ${key}`);
+        if (!ALLOWED[kind].has(key)) unknown.push(`${rel} → ${key} (${kind})`);
       }
     }
     assert.deepEqual(
       unknown,
       [],
-      'unrecognized frontmatter key. If it makes the agent load another file, it is not allowed — '
-        + 'the context an agent must ingest has to stay bounded. If it is inert metadata, add it to ALLOWED_KEYS.',
+      'frontmatter key not declared in skill-frontmatter.json. If it makes an agent load '
+        + 'another file it must not be added — the context an agent ingests has to stay '
+        + 'bounded. Otherwise declare it there, with a line saying what it does.',
+    );
+  });
+
+  test('the schema declares every frontmatter key the installer reads', () => {
+    // tools/install pulls specific keys by name. If it grows one the schema does not
+    // declare, this fails rather than the installer quietly honouring an undeclared key.
+    const install = readFileSync(
+      path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'tools', 'install'),
+      'utf8',
+    );
+    const read = [...install.matchAll(/frontmatter_value\s+"\$\w+"\s+"([\w-]+)"/gu)].map((m) => m[1]);
+    assert.ok(read.length > 0, 'expected to find frontmatter_value calls in tools/install');
+    const undeclared = [...new Set(read)].filter(
+      (k) => !ALLOWED.skill.has(k) && !ALLOWED.knowledge.has(k),
+    );
+    assert.deepEqual(
+      undeclared,
+      [],
+      'tools/install reads a frontmatter key that skill-frontmatter.json does not declare',
     );
   });
 });

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -238,5 +238,67 @@ describe('managed skill pruning', () => {
 
     assert.notEqual(result.status, 0);
     assert.equal(existsSync(stale), true);
+  });
+});
+
+describe('corpus: frontmatter cannot force a load', () => {
+  // The context an agent must ingest has no upper bound if a file can *require* other
+  // files. A body link is the agent's choice — it reads what it judges relevant, and a
+  // broken one costs a failed read. A frontmatter key that declares a dependency is a
+  // mandatory pull, and mandatory pulls compose: A requires B requires C.
+  //
+  // `tools/install` hardcodes `alwaysApply: false` into every Cursor rule it emits, so
+  // no *installed* skill forces a load today. Nothing stops a source file declaring one.
+  //
+  // This is an ALLOWLIST, not a denylist of known-bad keys. A denylist silently exempts
+  // whatever it forgot to name — `loadAll:` invented next month passes a list that only
+  // knows about `alwaysApply:`. An unrecognized key fails until someone decides it is safe.
+  const ALLOWED_KEYS = new Set(['name', 'description', 'maturity', 'domain', 'metadata']);
+
+  function frontmatterKeys(body) {
+    const m = /^---\n([\s\S]*?)\n---/u.exec(body);
+    if (!m) return [];
+    return m[1]
+      .split('\n')
+      .filter((l) => /^[A-Za-z_][\w-]*:/u.test(l)) // top-level only; nested lines are indented
+      .map((l) => l.slice(0, l.indexOf(':')));
+  }
+
+  function corpusFiles() {
+    const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+    const domainsDir = path.join(repoRoot, 'domains');
+    const out = [];
+    const walk = (dir) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(full);
+        else if (
+          entry.name === 'skill.md'
+          || (entry.name.endsWith('.md') && full.includes(`${path.sep}knowledge${path.sep}`))
+        ) {
+          out.push({
+            rel: path.relative(repoRoot, full).split(path.sep).join('/'),
+            body: readFileSync(full, 'utf8'),
+          });
+        }
+      }
+    };
+    walk(domainsDir);
+    return out;
+  }
+
+  test('no unrecognized frontmatter key in any skill or knowledge file', () => {
+    const unknown = [];
+    for (const { rel, body } of corpusFiles()) {
+      for (const key of frontmatterKeys(body)) {
+        if (!ALLOWED_KEYS.has(key)) unknown.push(`${rel} → ${key}`);
+      }
+    }
+    assert.deepEqual(
+      unknown,
+      [],
+      'unrecognized frontmatter key. If it makes the agent load another file, it is not allowed — '
+        + 'the context an agent must ingest has to stay bounded. If it is inert metadata, add it to ALLOWED_KEYS.',
+    );
   });
 });


### PR DESCRIPTION
Declares the permitted frontmatter keys for skills and knowledge files in [`skill-frontmatter.json`](https://github.com/MetaMask/skills/blob/main/skill-frontmatter.json), and fails `yarn test` on anything undeclared.

## What it guards

The boundary between a reference an agent **may** follow and one it **must**. A body link is the agent's own choice, and a broken one costs it a failed read. A frontmatter key that declares a dependency is a mandatory pull, and mandatory pulls compose — A requires B requires C — so the context an agent has to ingest stops having an upper bound.

`tools/install` already writes `alwaysApply: false` into every Cursor rule it emits, so nothing installed today forces a load. Nothing stopped a *source* file declaring one, and it would have been invisible until it shipped.

## Where the list lives

In `skill-frontmatter.json`, not in the test. The permitted keys describe the skill **format**, so an author who trips this check finds the list — and the reason a key is or is not allowed — in a file they would think to open. README links to it.

Keys are split by file kind, because they differ:

| | Permitted |
|---|---|
| `skill.md` | `name`, `description`, `maturity`, `mandatory`, `scope`, `metadata` |
| `knowledge/*.md` | `name`, `domain`, `description` |

## Why an allowlist

A denylist of known-bad keys silently exempts whatever it did not name:

| Injected into a `skill.md` | denylist naming `alwaysApply` | this check |
|---|---|---|
| `alwaysApply: true` | caught | caught |
| `loadAll: [../other/skill.md]` | **missed** | caught |

An unrecognized key fails until someone declares it. Adding a legitimate one is a line in the schema, and the assertion message says so — that friction is the point, since a new frontmatter key is exactly the change worth a moment's thought.

## A bug this found

Moving the list into config surfaced that it was wrong. `tools/install` reads **`mandatory`** (ship a skill past the domain filter, `tools/install:476`) and **`scope`** (install to `$HOME`, `tools/install:507`), both documented in README. Neither was permitted in the first draft, so the check would have rejected a documented feature — and told the author they had tried to force an eager load, which is not what those keys do.

A second test parses the `frontmatter_value` calls out of `tools/install` and fails if it reads a key the schema does not declare, so the two cannot drift apart silently in that direction either.

## Limits

- Top-level keys only. A nested `metadata.requires` would not be caught; nothing consumes nested keys today.
- Overlay frontmatter (`repos/<repo>.md`, which uses `repo` and `parent`) is out of scope.
- It enforces the shape of the rule, not the semantics — it cannot tell whether a newly declared key forces a load. It guarantees the decision gets made, not that it gets made correctly.

## Test plan

- [x] `yarn test` — 13 pass / 0 fail on the current corpus
- [x] `mandatory: true` and `scope: user` accepted — installer-supported, must not be rejected
- [x] `alwaysApply: true` and `loadAll: [...]` rejected, naming file and key
- [x] Schema-vs-installer test fails if `tools/install` reads an undeclared key
- [x] No `CHANGELOG.md` entry: no consumer-facing CLI behavior change; the schema is dev-time and stays out of `files`
