### PR TITLE
Stop the gate rejecting real test-file artifacts depending on which directory you publish from

### DIFF
--- a/domains/pr-workflow/skills/evidence/hooks/pr-evidence-gate.py
+++ b/domains/pr-workflow/skills/evidence/hooks/pr-evidence-gate.py
@@ -55,6 +55,12 @@ def main():
 
     cmd = (payload.get("tool_input") or {}).get("command", "")
 
+    # Resolve the repo the claim is about, so repo-relative artifact paths can be checked
+    # against that checkout rather than against wherever this shell happens to be.
+    global _TARGET_REPO_NAME  # noqa: PLW0603 - one value, set once, read by _repo_roots
+    _m = re.search(r"(?:--repo\s+|github\.com/|repos/)[\w.-]+/([\w.-]+)", cmd)
+    _TARGET_REPO_NAME = _m.group(1) if _m else ""
+
     is_porcelain = bool(GH_PORCELAIN.search(cmd))
     is_api = bool(GH_API.search(cmd)) and re.search(r"(?:-F|-f|--field|--raw-field)\s+body=|--input\b", cmd)
     if not (is_porcelain or is_api):
@@ -559,13 +565,57 @@ def _url_is_credible(url):
     return True
 
 
-def _local_ref_exists(ref):
+# Set from the publish command's --repo, so a repo-relative path can be resolved against
+# the repository the claim is actually about rather than against wherever the hook ran.
+_TARGET_REPO_NAME = ""
+
+
+def _repo_roots():
+    """Directories a repo-relative reference could resolve against.
+
+    The hook does not run from the repo under review — it runs wherever the publishing
+    shell happened to be. Checking only cwd meant a real `shared/lib/trace.test.ts` was
+    reported as fabricated whenever the publish came from a parent directory, which is
+    the normal case.
+    """
+    roots = [os.getcwd(), os.environ.get("CLAUDE_PROJECT_DIR") or ""]
+    try:
+        top = subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                             capture_output=True, text=True, timeout=5)
+        if top.returncode == 0:
+            roots.append(top.stdout.strip())
+    except Exception:  # noqa: BLE001 - absence of git is not a verdict
+        pass
+    if _TARGET_REPO_NAME:
+        base = os.getcwd()
+        for cand in (os.path.join(base, _TARGET_REPO_NAME),
+                     os.path.join(os.path.dirname(base), _TARGET_REPO_NAME)):
+            roots.append(cand)
+    return [r for r in roots if r and os.path.isdir(r)]
+
+
+def _local_ref_state(ref):
+    """'found' | 'missing' | 'unverifiable'.
+
+    The three are genuinely different and collapsing them is what broke this. 'missing'
+    means we looked in a real checkout and it is not there — that is a fabricated path.
+    'unverifiable' means there was nowhere to look, and reporting that as fabricated
+    blocks legitimate publishing from outside the repo.
+    """
     if os.path.isabs(ref):
-        return os.path.exists(ref)
-    for root in (os.getcwd(), os.environ.get("CLAUDE_PROJECT_DIR") or ""):
-        if root and os.path.exists(os.path.join(root, ref)):
-            return True
-    return False
+        return "found" if os.path.exists(ref) else "missing"
+    roots = _repo_roots()
+    if not roots:
+        return "unverifiable"
+    for root in roots:
+        if os.path.exists(os.path.join(root, ref)):
+            return "found"
+    # Only claim 'missing' from a root that actually looks like a checkout; otherwise we
+    # are asserting absence from a tree that was never going to contain it.
+    for root in roots:
+        if os.path.isdir(os.path.join(root, ".git")):
+            return "missing"
+    return "unverifiable"
 
 
 def _has_credible_artifact(unit, pattern):
@@ -576,8 +626,19 @@ def _has_credible_artifact(unit, pattern):
         if _url_is_credible(url):
             return True
     for m in _LOCAL_REF_RE.finditer(unit):
-        ref = m.group(1) or m.group(2)
-        if ref and _local_ref_exists(ref):
+        test_ref, capture_ref = m.group(1), m.group(2)
+        ref = test_ref or capture_ref
+        if not ref:
+            continue
+        state = _local_ref_state(ref)
+        if state == "found":
+            return True
+        # A test/spec path is listed in this gate's own contract as an acceptable
+        # artifact — the reviewer resolves it in the PR's repo, not on the publisher's
+        # disk. So when there is no checkout to check against, accept it. A capture
+        # (.png/.log/.json) is not accepted on the same terms: a local path to a capture
+        # is not something a reader can open, so it has to be real or re-hosted.
+        if state == "unverifiable" and test_ref:
             return True
     return False
 


### PR DESCRIPTION
Follow-up to #112. The credible-artifact check it added rejects real artifacts as fabricated, depending on which directory the publish runs from.

## The defect

`_local_ref_exists` resolved a repo-relative path against `cwd` and `CLAUDE_PROJECT_DIR` only. But the hook does not run from the repo under review — it runs wherever the publishing shell happened to be, which is normally a parent directory holding several checkouts.

So citing a real test file was refused:

> `[verdict]` — *needs: an inspectable ARTIFACT (https:// permalink, `/blob/<sha>/`, or a `*.test.ts` ref)*, raised against a paragraph whose only artifact was a repo-relative path to a test file.

`shared/lib/trace.test.ts` exists. The same body published cleanly from inside the repo and was blocked from one directory up. Hit while publishing evidence to `MetaMask/metamask-extension#43931`; worked around there with blob permalinks, which is better evidence anyway but is not a fix.

Note the message names `a *.test.ts ref` as acceptable — so the check was refusing something its own contract admits.

## The fix

The check was collapsing three different states into a boolean. They are now distinguished:

| state | meaning |
|---|---|
| `found` | the path resolves in some candidate root |
| `missing` | we looked in a real checkout and it is not there — **fabricated** |
| `unverifiable` | there was nowhere to look |

`_repo_roots` widens the candidates to the git toplevel and to a checkout named after the publish command's `--repo`, so the common case resolves and `missing` stays meaningful instead of being an artifact of where the shell was.

On `unverifiable`, a **test/spec** path is accepted and a **capture** is not. The asymmetry is deliberate: the reviewer resolves a test path in the PR's repo, not on the publisher's disk. A capture (`.png`/`.log`/`.json`) is not acceptable on those terms, because a local path to a capture is not something a reader can open at all — it has to exist or be re-hosted.

## Controls

Run from inside the repo and from the parent directory, since the bug only appears in the second:

| | inside repo | parent dir |
|---|---|---|
| real test path | credible | **NOT credible → credible** |
| fabricated test path | not credible | not credible |
| fabricated capture | not credible | not credible |

The middle row is the one that matters. Widening the search must not let an invented path through, and it does not — the target-repo root is found, so the check can still report `missing`.

`gate-controls.sh` 11/11 including all three negative arms; `node --test test/*.test.mjs` 61/61.

## Known, not fixed here

Writing this PR tripped a different instance of the same shape: quoting the gate's own
output inside a fenced block raises `verdict` and `data-only-exhibit` against the quoted
text. #112 excluded fenced blocks from the artifact *trigger* (`_is_evidence_artifact`)
but not from the per-unit scan, so documenting a rule still violates it. Left for a
separate change rather than folded in here — this PR is one defect.
