### PR TITLE
feat: Adds `shield` domain - `/deploy-batch-collector` skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- feat(shield): add `deploy-batch-collector` skill for Shield contracts.
 - Add opt-in stale project skill pruning via `--prune-stale` and `SKILLS_PRUNE_STALE=1`.
 - docs(testing): document CV stale-press flakiness plus high-leverage assert patterns (migration parity, filter both-sides example, loading/skeleton honesty, RefreshControl + flag overrides) in `mobile-testing` component-view and placement refs.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ questions above, which no check can answer.
    - `scripts/` — Helper scripts (bash, Python, etc.)
    - `adapters/` — Optional runtime payloads used by scripts
    - `repos/<consuming-repo>.md` — Repo-specific overlays (`metamask-extension.md`,
-     `metamask-mobile.md`, `core.md`)
+     `metamask-mobile.md`, `core.md`, `shield-contracts.md`)
 
 6. **Test your skill** — Install locally against a consumer repo before submitting.
    `--repo` must match the repo you are installing into:

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Two audiences share this repo:
    `smart-accounts-kit`, OpenCode plugin, etc.). Drop them into your
    editor/agent and it will operate the tooling correctly.
 2. **MetaMask product engineers** — skills under `domains/perps/`,
-   `domains/testing/`, `domains/pr-workflow/`, `domains/agentic/`, etc. carry the conventions
-   and review heuristics for `metamask-extension`, `metamask-mobile`, and `core`.
+   `domains/testing/`, `domains/pr-workflow/`, `domains/agentic/`,
+   `domains/shield/`, etc. carry the conventions and review heuristics for
+   `metamask-extension`, `metamask-mobile`, `core`, and `shield-contracts`.
    These install into consumer repos via a small CLI.
 
 Single source of truth, multi-operator output (Claude Code, Cursor,
@@ -369,6 +370,7 @@ domains/<area>/
     repos/metamask-extension.md   # optional repo overlay
     repos/metamask-mobile.md      # optional repo overlay
     repos/core.md                 # optional Core monorepo overlay
+    repos/shield-contracts.md     # optional Shield contracts overlay
 ```
 
 ### `skill.md` frontmatter
@@ -394,7 +396,7 @@ deliberately. It is enforced by `yarn audit:skills` from
 
 ```yaml
 ---
-repo: metamask-extension  # or metamask-mobile / core
+repo: metamask-extension  # or metamask-mobile / core / shield-contracts
 parent: <skill-name>
 ---
 ```

--- a/domains/shield/skills/deploy-batch-collector/repos/shield-contracts.md
+++ b/domains/shield/skills/deploy-batch-collector/repos/shield-contracts.md
@@ -1,0 +1,35 @@
+---
+repo: shield-contracts
+parent: deploy-batch-collector
+---
+
+# shield-contracts overlay
+
+Copy the newest existing chain.
+
+## Files to touch
+
+| File | What to add |
+| --- | --- |
+| `script/Config.sol` | `networks[<chainId>] = NetworkConfig({name, chainId, isTestnet, blockExplorerUrl})` |
+| `foundry.toml` `[etherscan]` | `<slug> = { key = "${<EXPLORER>_API_KEY}", chain = <id>, url = "https://api.etherscan.io/v2/api?chainid=<id>" }` |
+| `make/BatchCollectorUpgradeable.mk` | `deploy-<slug>`, `upgrade-<slug>`, `verify-<slug>`, `verify-proxy-<slug>` plus `.PHONY` |
+| `.env.example` | `<SLUG>_RPC_URL=` and `<EXPLORER>_API_KEY=` |
+| `README.md` | deploy / upgrade / verify / verify-proxy commands and Networks list |
+
+Makefile `--verify` flags must include `--verifier etherscan --verifier-url https://api.etherscan.io/v2/api?chainid=<id>`.
+
+`script/VerifyContract.s.sol` already builds the V2 URL from `block.chainid` when `VERIFIER_URL` is unset. Keep it that way.
+
+## Commands
+
+```bash
+make -f make/BatchCollectorUpgradeable.mk deploy-<slug>
+make -f make/BatchCollectorUpgradeable.mk verify-<slug>
+make -f make/BatchCollectorUpgradeable.mk verify-proxy-<slug>
+make -f make/BatchCollectorUpgradeable.mk upgrade-<slug>
+```
+
+Broadcast path: `broadcast/DeployBatchCollectorUpgradeable.s.sol/<chainId>/`.
+
+Mainnet `Config.sol` logs `WARNING: Deploying to MAINNET` before broadcast.

--- a/domains/shield/skills/deploy-batch-collector/skill.md
+++ b/domains/shield/skills/deploy-batch-collector/skill.md
@@ -1,0 +1,103 @@
+---
+name: deploy-batch-collector
+description: >-
+  Add a chain and deploy, verify, or upgrade BatchCollectorUpgradeable in
+  Shield contracts. Use when asked to deploy the Shield batch collector on a
+  new chain or add network support.
+maturity: stable
+---
+
+# Deploy BatchCollectorUpgradeable
+
+Copy the newest existing chain in the consumer repo rather than inventing a new layout.
+
+Do not commit `.env`, private keys, or secrets. Broadcast JSON is a local record only; it does not lock on-chain permissions.
+
+## When to use
+
+- Add a new EVM chain to Shield contracts
+- Deploy / verify / upgrade `BatchCollectorUpgradeable` on a chain
+
+## Prerequisites
+
+- Foundry (`forge`, `cast`). Confirm `forge --version` knows the chain before enabling `--verify`.
+- Env file copied from the repo example (never commit secrets).
+- Chain ID, RPC URL, explorer URL, and an Etherscan API V2 key.
+
+## Workflow
+
+### 1. Collect chain facts
+
+Need: slug, chain ID, RPC env name, explorer API env name, explorer site, mainnet vs testnet.
+
+### 2. Patch network wiring
+
+Copy the newest existing chain. Add the chain to network config, explorer verification, deploy/upgrade/verify commands, env example, and docs.
+
+Existing chains already use Etherscan API V2 (`https://api.etherscan.io/v2/api?chainid=<id>`). Copy that URL. Do not introduce a V1 explorer endpoint.
+
+### 3. Choose roles before broadcasting
+
+`ADMIN_ADDRESS` can grant/revoke roles and authorize UUPS upgrades. `OPERATOR_ADDRESS` submits `collectPayments`. `TREASURY_ADDRESS` receives withdrawals.
+
+- Test deploy: set admin, operator, and treasury to one address you control so withdrawals do not need extra signers.
+- Prod deploy: use the real role split. Confirm who holds `ADMIN_PRIVATE_KEY` before promising an upgrade.
+
+The deployer key (`DEPLOYER_PRIVATE_KEY`) only needs gas. It does not have to be admin.
+
+### 4. Deploy
+
+Run the consumer repo's `deploy-<slug>` target. Required: deployer key, admin, operator, treasury, and RPC. Explorer key optional but recommended.
+
+If Foundry reports `Chain <id> not supported`, upgrade Foundry or drop `--verify` for this chain, deploy, then verify with the `verify-*` targets.
+
+### 5. If verify fails after a successful broadcast
+
+On-chain deploy already happened. Do not redeploy. Set implementation, proxy, and the same constructor/initialize addresses, then run `verify-<slug>` and `verify-proxy-<slug>`.
+
+### 6. Keep broadcast logs
+
+Foundry writes `broadcast/<Script>/<chainId>/run-latest.json`.
+
+- Commit `run-latest.json`.
+- If `run-<timestamp>.json` is missing, copy `run-latest.json` to `run-<timestamp>.json` using the `timestamp` field inside the JSON.
+- Do not use `--resume` against another account's logs. A new deployer key is not blocked by old files.
+- Upgrading the existing proxy requires the on-chain admin key (`ADMIN_PRIVATE_KEY`), not the original deployer.
+
+### 7. Format and PR
+
+After a Foundry bump, run `forge fmt` before pushing. Include broadcast artifacts in the PR. Never include `.env`.
+
+## Examples
+
+### Add a chain, then deploy
+
+User: "Deploy BatchCollector to `<chain>` for testing."
+
+Agent: add the chain using Etherscan V2; set test roles to one controllable address; run `deploy-<slug>`; if verify fails, run `verify-<slug>` and `verify-proxy-<slug>`; commit broadcast JSON.
+
+### Later deploy with a different key
+
+User: "Redeploy with a different deployer account."
+
+Agent: do not `--resume`. Use the new `DEPLOYER_PRIVATE_KEY` and the intended `ADMIN_ADDRESS` / `OPERATOR_ADDRESS` / `TREASURY_ADDRESS`. Old broadcast files are logs only.
+
+## Troubleshooting
+
+**`You are using a deprecated V1 endpoint`**
+Use `https://api.etherscan.io/v2/api?chainid=<id>` for verification.
+
+**`Chain <id> not supported` during `--verify`**
+Foundry is too old for that chain. Upgrade, or deploy without `--verify` and verify separately.
+
+**CI `forge fmt --check` fails after a Foundry upgrade**
+Run `forge fmt` and push. Do not mix formatting with unrelated edits if CI is already red.
+
+**Cannot withdraw after a test collect**
+Treasury is a different address, or you are not admin. Admin can change treasury/operator; only treasury receives tokens.
+
+## Security considerations
+
+- Never print, commit, or paste `DEPLOYER_PRIVATE_KEY` / `ADMIN_PRIVATE_KEY`.
+- Confirm chain, roles, and RPC before `--broadcast` on mainnet.
+- Upgrade is UUPS: only `ADMIN_ROLE` on the proxy can upgrade.

--- a/tools/skill-schema.mjs
+++ b/tools/skill-schema.mjs
@@ -23,7 +23,7 @@ export const BUNDLE_DIRS = ['references', 'scripts', 'assets', 'adapters', 'work
 // delivers it via copy_domain_knowledge.
 export const ALLOWED_SIBLING_DIRS = [...BUNDLE_DIRS, 'repos'];
 
-export const KNOWN_REPOS = ['metamask-extension', 'metamask-mobile', 'core'];
+export const KNOWN_REPOS = ['metamask-extension', 'metamask-mobile', 'core', 'shield-contracts'];
 
 // The description is always loaded into the operator's discovery surface, so it is the
 // per-skill always-on cost, and the only part of a skill that carries its own trigger


### PR DESCRIPTION
## Description

Adds a product-engineer skill for adding an EVM chain and deploying, verifying, or upgrading `BatchCollectorUpgradeable` in `consensys-vertical-apps/shield-contracts`.

The skill is generic (copy the newest existing chain; placeholders for slug/chain ID). It does not include chain-specific examples or secrets.

## Type of Change

- [x] New skill
- [ ] Skill improvement/update
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## Skill Details (if adding a new skill)

**Provider Name:** MetaMask / Shield
**Skill Name:** `deploy-batch-collector`
**Brief Description:** Walk an agent through adding a chain and deploying, verifying, or upgrading `BatchCollectorUpgradeable` in `shield-contracts`.

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/MetaMask/skills/blob/main/CONTRIBUTING.md) guidelines
- [x] My skill follows the [SKILL_TEMPLATE.md](https://github.com/MetaMask/skills/blob/main/.github/SKILL_TEMPLATE.md) format
- [x] I have tested this skill with an AI agent
- [x] My skill does not contain any secrets, private keys, or sensitive data
- [x] I have added appropriate documentation
- [x] My changes don't break existing skills

## Testing

- `node .github/scripts/lint-skill-entry.mjs domains/shield/skills/deploy-batch-collector/skill.md` — 0 errors, 0 warnings
- Overlay frontmatter uses `repo: shield-contracts` and `parent: deploy-batch-collector`
- `shield-contracts` added to `KNOWN_REPOS` so overlay lint does not warn

## Additional Context

**Who it is for:** Shield / product engineers working in `shield-contracts`.

**Layout:**
- Domain: `domains/shield/`
- Skill: `domains/shield/skills/deploy-batch-collector/skill.md`
- Overlay: `domains/shield/skills/deploy-batch-collector/repos/shield-contracts.md`

Also wires `shield-contracts` into README/CONTRIBUTING overlay examples and `tools/skill-schema.mjs`.
