### PR TITLE
docs(testing): document CV flakiness and high-leverage assert patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add opt-in stale project skill pruning via `--prune-stale` and `SKILLS_PRUNE_STALE=1`.
-- docs(testing): document CV stale-press flakiness (re-query before press; default route probes) in `mobile-testing` component-view references.
+- docs(testing): document CV stale-press flakiness plus high-leverage assert patterns (migration parity, filter both-sides example, loading/skeleton honesty, RefreshControl + flag overrides) in `mobile-testing` component-view and placement refs.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add opt-in stale project skill pruning via `--prune-stale` and `SKILLS_PRUNE_STALE=1`.
+- docs(testing): document CV stale-press flakiness (re-query before press; default route probes) in `mobile-testing` component-view references.
 
 ### Changed
 

--- a/domains/testing/skills/mobile-testing/references/component-view.md
+++ b/domains/testing/skills/mobile-testing/references/component-view.md
@@ -117,7 +117,11 @@ For run-by-name, watch mode, or other options, see `component-view/reference.md`
 
 9. **Every view with async data needs one data-completeness test** — wait for the load and validate all significant fields of all items in the base mock using `within()` per row. One per independent async data flow.
 
-10. **Filter / segmentation tests must assert both sides** — after selecting a filter, assert both what appears (positive `findByTestId`) and what disappears (negative `queryByTestId(...).not.toBeOnTheScreen()`).
+10. **Filter / segmentation tests must assert both sides** — after selecting a filter, assert both what appears (positive `findByTestId`) and what disappears (negative `queryByTestId(...).not.toBeOnTheScreen()`). Spy-only checks (refetch count / analytics) are not enough — seed distinct before/after rows.
+
+11. **Match loading asserts to real UX** — pending-phase tests assert skeleton / not-yet-visible content, not optimistic titles the production screen does not show while loading.
+
+12. **Pull-to-refresh via `refreshControl.props.onRefresh`** — prefer the prop handler inside `act`; `fireEvent(scrollView, 'refresh')` often never hits the handler.
 
 
 ## Reference files (when to use)

--- a/domains/testing/skills/mobile-testing/references/component-view/navigation-mocking.md
+++ b/domains/testing/skills/mobile-testing/references/component-view/navigation-mocking.md
@@ -59,6 +59,18 @@ The most valuable navigation tests follow a **complete user journey across multi
 //    - Positive: new items appear (the filtered set)
 //    - Negative: old items are gone (queryByTestId(...).not.toBeOnTheScreen())
 //    Asserting only one side does not prove the list actually changed.
