### PR TITLE
feat(cli): resolve hook registration at install, and on demand

### DIFF
--- a/bin/metamask-skills.mjs
+++ b/bin/metamask-skills.mjs
@@ -22,6 +22,7 @@ Usage:
   metamask-skills describe <skill|domain/skill> [options]
   metamask-skills sync [options]
   metamask-skills postinstall [options]
+  metamask-skills hooks [options]
   metamask-skills install [options]
 
 Options:
@@ -799,6 +800,55 @@ function invokedDirectly() {
   }
 }
 
+
+/**
+ * Print the Claude Code registration for every hook an installed skill ships.
+ *
+ * The installer copies `hooks/` like any other bundle directory, but a hook does nothing
+ * until it is registered in settings.json — and the path to register is absolute, so it
+ * differs per machine and per consumer repo and cannot be documented as a constant. This
+ * resolves it against the actual install.
+ */
+function printHookRegistration(args) {
+  const { target } = parseGlobalArgs(args);
+  const skillsDir = path.join(target, '.claude', 'skills');
+
+  let entries = [];
+  try {
+    for (const skill of readdirSync(skillsDir, { withFileTypes: true })) {
+      if (!skill.isDirectory()) continue;
+      const hooks = path.join(skillsDir, skill.name, 'hooks');
+      if (!dirExists(hooks)) continue;
+      for (const file of readdirSync(hooks)) {
+        if (file.endsWith('.py')) entries.push(path.join(hooks, file));
+      }
+    }
+  } catch {
+    warn(`no installed skills found under ${skillsDir}`);
+    return 1;
+  }
+
+  if (entries.length === 0) {
+    process.stdout.write('No installed skill ships a hook.\n');
+    return 0;
+  }
+
+  const commands = entries
+    .map((f) => `            { "type": "command", "command": "python3 ${f}" }`)
+    .join(',\n');
+
+  process.stdout.write(
+    `${entries.length} hook(s) installed. Copying a hook does not activate it — Claude Code\n` +
+      `runs one only once it is registered. Add this to ~/.claude/settings.json, or to\n` +
+      `${path.join(target, '.claude', 'settings.json')} to scope it to this repo:\n\n` +
+      '  {\n    "hooks": {\n      "PreToolUse": [\n        {\n          "matcher": "Bash",\n          "hooks": [\n' +
+      `${commands}\n` +
+      '          ]\n        }\n      ]\n    }\n  }\n',
+  );
+  return 0;
+}
+
+
 if (invokedDirectly()) {
   const [command, ...args] = process.argv.slice(2);
   if (!command || command === '-h' || command === '--help') {
@@ -817,6 +867,8 @@ if (invokedDirectly()) {
       exitCode = sync(args);
     } else if (command === 'postinstall') {
       exitCode = postinstall(args);
+    } else if (command === 'hooks') {
+      exitCode = printHookRegistration(args);
     } else if (command === 'install') {
       exitCode = install(args);
     } else {

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -240,3 +240,73 @@ describe('managed skill pruning', () => {
     assert.equal(existsSync(stale), true);
   });
 });
+
+describe('hook registration', () => {
+  // Copying a hook does not activate it: Claude Code runs one only once it is registered
+  // in settings.json, and the path to register is absolute — different per machine and per
+  // consumer repo, so it cannot be documented as a constant. Both surfaces resolve it.
+  let root;
+  let source;
+  let target;
+
+  before(() => {
+    root = mkdtempSync(path.join(os.tmpdir(), 'mms-hooks-'));
+    source = path.join(root, 'source');
+    target = path.join(root, 'target');
+    const dir = path.join(source, 'domains', 'testing', 'skills', 'gatekeeper');
+    mkdirSync(path.join(dir, 'hooks'), { recursive: true });
+    mkdirSync(path.join(source, 'tools'), { recursive: true });
+    symlinkSync(INSTALL, path.join(source, 'tools', 'install'));
+    mkdirSync(target, { recursive: true });
+    writeFileSync(
+      path.join(dir, 'skill.md'),
+      ['---', 'name: gatekeeper', 'description: Gate writes', 'maturity: stable', '---', 'Body.'].join('\n'),
+    );
+    writeFileSync(path.join(dir, 'hooks', 'evidence-gate.py'), 'print("gate")\n');
+    const r = spawnSync('bash', [INSTALL, '--target', target, '--repo', 'core', '--source', source], {
+      encoding: 'utf8',
+    });
+    assert.equal(r.status, 0, r.stderr);
+    installOutput = r.stdout;
+  });
+
+  let installOutput = '';
+
+  after(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test('the hook file is delivered', () => {
+    assert.ok(
+      existsSync(path.join(target, '.claude/skills', 'mms-gatekeeper', 'hooks', 'evidence-gate.py')),
+    );
+  });
+
+  test('install prints a registration with the path resolved', () => {
+    assert.match(installOutput, /Copying the file does not activate it/u);
+    assert.match(installOutput, /mms-gatekeeper\/hooks\/evidence-gate\.py/u);
+  });
+
+  test('the printed registration is valid JSON', () => {
+    const body = installOutput.slice(installOutput.indexOf('{'), installOutput.lastIndexOf('}') + 1);
+    const parsed = JSON.parse(body);
+    assert.equal(parsed.hooks.PreToolUse[0].matcher, 'Bash');
+    assert.match(parsed.hooks.PreToolUse[0].hooks[0].command, /^python3 \//u);
+  });
+
+  test('the hooks subcommand prints the same registration on demand', () => {
+    const r = spawnSync(process.execPath, [BIN, 'hooks', '--target', target], { encoding: 'utf8' });
+    assert.equal(r.status, 0, r.stderr);
+    const body = r.stdout.slice(r.stdout.indexOf('{'), r.stdout.lastIndexOf('}') + 1);
+    assert.equal(JSON.parse(body).hooks.PreToolUse[0].hooks.length, 1);
+  });
+
+  test('a target with no hooks says so rather than printing empty JSON', () => {
+    const bare = mkdtempSync(path.join(os.tmpdir(), 'mms-nohooks-'));
+    mkdirSync(path.join(bare, '.claude', 'skills', 'mms-x'), { recursive: true });
+    const r = spawnSync(process.execPath, [BIN, 'hooks', '--target', bare], { encoding: 'utf8' });
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /No installed skill ships a hook/u);
+    rmSync(bare, { recursive: true, force: true });
+  });
+});

--- a/tools/install
+++ b/tools/install
@@ -386,6 +386,9 @@ copy_domain_knowledge() {
 
 copy_project_bundles() {
   local skill_dir="$1" out_name="$2"
+  # A hook is inert until an operator registers it, so remember which skills shipped one
+  # and print the registration at the end rather than leaving the file to be discovered.
+  [[ -d "$skill_dir/hooks" ]] && HOOK_SKILLS+=("$out_name")
   copy_bundle_dirs "$skill_dir" "$CLAUDE_DIR/$out_name" ".claude/skills/$out_name"
   copy_domain_knowledge "$skill_dir" "$CLAUDE_DIR/$out_name" ".claude/skills/$out_name"
   copy_bundle_dirs "$skill_dir" "$CURSOR_DIR/$out_name" ".cursor/rules/$out_name"
@@ -592,6 +595,7 @@ RESOLVED_KEYS=()
 RESOLVED_DIRS=()
 RESOLVED_DOMAINS=()
 SKIPPED_USER_SKILLS=()
+HOOK_SKILLS=()
 FAILED_SKILLS=()
 EXPECTED_PROJECT_SKILLS=()
 
@@ -659,6 +663,47 @@ $PRUNE_STALE && remove_stale_project_skills
 
 echo
 $DRY_RUN && echo "Dry run complete. No files written." || echo "Install complete."
+
+set +u
+HOOK_COUNT=${#HOOK_SKILLS[@]}
+set -u
+if (( HOOK_COUNT > 0 )) && ! $DRY_RUN; then
+  echo
+  echo "Note: $HOOK_COUNT skill(s) ship a hook. Copying the file does not activate it —"
+  echo "Claude Code runs a hook only once it is registered in settings.json."
+  echo
+  echo "Add this to ~/.claude/settings.json (or $TARGET/.claude/settings.json):"
+  echo
+
+  hook_entries=()
+  for out_name in "${HOOK_SKILLS[@]}"; do
+    for hook_file in "$CLAUDE_DIR/$out_name/hooks"/*.py; do
+      [[ -f "$hook_file" ]] || continue
+      hook_entries+=("            { \"type\": \"command\", \"command\": \"python3 $hook_file\" }")
+    done
+  done
+
+  echo '  {'
+  echo '    "hooks": {'
+  echo '      "PreToolUse": ['
+  echo '        {'
+  echo '          "matcher": "Bash",'
+  echo '          "hooks": ['
+  for i in "${!hook_entries[@]}"; do
+    if (( i < ${#hook_entries[@]} - 1 )); then
+      echo "${hook_entries[$i]},"
+    else
+      echo "${hook_entries[$i]}"
+    fi
+  done
+  echo '          ]'
+  echo '        }'
+  echo '      ]'
+  echo '    }'
+  echo '  }'
+  echo
+  echo "Re-run \`metamask-skills hooks\` to print this again."
+fi
 
 set +u
 SKIPPED_USER_COUNT=${#SKIPPED_USER_SKILLS[@]}


### PR DESCRIPTION
Stacked on #99, which is what makes `hooks/` reach a consumer at all. **Base is #99's branch, not `main`** — review that one first.

## The gap

Copying a hook does not activate it. Claude Code runs one only once it is registered in `settings.json`, and the path to register is **absolute** — different per machine, per consumer repo, and per `mms-` prefixed skill directory. So the setup reference could only ever say:

```
python3 /absolute/path/to/evidence/hooks/pr-evidence-gate.py
```

and leave the reader to work out what that is. Meanwhile `evidence` cites the hook twice in its body as its enforcement mechanism, so someone installing it reasonably assumes the gate is live. It isn't.

## Two surfaces, one output

**At install** — when any installed skill ships a hook, `tools/install` prints the registration with every path resolved against the actual install:

```
Note: 1 skill(s) ship a hook. Copying the file does not activate it —
Claude Code runs a hook only once it is registered in settings.json.

Add this to ~/.claude/settings.json (or <target>/.claude/settings.json):

  {
    "hooks": {
      "PreToolUse": [
        {
          "matcher": "Bash",
          "hooks": [
            { "type": "command", "command": "python3 <target>/.claude/skills/mms-gatekeeper/hooks/evidence-gate.py" }
          ]
        }
      ]
    }
  }
```

**On demand** — `metamask-skills hooks [--target <path>]` prints the same thing, for anyone who scrolled past it or is re-registering later. Says *"No installed skill ships a hook"* rather than printing empty JSON, and exits non-zero only when the target has no installed skills at all.

## What it deliberately does not do

**Neither surface writes to `settings.json`.** Editing a user's operator config is a materially larger permission than "copy files into the repo you pointed me at", and it should be decided deliberately rather than inherited as a side effect of shipping one hook. This is also the only hook in the corpus — a sample of one is thin evidence for automating a write to `$HOME`.

## Test plan

- [x] `yarn test` — 69 pass / 0 fail across three files
- [x] Fixture skill with `hooks/evidence-gate.py`: file delivered, registration printed, path resolved
- [x] Printed registration **parses as JSON** — asserted by `JSON.parse`, matcher and command checked
- [x] `metamask-skills hooks` emits the same registration
- [x] Target with skills but no hooks → message, exit 0
- [x] Target with no installed skills → warning, exit 1

## Note

An earlier version emitted a trailing comma and told the reader to delete it. Handing someone JSON that doesn't parse is worse than handing them none, so the entries are joined properly and the output is valid as printed.