### PR TITLE
Stop the figures check firing on every body that cites a Sentry Discover link

### DIFF
--- a/domains/pr-workflow/skills/evidence/scripts/attest-gate.sh
+++ b/domains/pr-workflow/skills/evidence/scripts/attest-gate.sh
@@ -275,11 +275,17 @@ fi
 # rather than measurements — whole URLs, issue refs, version strings, dates, SHAs,
 # file:line citations, hyphenated identifiers like P-256, and regex quantifiers. Every
 # one of those was added after a control run flagged something that was not a figure.
+#
+# URLs are stripped to whitespace rather than to the first `)`. A Sentry Discover
+# permalink contains `count()` and `count_unique(trace)`, so stopping at `(` left the
+# whole query string in the prose, and every digit in it — project id, time window,
+# per_page — was reported as a figure tracing to no exhibit. A check that fires on every
+# body citing a Discover link teaches the operator to publish through it.
 echo
 NUM_ORPHANS="$(
   awk '/^```/{f=!f; next} f{print}' "$FILE" > "$FILE.exh" 2>/dev/null
   awk '/^```/{f=!f; next} !f{print}' "$FILE" \
-    | sed -E 's#https?://[^ )]*##g' \
+    | sed -E 's#https?://[^[:space:]]*##g' \
     | sed -E 's/#[0-9]+//g; s/\bv?[0-9]+\.[0-9]+(\.[0-9]+)?\b//g; s/\b[0-9]{4}-[0-9]{2}-[0-9]{2}\b//g; s/\b[0-9a-f]{7,}\b//g; s/:[0-9]+\b//g; s/[A-Za-z]+-[0-9]+//g; s/\{[0-9,]+\}//g' \
     | grep -oE '\b[0-9]{2,}\b' | sort -u \
     | while read -r n; do grep -qF "$n" "$FILE.exh" || printf '%s ' "$n"; done


### PR DESCRIPTION
Follow-up to #112, which merged without this — the fix was written while validating a real body and never made it into that branch.

## The defect

Check 13 (*figures trace to an exhibit*) strips URLs before looking for unexhibited numbers. It stripped with `[^ )]*`, which **stops at the first `(`**.

Every Sentry Discover permalink contains `count()` and `count_unique(trace)`. So the strip halted mid-URL and left the entire query string sitting in the prose, where its digits — project id, time window, `per_page` — were reported as figures tracing to no exhibit.

On a real validation body for `MetaMask/metamask-extension#43931`, that produced:

```
these appear in the prose and in no exhibit: 07 15 2026 22 273496 300 41 42869 50 55
```

Of those, `07 / 15 / 2026 / 22 / 50 / 273496 / 42869` were fragments of the permalink itself. One (`55`) was a genuine unexhibited figure — which is the finding the noise was burying.

This fires on any validation run citing live Sentry data, which is most of them. A check that is wrong nearly every time is one the operator learns to publish through, and then it catches nothing when it is right.

## The fix

Strip to whitespace instead, which consumes the URL whether or not it contains parentheses.

## Controls

The wider strip removes more text, so the risk is that it blinds the check. Three arms — a body with a genuine orphan figure, one whose figure appears in an exhibit, and one citing a Discover permalink:

| | before | after |
|---|---|---|
| genuine orphan figure | FAIL | **FAIL** |
| figure present in an exhibit | PASS | **PASS** |
| body citing a Discover permalink | **FAIL** | **PASS** |

The first row is the one that matters: it shows the fix removed the false positive without removing the check's power. `node --test test/*.test.mjs` — 61/61.