+//
+// ❌ Analytics / refetch alone is NOT enough — Golden Rule 10 still requires list
+//    membership assertions. Bugbot catches this when the mock returns [] so no
+//    rows exist to check:
+// await waitFor(() => expect(listSpy.mock.calls.length).toBeGreaterThan(n));
+// expect(trackFilterSpy).toHaveBeenCalled(); // still missing both-sides UI
+//
+// ✅ Seed distinct before/after datasets, then assert membership:
+// expect(await findByText('Games market')).toBeOnTheScreen();
+// fireEvent.press(getByText('Props'));
+// expect(await findByText('Props market')).toBeOnTheScreen();
+// expect(queryByText('Games market')).not.toBeOnTheScreen();
 it('displays only BNB tokens when BNB Chain network filter is selected', async () => {
   // Dynamic mock: returns different data based on the chainIds param
   getMyFeatureDataMock.mockImplementation(async (params) => {

--- a/domains/testing/skills/mobile-testing/references/component-view/navigation-mocking.md
+++ b/domains/testing/skills/mobile-testing/references/component-view/navigation-mocking.md
@@ -12,6 +12,8 @@ Reference: [SKILL.md](../SKILL.md) · [Writing Tests](writing-tests.md) · [Refe
 
 When navigation hits a registered route, the framework renders an element with `` testID=`route-${routeName}` `` so you can assert with ``await findByTestId(`route-${Routes.X}`)``. If you passed `Component`, the real component is shown instead. Use only `{ name }` when you just need to assert navigation; use `Component` when the test interacts with the destination screen. For cross-screen journeys, use a renderer that registers all reachable routes with `Component`.
 
+Do **not** mount a custom nested navigator (or other probe stack) solely to assert `route-${Routes.X}` — the default probe is enough and avoids extra surface area that can hide real navigation failures.
+
 ```typescript
 // tests/component-view/renderers/myFeature.ts
 export function renderMyFeatureWithRoutes(options = {}) {

--- a/domains/testing/skills/mobile-testing/references/component-view/reference.md
+++ b/domains/testing/skills/mobile-testing/references/component-view/reference.md
@@ -62,12 +62,15 @@ Before declaring the task done, go through this checklist for every test written
 | 2   | **No selector mocking** — no `(useSelector as jest.Mock).mockImplementation(...)` anywhere in the file                                                                                                                                                       | Remove; drive behavior through state overrides instead                 |
 | 3   | **No fake timers** — no `jest.useFakeTimers()`, `jest.advanceTimersByTime()`, or `jest.useRealTimers()`                                                                                                                                                      | Remove fake timers; use `waitFor` / `findBy` for async flows           |
 | 4   | **Data-completeness test exists** — if the view loads data asynchronously (API, Engine polling), there is one test that waits for the load and validates all fields of all items in the full base mock using `within()` per row                              | Add the data-completeness test                                         |
-| 5   | **Filter/segmentation tests have paired assertions** — every test that selects a filter or changes a network asserts both what appears (`findByTestId`) AND what disappears (`queryByTestId(...).not.toBeOnTheScreen()`) for each item from the previous set | Add the missing negative assertions                                    |
+| 5   | **Filter/segmentation tests have paired assertions** — every test that selects a filter or changes a network asserts both what appears (`findByTestId`) AND what disappears (`queryByTestId(...).not.toBeOnTheScreen()`) for each item from the previous set. Spy-only checks (refetch count / analytics) are **not** enough | Seed distinct before/after rows; add the missing negative assertions |
 | 6   | **No raw strings in `getByTestId` / `findByTestId` / `queryByTestId`** — all test IDs reference constants from the component's `ComponentName.testIds.ts`                                                                                                    | Create or update the testIds file; replace raw strings with constants  |
 | 7   | **Any `jest.mock` for non-Engine modules is flagged** — if a service module is mocked directly, the `eslint-disable` comment is present and a tracking issue is linked                                                                                       | Add the comment and issue link                                         |
 | 8   | **AAA formatting** — blank lines between the Arrange, Act, and Assert blocks in every test                                                                                                                                                                   | Add the blank line separators                                          |
 | 9   | **Import order** — `mocks.ts` is first; remaining order follows project ESLint rules                                                                                                                                                                         | Ensure `mocks.ts` is the very first import; reorder the rest as needed |
 | 10  | **No stale press targets** — do not `fireEvent.press` a node held across `await`s when the UI re-renders (live countdown, polling). Re-query with `getByTestId` / `findByTestId` immediately before press                                                     | Re-query right before press; see What NOT to Do                        |
+| 11  | **Loading asserts match real UX** — pending-phase tests assert skeleton / “not yet visible”, not optimistic titles the production screen does not show while `isLoading`                                                                                      | Rename and assert the real pending UI; resolve then assert loaded state |
+| 12  | **Pull-to-refresh uses `refreshControl.props.onRefresh`** — not `fireEvent(scrollView, 'refresh')`                                                                                                                                                            | Call the prop handler inside `act`                                     |
+| 13  | **Unit→CV migrations keep assert specificity** — deleted unit payload fields (`tabId`, formatted dates, full analytics) still appear in the CV replacement                                                                                                   | Restore dropped fields in CV or KEEP a focused unit; see unit-cv-overlap |
 
 ---
 
@@ -85,6 +88,8 @@ Before declaring the task done, go through this checklist for every test written
 | `No QueryClient set`                                                   | Missing provider — not in Engine mock                                                                | Add to mocks.ts or wrap with QueryClientProvider in renderer                                                        |
 | Flakey number assertions                                               | Non-deterministic exchange rates                                                                     | Add `deterministicFiat: true`                                                                                       |
 | Test passes locally, fails in CI                                       | Time-sensitive assertions, or stale press under CI load                                              | Use `waitFor` / `findBy`; re-query before press when the UI re-renders on a timer                                   |
+| Pull-to-refresh never refetches                                        | `fireEvent(scrollView, 'refresh')` did not hit the handler                                           | `await act(async () => { await scrollView.props.refreshControl.props.onRefresh(); })`                             |
+| Sheet / branch `testID` missing                                        | Remote feature flag off in Redux; UI routes elsewhere                                                | Override `RemoteFeatureFlagController` / preset so the gated UI mounts                                            |
 
 ### Inspect what's rendered
 
@@ -129,6 +134,11 @@ await findByTestId('my-element', {}, { timeout: 3000 });
 await findByTestId(MyViewSelectorsIDs.CARD);
 await findByTestId(MyViewSelectorsIDs.LIVE_BADGE);
 fireEvent.press(getByTestId(MyViewSelectorsIDs.CARD));
+
+// Pull-to-refresh — call the RefreshControl handler (fireEvent 'refresh' often no-ops)
+await act(async () => {
+  await scrollView.props.refreshControl.props.onRefresh();
+});
 
 // Within a subtree — scope queries to avoid false positives when the same text or
 // testID appears in multiple list items (e.g., every row shows a "price" label).
@@ -185,6 +195,30 @@ fireEvent.press(getByTestId(MyViewSelectorsIDs.CARD));
 extraRoutes: [{ name: Routes.FEATURE.ROOT, Component: NestedStackProbe }];
 // ✅ Default route probe when you only need to prove navigation
 extraRoutes: [{ name: Routes.FEATURE.ROOT }];
+
+// ❌ Filter/segmentation: analytics or refetch count only
+await waitFor(() => expect(listSpy.mock.calls.length).toBeGreaterThan(n));
+expect(trackFilterSpy).toHaveBeenCalled();
+// ✅ Assert both list membership sides (Golden Rule 10)
+expect(await findByText('Games market')).toBeOnTheScreen();
+fireEvent.press(getByText('Props'));
+expect(await findByText('Props market')).toBeOnTheScreen();
+expect(queryByText('Games market')).not.toBeOnTheScreen();
+
+// ❌ Claim optimistic title while loading when production shows a skeleton
+expect(getByText(routeTitle)).toBeOnTheScreen(); // while getMarket is pending
+// ✅ Assert the real pending UI, then resolve
+expect(await findByTestId(MyDetailSelectorsIDs.SKELETON)).toBeOnTheScreen();
+
+// ❌ fireEvent(scrollView, 'refresh') — often never calls onRefresh in RNTL
+// ✅ await act(async () => { await scrollView.props.refreshControl.props.onRefresh(); });
+
+// ❌ Weaken unit→CV analytics: drop tabId/filterId after deleting the full unit assert
+expect(trackSpy).toHaveBeenCalledWith(expect.objectContaining({ feedId }));
+// ✅ Keep the same payload specificity the unit had
+expect(trackSpy).toHaveBeenCalledWith(
+  expect.objectContaining({ feedId, tabId, filterId, entryPoint }),
+);
 
 // ❌ Raw string literal in getByTestId / findByTestId / queryByTestId
 getByTestId('my-view-scroll-view');

--- a/domains/testing/skills/mobile-testing/references/component-view/reference.md
+++ b/domains/testing/skills/mobile-testing/references/component-view/reference.md
@@ -67,6 +67,7 @@ Before declaring the task done, go through this checklist for every test written
 | 7   | **Any `jest.mock` for non-Engine modules is flagged** — if a service module is mocked directly, the `eslint-disable` comment is present and a tracking issue is linked                                                                                       | Add the comment and issue link                                         |
 | 8   | **AAA formatting** — blank lines between the Arrange, Act, and Assert blocks in every test                                                                                                                                                                   | Add the blank line separators                                          |
 | 9   | **Import order** — `mocks.ts` is first; remaining order follows project ESLint rules                                                                                                                                                                         | Ensure `mocks.ts` is the very first import; reorder the rest as needed |
+| 10  | **No stale press targets** — do not `fireEvent.press` a node held across `await`s when the UI re-renders (live countdown, polling). Re-query with `getByTestId` / `findByTestId` immediately before press                                                     | Re-query right before press; see What NOT to Do                        |
 
 ---
 
@@ -74,15 +75,16 @@ Before declaring the task done, go through this checklist for every test written
 
 ### Identify the error type first
 
-| Error pattern                                    | Likely cause                                       | Fix                                                               |
-| ------------------------------------------------ | -------------------------------------------------- | ----------------------------------------------------------------- |
-| `jest.mock is not allowed in *.view.test.*`      | Arbitrary `jest.mock` added to test                | Remove it; drive via state instead                                |
-| `Unable to find an element with testID: xxx`     | State not providing needed data, or element hidden | Add the relevant state via overrides or check rendering condition |
-| `Cannot read property 'X' of undefined`          | Preset missing a required state slice              | Add `.withMinimalXController()` or override in preset             |
-| `Warning: An update was not wrapped in act(...)` | Async state update not awaited                     | Use `await waitFor(...)`                                          |
-| `No QueryClient set`                             | Missing provider — not in Engine mock              | Add to mocks.ts or wrap with QueryClientProvider in renderer      |
-| Flakey number assertions                         | Non-deterministic exchange rates                   | Add `deterministicFiat: true`                                     |
-| Test passes locally, fails in CI                 | Time-sensitive assertions                          | Use `waitFor` not inline assertions after interactions            |
+| Error pattern                                                          | Likely cause                                                                                         | Fix                                                                                                                 |
+| ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `jest.mock is not allowed in *.view.test.*`                            | Arbitrary `jest.mock` added to test                                                                  | Remove it; drive via state instead                                                                                  |
+| `Unable to find an element with testID: xxx`                           | State not providing needed data, or element hidden                                                   | Add the relevant state via overrides or check rendering condition                                                   |
+| `Unable to find … route-X` after press; dump still on the source screen | Held element went stale (live clock / polling re-render); `fireEvent.press` was a no-op             | Re-query immediately before press: `fireEvent.press(getByTestId(...))` — never press a node captured across `await`s |
+| `Cannot read property 'X' of undefined`                                | Preset missing a required state slice                                                                | Add `.withMinimalXController()` or override in preset                                                               |
+| `Warning: An update was not wrapped in act(...)`                       | Async state update not awaited                                                                       | Use `await waitFor(...)`                                                                                            |
+| `No QueryClient set`                                                   | Missing provider — not in Engine mock                                                                | Add to mocks.ts or wrap with QueryClientProvider in renderer                                                        |
+| Flakey number assertions                                               | Non-deterministic exchange rates                                                                     | Add `deterministicFiat: true`                                                                                       |
+| Test passes locally, fails in CI                                       | Time-sensitive assertions, or stale press under CI load                                              | Use `waitFor` / `findBy`; re-query before press when the UI re-renders on a timer                                   |
 
 ### Inspect what's rendered
 
@@ -122,6 +124,11 @@ await findByTestId(`route-${Routes.SOME_SCREEN}`);
 
 // findByTestId 3rd-arg timeout (NOT 2nd arg)
 await findByTestId('my-element', {}, { timeout: 3000 });
+
+// Re-query before press when the target can re-render (live countdown, polling).
+await findByTestId(MyViewSelectorsIDs.CARD);
+await findByTestId(MyViewSelectorsIDs.LIVE_BADGE);
+fireEvent.press(getByTestId(MyViewSelectorsIDs.CARD));
 
 // Within a subtree — scope queries to avoid false positives when the same text or
 // testID appears in multiple list items (e.g., every row shows a "price" label).
@@ -164,6 +171,20 @@ renderComponentViewScreen(MyView, { name: 'X' }, {
   state: { engine: { backgroundState: { /* 200 lines */ } } },
 });
 // ✅ Instead: use a preset + minimal overrides
+
+// ❌ Hold a node across awaits when the UI re-renders (live countdown, polling)
+const card = await findByTestId(MyViewSelectorsIDs.CARD);
+await findByTestId(MyViewSelectorsIDs.LIVE_BADGE);
+fireEvent.press(card); // stale under CI — press may be a no-op
+// ✅ Re-query immediately before press
+await findByTestId(MyViewSelectorsIDs.CARD);
+await findByTestId(MyViewSelectorsIDs.LIVE_BADGE);
+fireEvent.press(getByTestId(MyViewSelectorsIDs.CARD));
+
+// ❌ Custom nested navigator only to assert navigation occurred
+extraRoutes: [{ name: Routes.FEATURE.ROOT, Component: NestedStackProbe }];
+// ✅ Default route probe when you only need to prove navigation
+extraRoutes: [{ name: Routes.FEATURE.ROOT }];
 
 // ❌ Raw string literal in getByTestId / findByTestId / queryByTestId
 getByTestId('my-view-scroll-view');

--- a/domains/testing/skills/mobile-testing/references/component-view/writing-tests.md
+++ b/domains/testing/skills/mobile-testing/references/component-view/writing-tests.md
@@ -40,11 +40,43 @@ Ask: "What can a user **do** on this screen?" — type/paste input, press a butt
 
 Drop anything that only produces a render scenario: "The screen shows X when state is Y", "Button is disabled without input", "Token name appears in header".
 
-### 3. Deduplicate against existing tests
+### 3. High-leverage interaction pitfalls (from Mobile CV migrations)
+
+These patterns prevent false-green CV and weak unit→CV migrations:
+
+**Loading / skeleton honesty** — Match the pending phase to production UX. If the screen shows a skeleton while `isLoading`, assert skeleton (or that the loaded title is not yet visible), then resolve, then assert post-load behaviour. Do not name a test “shows title while waiting” when production keeps the skeleton until data resolves.
+
+```typescript
+// ✅ Pending phase matches real UX
+it('shows the loading skeleton until the market request resolves', async () => {
+  getMarketSpy.mockImplementation(() => new Promise(() => undefined));
+
+  const { findByTestId, queryByTestId } = renderMyDetailView({
+    initialParams: { marketId: 'm1' },
+  });
+
+  expect(await findByTestId(MyDetailSelectorsIDs.SKELETON)).toBeOnTheScreen();
+  expect(queryByTestId(MyDetailSelectorsIDs.TITLE)).not.toBeOnTheScreen();
+});
+```
+
+**RefreshControl** — Prefer calling the prop handler; `fireEvent(scrollView, 'refresh')` often never hits `onRefresh` in RNTL:
+
+```typescript
+await act(async () => {
+  await scrollView.props.refreshControl.props.onRefresh();
+});
+```
+
+**Flag-gated sheets / branches** — UI behind remote flags only mounts when the flag is on in Redux. Drive via preset / `RemoteFeatureFlagController` overrides; do not assert a sheet `testID` if the flag routes to a full screen instead.
+
+**Migration assert parity** — When moving unit → CV, compare deleted unit expects field-by-field. If the unit checked `tabId` / `filterId` / formatted dates / full analytics payloads, the CV replacement must keep that specificity. Partial `objectContaining({ feedId })` after deleting a full payload assert is a regression. See [`../placement/unit-cv-overlap.md`](../placement/unit-cv-overlap.md).
+
+### 4. Deduplicate against existing tests
 
 Read `ComponentName.view.test.tsx` (if it exists) and remove any candidate already covered.
 
-### 4. Run coverage and prioritize
+### 5. Run coverage and prioritize
 
 ```bash
 yarn test:view:coverage:folder app/components/UI/MyFeature

--- a/domains/testing/skills/mobile-testing/references/placement/unit-cv-overlap.md
+++ b/domains/testing/skills/mobile-testing/references/placement/unit-cv-overlap.md
@@ -33,8 +33,9 @@ yarn jest -c jest.config.view.js ./path/Component.view.test.tsx \
 ```
 
 3. Classify each unit `it(...)`: reason → best layer → DELETE | MIGRATE | KEEP.
-4. Apply (IMPLEMENT mode only): add CV for MIGRATE → delete DELETE/migrated unit its → residual toast matrices via pure helper + unit (**EXTRACT+UNIT**) when user accepts → re-run unit + CV.
-5. Record metrics: unit its removed, CV its added, ratio, app LOC + why, residual gaps.
+4. **Mandatory assert-parity gap check before DELETE** — Diff the deleted unit’s `expect` payloads against the CV replacement field-by-field (`tabId`, `filterId`, formatted dates, image URI, list membership, full analytics objects). If any field was dropped, restore it in CV **or** KEEP a focused unit with a reason — do **not** delete a specific assert and replace it with a weaker `objectContaining({ feedId })`. Partial parity is a regression.
+5. Apply (IMPLEMENT mode only): add CV for MIGRATE → delete DELETE/migrated unit its → residual toast matrices via pure helper + unit (**EXTRACT+UNIT**) when user accepts → re-run unit + CV.
+6. Record metrics: unit its removed, CV its added, ratio, app LOC + why, residual gaps.
 
 ## In-repo docs (keep minimal)
 


### PR DESCRIPTION
## Description

Expands component-view guidance with patterns learned from Mobile CV work:

1. **Stale press targets** ([Mobile #34241](https://github.com/MetaMask/metamask-mobile/pull/34241)) — do not hold an element across `await`s when the UI re-renders on a timer; re-query immediately before `fireEvent.press`. Prefer default `{ name: Routes.X }` route probes.
2. **Migration assert parity** ([MMQA-2104](https://consensyssoftware.atlassian.net/browse/MMQA-2104) / [Mobile #34197](https://github.com/MetaMask/metamask-mobile/pull/34197)) — unit→CV must not weaken deleted expects (`tabId`, `filterId`, formatted dates, full analytics). Mandatory gap-check in `unit-cv-overlap`.
3. **Filter both-sides** — Golden Rule 10 already required this; add an explicit antipattern: analytics/refetch alone is **not** enough — seed distinct before/after rows.
4. **Loading / skeleton honesty** — pending-phase tests must match production UX (skeleton / not-yet-visible), not optimistic titles the screen does not show while loading.
5. **RefreshControl + flag overrides** — call `refreshControl.props.onRefresh` inside `act`; drive flag-gated sheets via Redux / remote-flag overrides.

### Files updated (`testing/mobile-testing`)

- `references/component-view.md` — Golden Rules 10–12
- `references/component-view/writing-tests.md` — high-leverage interaction pitfalls
- `references/component-view/navigation-mocking.md` — analytics-only filter antipattern
- `references/component-view/reference.md` — self-review 5/11–13, diagnosing failures, assertion patterns, What NOT to Do
- `references/placement/unit-cv-overlap.md` — mandatory assert-parity gap check before DELETE
- `CHANGELOG.md`

## Type of Change

- [x] Skill improvement/update
- [ ] New skill
- [ ] Bug fix
- [x] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/MetaMask/skills/blob/main/CONTRIBUTING.md) guidelines
- [x] My skill follows the [SKILL_TEMPLATE.md](https://github.com/MetaMask/skills/blob/main/.github/SKILL_TEMPLATE.md) format
- [x] I have tested this skill with an AI agent
- [x] My skill does not contain any secrets, private keys, or sensitive data
- [x] I have added appropriate documentation
- [x] My changes don't break existing skills

## Testing

Reviewed guidance against Mobile CV fixes in #34241 and the MMQA-2104 Predict unit↔CV pass (#34197). No installer/CLI behavior change.

## Additional Context

Highest-leverage items first (parity, filter both-sides example, loading honesty, RefreshControl/flags), on top of the existing stale-press / route-probe docs.

After merge, Mobile consumers pick this up on next `metamask-skills sync --include testing/mobile-testing`. Companion in-repo doc sync for `docs/testing/component-view-tests.md` can follow separately if desired.