### PR TITLE
feat: add skill to analyze cpu performance in any swaps related feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `swaps-cpu-profile-audit` skill for MetaMask Mobile: parse a recorded Hermes / React Native Release Profiler `.cpuprofile` and audit slow frames in swaps/bridge. ([#123](https://github.com/MetaMask/skills/pull/123))
 - Add opt-in stale project skill pruning via `--prune-stale` and `SKILLS_PRUNE_STALE=1`.
 - docs(testing): document CV stale-press flakiness plus high-leverage assert patterns (migration parity, filter both-sides example, loading/skeleton honesty, RefreshControl + flag overrides) in `mobile-testing` component-view and placement refs.
 

--- a/domains/swaps/skills/swaps-cpu-profile-audit/repos/metamask-mobile.md
+++ b/domains/swaps/skills/swaps-cpu-profile-audit/repos/metamask-mobile.md
@@ -1,0 +1,276 @@
+---
+repo: metamask-mobile
+parent: swaps-cpu-profile-audit
+---
+
+# Swaps CPU Profile Audit — MetaMask Mobile
+
+Audits a `.cpuprofile` already captured via
+[`docs/readme/release-build-profiler.md`](../../../../../../docs/readme/release-build-profiler.md).
+Nothing here touches a device, a simulator, Metro, or an `mm` session — it is
+pure file analysis. Subject: `app/components/UI/Bridge/**`.
+
+## Recording (human, not this skill)
+
+Recording a fresh profile is manual, on-device work the user does themselves,
+per `docs/readme/release-build-profiler.md`:
+
+1. Build/install an **RC build** (dev builds are not representative).
+2. On the device, **shake** → the **Performance Profiler** menu appears.
+3. **Start**, reproduce the swaps/bridge flow, **Stop**.
+4. iOS: **Export** the file (Share sheet). Android: it lands in Downloads
+   automatically.
+
+This skill's job starts once that `.cpuprofile` exists somewhere on disk. If
+the user has not recorded one yet, point them at that doc rather than trying
+to drive a device yourself.
+
+## Step 1 — Locate the profile and the source maps
+
+Ask for (or find) the `.cpuprofile` path — typically named
+`sampling-profiler-trace*.cpuprofile` or similar. Source maps are optional but
+the entire point of this skill is scoping findings to
+`app/components/UI/Bridge/**`, which needs original file paths — without a
+source map, frames stay at the minified-bundle level and almost nothing will
+match. If the user doesn't have sourcemaps yet, get them one of two ways:
+
+**From a local RC build (matches the profile exactly, and is what the
+Performance Profiler UI itself requires — `METAMASK_ENVIRONMENT=rc`):**
+
+```bash
+# iOS — the "Bundle JS Code & Upload Sentry Files" Xcode phase always writes this
+yarn build:ios:main:rc
+ls -la sourcemaps/ios/index.js.map
+
+# Android — the RN Gradle plugin's Hermes compose step always writes this
+# (variant is prodRelease for the `main` flavor)
+yarn build:android:main:rc
+ls -la android/app/build/generated/sourcemaps/react/prodRelease/index.android.bundle.map
+```
+
+**From CI, if the profile came from a CI-built RC instead:** GitHub Actions
+artifacts from the `Build Mobile App` (`build.yml`) workflow —
+`ios-sourcemaps-main-rc` (contains `index.js.map`) or
+`android-sourcemaps-main-rc` (contains `index.android.bundle.map`). Download
+and unzip.
+
+Two traps, either of which silently produces an unusable or missing map:
+
+- **A `yarn watch` / Metro dev-server map does not work here.** Metro's
+  `/index.map` endpoint (what `react-native-release-profiler`'s
+  `--generate-sourcemap` falls back to) serves a **dev** bundle map, which
+  does not correctly symbolicate a **release** Hermes profile — different
+  minification, different module IDs. Always use the Release/RC-build map
+  above, not a running watcher.
+- **`yarn gen-bundle:ios` / `gen-bundle:android` do not pass
+  `--sourcemap-output`** (as of this writing) — running them produces a
+  bundle with no map at all. Don't use them for this.
+
+If no source maps exist at all, proceed anyway (Step 2 is skippable) but say
+so explicitly in the final report — the audit becomes best-effort.
+
+## Step 2 — Symbolicate (skip only if already converted, or no sourcemaps)
+
+```bash
+cd <metamask-mobile>
+yarn react-native-release-profiler --local /path/to/profile.cpuprofile --sourcemap-path /path/to/sourcemaps
+```
+
+This writes `<profile>-converted.json` in the current directory — a JSON
+**array** of Chrome-trace Begin/End duration events, each carrying
+`args.url` / `args.line` / `args.column` resolved to original `app/...`
+source when the source map covers that frame. Without `--sourcemap-path`, run
+the same command anyway — it still produces a converted JSON, just with
+unresolved (minified) names/paths.
+
+## Step 3 — Aggregate with the bundled analyzer
+
+The script ships inside this skill, installed under whichever harness
+directory `yarn skills` wrote to. Probe for it rather than hardcoding one
+path — which of these exists depends on which harnesses were synced, and
+that can differ per directory:
+
+```bash
+cd <metamask-mobile>
+
+for AC in \
+  .claude/skills/mms-swaps-cpu-profile-audit/scripts/analyze-cpuprofile.cjs \
+  .cursor/rules/mms-swaps-cpu-profile-audit/scripts/analyze-cpuprofile.cjs \
+  .agents/skills/mms-swaps-cpu-profile-audit/scripts/analyze-cpuprofile.cjs
+do
+  [ -f "$AC" ] && break
+done
+if [ ! -f "${AC:-}" ]; then
+  echo "analyze-cpuprofile.cjs not found under .claude, .cursor, or .agents." >&2
+  echo "Run 'yarn skills' to (re)sync it, then retry." >&2
+  exit 1
+fi
+
+node "$AC" --profile /path/to/profile-converted.json
+```
+
+It is **read-only** — plain Node, no dependencies, no network, no repo
+writes — so it needs no sandbox permission beyond reading the profile file
+and this repo. It auto-detects the input shape (converted JSON array, or a
+raw un-converted `.cpuprofile` object as a fallback) and prints a Markdown
+report to stdout: capture duration, a by-area self-time breakdown, and the
+top in-scope (`app/components/UI/Bridge/**`) frames. Frames outside that
+scope are never itemized — the "Time spent in swaps/bridge" line's
+percentage is the only signal about them, on purpose, since this skill's
+whole job is staying scoped to swaps. Useful flags:
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--scope <substring>` | `components/UI/Bridge` | What counts as "in scope". Rarely needs changing. |
+| `--top <n>` | `40` | How many ranked frames to list per section. |
+| `--json` | off | Emit the aggregated JSON instead of Markdown (for further scripting). |
+| `--out <path>` | stdout | Write the report to a file instead of printing it. |
+
+The report header prints the capture's actual duration as a plain value in
+the "Metric | Value" table — no ideal/minimum comparison for now, just the
+raw timing:
+
+```
+| Metric | Value |
+|---|---|
+| Capture length | ~10s |
+```
+
+Use judgment on whether that duration looks long enough to cover the full
+swaps/bridge journey (quote fetch, screen transitions, animations) and say
+so in Step 6 (confidence) if it looks short.
+
+Read the Markdown report yourself before writing the final audit — it is raw
+aggregated data, not the finished analysis. Step 4 below is where the actual
+audit work happens.
+
+### Optional: one-shot wrapper (`scripts/run.sh`)
+
+If the input is an archive (a zipped sourcemaps CI artifact, or a bundle
+containing the `.cpuprofile` alongside other files) or you'd simply rather
+not run Steps 2–3 by hand, `scripts/run.sh` (next to `analyze-cpuprofile.cjs`
+in this skill) does the whole staging → convert → aggregate pipeline in one
+call. Every file it extracts, converts, or writes (staged input, extracted
+archives, the `*-converted.json`, the final report) goes under a throwaway
+run folder created **inside the metamask-mobile repo itself**
+(`<repo>/.mms-swaps-cpu-audit-run.XXXXXX/`), which is deleted automatically
+when the script exits — success, failure, or interrupted — so nothing is
+left on disk afterwards and there is no manual cleanup step. (An earlier
+version of this script staged everything under the OS tmp directory instead;
+that made `yarn --cwd <repo> react-native-release-profiler` resolve
+Corepack's pinned Yarn version inconsistently, since Corepack determines the
+version from the `packageManager` field by walking up from the shell's
+actual cwd, not from `--cwd`. Anchoring the run folder inside the repo, and
+always invoking `yarn` with the repo as cwd, avoids that.)
+
+```bash
+for RC in \
+  .claude/skills/mms-swaps-cpu-profile-audit/scripts/run.sh \
+  .cursor/rules/mms-swaps-cpu-profile-audit/scripts/run.sh \
+  .agents/skills/mms-swaps-cpu-profile-audit/scripts/run.sh
+do
+  [ -f "$RC" ] && break
+done
+
+bash "$RC" \
+  --repo <metamask-mobile> \
+  --profile /path/to/profile.cpuprofile-or-converted.json-or-archive.zip \
+  --sourcemaps /path/to/sourcemaps-dir-or.zip   # optional
+```
+
+It prints the same Markdown report `analyze-cpuprofile.cjs` would produce
+directly, so Step 4 below still applies unchanged — by the time it returns,
+its run folder has already been removed.
+
+## Step 4 — Area map (how self time attributes to a swaps surface)
+
+The analyzer buckets any in-scope frame by matching its resolved source path
+against `app/components/UI/Bridge/**` subfolders, most-specific first. This
+mirrors the directory as of the time this was written — re-run
+`find app/components/UI/Bridge -maxdepth 2 -type d` if it looks stale, and
+update `AREA_MAP` in the script if the tree has been restructured:
+
+| Path fragment | Reported area | User-facing surface |
+|---|---|---|
+| `Views/BridgeView` | Swaps/Bridge screen (BridgeView) | Main swaps screen |
+| `components/BridgeTokenSelector` | Asset picker (token selector modal) | Asset picker |
+| `components/QuoteSelectorView` | Quote select screen | Quote select screen |
+| `components/QuoteDetailsCard`, `QuoteDetailsRecipientKeyValueRow` | Quote details card | Quote select screen |
+| `components/QuoteCountdownTimer` | Quote countdown timer | Quote select screen |
+| `components/PostTradeBottomSheet`, `components/TransactionDetails` | Post-trade modal | Post-trade modal |
+| `Views/BatchSellReview` | Batch sell — review | Batch sell |
+| `Views/BatchSellTokenSelect` | Batch sell — token select | Batch sell |
+| `components/BatchSell*Modal` | Batch sell — \<modal\> | Batch sell |
+| `components/TokenInputArea` | Token input area | Main swaps screen |
+| `components/SwapsKeypad` | Keypad | Main swaps screen |
+| `components/SlippageModal` | Slippage modal | Slippage modal |
+| `components/BlockaidModal`, `HighRateAlertModal`, `PriceImpactModal`, `MissingPriceModal`, `TokenWarningModal`, `MarketClosedBottomSheets` | \<respective\> modal | Warning/alert modals |
+| `hooks/` | Bridge hooks | (cross-cutting — attribute to whichever screen calls the hook) |
+| `utils/` | Bridge utils | (cross-cutting) |
+| anywhere else under `Bridge/` | Bridge (other / unmapped subfolder) | Unmapped — read the file to place it |
+
+Frames under `hooks/` or `utils/` are cross-cutting: the analyzer buckets
+them into "Bridge hooks"/"Bridge utils" rather than a specific screen, so
+when one shows up hot, check its call sites (`grep -rn "useTheHookName("
+app/components/UI/Bridge`) to say which screen actually pays for it in the
+report.
+
+## Step 5 — Diagnose and propose fixes
+
+For every in-scope hot frame, read the actual source at `file:line` (and its
+immediate call site) before writing a finding — self/total time tells you
+*where*, not *why*. Match what you read against the `performance` skill's
+verified anti-pattern catalogue and cite its fix recipe rather than
+improvising:
+
+| Symptom in the code | Guide |
+|---|---|
+| Selector returns a new array/object/identity, or mutates | `mm-selector-memoization.md` |
+| Hook builds a fresh array/object/function and returns it without `useMemo`/`useCallback` | `mm-unstable-hook-return.md` |
+| `useSelector(x, isEqual)` band-aid, inline `useSelector(state => state.x)` | `mm-redux-antipatterns.md` |
+| `Context.Provider value={{...}}` inline object | `mm-context-performance.md` |
+| `JSON.stringify` in a `useEffect`/`useMemo` dependency array | `mm-hook-dependency-arrays.md` |
+| Screen/modal fetches everything on mount instead of what's visible | `mm-eager-work-on-mount.md` |
+| `FlatList`/`ScrollView` rendering a growing list without perf props | `js-lists-flatlist-flashlist.md` |
+| `useNativeDriver: false` animating layout properties | `mm-layout-animations.md` |
+
+These guides live in the `performance` skill
+(`domains/performance/skills/performance/references/`) — read the specific
+guide before proposing the fix in your report, don't just cite the filename.
+
+## Worked example
+
+```bash
+$ yarn react-native-release-profiler --local ~/Downloads/sampling-profiler-trace-1699999999.cpuprofile \
+    --sourcemap-path ~/Downloads/ios-sourcemaps-main-rc
+Successfully converted to Chrome tracing format and pulled the file to ./sampling-profiler-trace-1699999999-converted.json
+
+$ node .agents/skills/mms-swaps-cpu-profile-audit/scripts/analyze-cpuprofile.cjs \
+    --profile ./sampling-profiler-trace-1699999999-converted.json
+# CPU profile audit — scope: `components/UI/Bridge`
+
+| Metric | Value |
+|---|---|
+| Format detected | converted |
+| Capture length | ~5s |
+| Distinct frames sampled | 42 |
+| Time spent in swaps/bridge | 1234.56 ms (82.3% of all sampled time) |
+
+## By area (self time)
+| Area | Time (ms) | % of swaps time | # of hot spots |
+|---|---|---|---|
+| Quote select screen | 612.40 | 41.2% | 6 |
+| Asset picker (token selector modal) | 398.10 | 26.8% | 4 |
+...
+```
+
+This raw table is aggregated data, not the finished audit — read it, then
+open the top frame in "Quote select screen" (say,
+`app/components/UI/Bridge/components/QuoteSelectorView/index.tsx:88`), read
+what it's actually doing, and turn it into a plain-language row in the final
+report's probable-cause/fix table (see `skill.md`'s Output format; the
+`Metric`/`By area` tables above are reused as-is in the final report):
+
+| Screen | Probable cause | Fix |
+|---|---|---|
+| Quote select screen | Re-sorts the entire quote list every time the screen re-renders — sort comparator is inline and not memoized — 612ms, 6x, `QuoteSelectorView/index.tsx:88` | Wrap in `useMemo` keyed on the quote list identity (see `mm-unstable-hook-return.md` if the list itself has no stable reference either) |

--- a/domains/swaps/skills/swaps-cpu-profile-audit/scripts/analyze-cpuprofile.cjs
+++ b/domains/swaps/skills/swaps-cpu-profile-audit/scripts/analyze-cpuprofile.cjs
@@ -1,0 +1,447 @@
+#!/usr/bin/env node
+//
+// analyze-cpuprofile.js — aggregate self/total JS time from a Hermes /
+// React Native Release Profiler CPU capture, scoped to the swaps/bridge
+// screen tree (app/components/UI/Bridge/** in metamask-mobile).
+//
+// Read-only: it only reads the profile (and prints/writes a report). It
+// never touches a device, Metro, or the repository.
+//
+// Input (auto-detected):
+//   1. Preferred — the Chrome-trace JSON produced by:
+//        yarn react-native-release-profiler --local <profile.cpuprofile> \
+//          --sourcemap-path <sourcemaps-dir-or-file>
+//      i.e. a JSON ARRAY of Begin/End duration events (the "*-converted.json"
+//      file). With sourcemaps applied, `args.url`/`args.line`/`args.column`
+//      point at ORIGINAL app source, which is what makes swaps-tree scoping
+//      possible. Without `--sourcemap-path`, the array still parses, but
+//      names/paths stay at the minified-bundle level and almost nothing will
+//      match `--scope`.
+//   2. Fallback — a raw Hermes `.cpuprofile` (an OBJECT with `samples` and
+//      `stackFrames`), i.e. the file before conversion. No sourcemap
+//      resolution is attempted in this mode; only usable when the recorded
+//      build already preserved readable names/paths (dev-ish bundles).
+//
+// Usage:
+//   node analyze-cpuprofile.js --profile <path> \
+//     [--scope <substring>] [--top <n>] [--out <path>] [--json]
+//
+// Exit code is always 0 on a successful parse (there is nothing to "fail" —
+// an empty in-scope result is a valid, reportable finding). Exit 1 on a
+// missing/unparseable file.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// Everything owned by the swaps/bridge team in metamask-mobile, mirroring the
+// breadth of a CODEOWNERS-style boundary (e.g. `**/bridge/**`,
+// `**/bridge-status/**`, `ui/pages/swaps`, `app/scripts/controllers/swaps` in
+// metamask-extension's `.github/CODEOWNERS`) rather than just the
+// `app/components/UI/Bridge/**` screen tree. Re-verify with
+// `find app -type d \( -iname '*bridge*' -o -iname '*swap*' \)` if the tree
+// has been restructured since this was written.
+const DEFAULT_SCOPE_ROOTS = [
+  'components/UI/Bridge',
+  'core/redux/slices/bridge',
+  'reducers/swaps',
+  'selectors/bridgeController',
+  'selectors/bridgeStatusController',
+  'selectors/featureFlagController/swapsChainValueOrderOverride',
+  'core/Engine/controllers/bridge-controller',
+  'core/Engine/controllers/bridge-status-controller',
+  'core/Engine/messengers/bridge-controller-messenger',
+  'core/Engine/messengers/bridge-status-controller-messenger',
+  'util/bridge',
+  'util/notifications/notification-states/swap-completed',
+  'components/UI/MultichainBridgeTransactionListItem',
+  'components/UI/HardwareWallet/Swaps',
+  'components/Views/confirmations/components/rows/bridge-fee-row',
+  'components/Views/confirmations/components/rows/bridge-time-row',
+  'components/Views/confirmations/components/activity/transaction-details-bridge-fee-row',
+];
+
+function parseArgs(argv) {
+  const args = { scope: DEFAULT_SCOPE_ROOTS.join(','), top: 40, json: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '--profile') args.profile = argv[++i];
+    else if (a === '--scope') args.scope = argv[++i];
+    else if (a === '--top') args.top = Number(argv[++i]);
+    else if (a === '--out') args.out = argv[++i];
+    else if (a === '--json') args.json = true;
+    else if (a === '--help' || a === '-h') args.help = true;
+  }
+  return args;
+}
+
+function printHelp() {
+  const lines = [];
+  for (const line of fs.readFileSync(__filename, 'utf8').split('\n')) {
+    if (line.startsWith('#!')) continue; // shebang
+    if (!line.startsWith('//')) break; // leading header comment block only
+    lines.push(line.replace(/^\/\/ ?/, ''));
+  }
+  process.stderr.write(lines.join('\n') + '\n');
+}
+
+// Ordered, most-specific first. Matched as a substring of the resolved
+// source path. Mirrors app/components/UI/Bridge/** in metamask-mobile —
+// re-verify against `find app/components/UI/Bridge -maxdepth 2 -type d` if
+// that tree has been restructured since this was written.
+const AREA_MAP = [
+  ['Views/BridgeView', 'Swaps/Bridge screen (BridgeView)'],
+  ['components/BridgeTokenSelector', 'Asset picker (token selector modal)'],
+  ['components/QuoteSelectorView', 'Quote select screen'],
+  ['components/QuoteDetailsRecipientKeyValueRow', 'Quote details card'],
+  ['components/QuoteDetailsCard', 'Quote details card'],
+  ['components/QuoteCountdownTimer', 'Quote countdown timer'],
+  ['components/PostTradeBottomSheet', 'Post-trade modal'],
+  ['components/TransactionDetails', 'Post-trade modal'],
+  ['Views/BatchSellReview', 'Batch sell \u2014 review'],
+  ['Views/BatchSellTokenSelect', 'Batch sell \u2014 token select'],
+  ['components/BatchSellDestinationTokenSelectorModal', 'Batch sell \u2014 destination token selector'],
+  ['components/BatchSellFinalReviewModal', 'Batch sell \u2014 final review modal'],
+  ['components/BatchSellMinimumReceivedInfoModal', 'Batch sell \u2014 info modal'],
+  ['components/BatchSellNetworkFeeInfoModal', 'Batch sell \u2014 info modal'],
+  ['components/BatchSellPriceImpactInfoModal', 'Batch sell \u2014 info modal'],
+  ['components/BatchSellQuoteDetailsModal', 'Batch sell \u2014 quote details modal'],
+  ['components/TokenInputArea', 'Token input area'],
+  ['components/SwapsKeypad', 'Keypad'],
+  ['components/SlippageModal', 'Slippage modal'],
+  ['components/FlipQuoteButton', 'Flip quote button'],
+  ['components/BlockaidModal', 'Security alert modal'],
+  ['components/HighRateAlertModal', 'Security alert modal'],
+  ['components/PriceImpactModal', 'Price impact modal'],
+  ['components/MissingPriceModal', 'Missing price modal'],
+  ['components/TokenWarningModal', 'Token warning modal'],
+  ['components/MarketClosedBottomSheets', 'Market closed modal'],
+  ['components/RecipientSelectorModal', 'Recipient selector modal'],
+  ['components/GaslessQuickPickOptions', 'Gasless quick-pick options'],
+  ['components/SwapDiscoveryFeed', 'Swap discovery feed'],
+  ['components/BridgeTrendingTokensSection', 'Trending tokens section'],
+  ['components/RobinhoodSwapsBanner', 'Robinhood banner'],
+  ['components/SwapsConfirmButton', 'Confirm button'],
+  ['components/InputStepper', 'Input stepper'],
+  ['components/CollapsibleBottomSheet', 'Collapsible bottom sheet'],
+  // Swaps/bridge-owned code outside the `components/UI/Bridge` screen tree
+  // (redux state, selectors, controller wiring, app-level utils,
+  // confirmations rows, notifications). See DEFAULT_SCOPE_ROOTS above.
+  ['core/redux/slices/bridge', 'Bridge redux state'],
+  ['reducers/swaps', 'Swaps redux state (legacy)'],
+  ['selectors/bridgeStatusController', 'Bridge status selectors'],
+  ['selectors/bridgeController', 'Bridge controller selectors'],
+  ['selectors/featureFlagController/swapsChainValueOrderOverride', 'Swaps feature-flag selectors'],
+  ['core/Engine/controllers/bridge-status-controller', 'BridgeStatusController wiring'],
+  ['core/Engine/controllers/bridge-controller', 'BridgeController wiring'],
+  ['core/Engine/messengers/bridge-status-controller-messenger', 'BridgeStatusController messenger'],
+  ['core/Engine/messengers/bridge-controller-messenger', 'BridgeController messenger'],
+  ['util/notifications/notification-states/swap-completed', 'Swap-completed notification'],
+  ['util/bridge', 'Bridge utils (app-level)'],
+  ['components/UI/MultichainBridgeTransactionListItem', 'Multichain bridge tx history item'],
+  ['components/UI/HardwareWallet/Swaps', 'Hardware wallet swaps'],
+  ['components/Views/confirmations/components/rows/bridge-fee-row', 'Confirmations \u2014 bridge fee row'],
+  ['components/Views/confirmations/components/rows/bridge-time-row', 'Confirmations \u2014 bridge time row'],
+  [
+    'components/Views/confirmations/components/activity/transaction-details-bridge-fee-row',
+    'Confirmations \u2014 bridge fee row (tx details)',
+  ],
+  ['hooks/', 'Bridge hooks'],
+  ['utils/', 'Bridge utils'],
+];
+
+function areaFor(sourcePath, scopeRoots) {
+  if (!sourcePath) return null;
+  if (!scopeRoots.some((root) => sourcePath.includes(root))) return null;
+  for (let i = 0; i < AREA_MAP.length; i += 1) {
+    if (sourcePath.includes(AREA_MAP[i][0])) return AREA_MAP[i][1];
+  }
+  return 'Bridge (other / unmapped subfolder)';
+}
+
+// Best-effort recovery of `(path:line:col)` out of a Hermes-style function
+// name when no source map was available to resolve `args.url` properly.
+function extractPathFromName(name) {
+  if (!name) return null;
+  const m = /\(([^()]+):(\d+):(\d+)\)\s*$/.exec(name);
+  if (!m) return null;
+  return { url: m[1], line: Number(m[2]), column: Number(m[3]) };
+}
+
+function newFrame(key, name, url, line, category) {
+  return { key, name, url: url || null, line: line || null, category: category || 'unknown', selfMicros: 0, totalMicros: 0, calls: 0 };
+}
+
+// --- Path 1: converted Chrome-trace JSON (array of B/E duration events) ---
+//
+// Produced by `hermes-profile-transformer` via the `react-native-release-profiler`
+// CLI. Events are emitted in a strictly nested (LIFO) B/E stream in ts order,
+// so a single-pass stack replay recovers both self time (whichever frame is
+// on top of the stack between two consecutive events owns that time slice)
+// and total/inclusive time (span from a frame's B to its matching E).
+function analyzeConverted(events) {
+  const frames = new Map();
+  const stack = [];
+  let lastTs = events.length > 0 ? Number(events[0].ts) : 0;
+  const firstTs = lastTs;
+  let maxTs = lastTs;
+
+  const keyFor = (ev) => {
+    const args = ev.args || {};
+    const url = args.url || (extractPathFromName(ev.name) || {}).url || null;
+    const line = args.line != null ? Number(args.line) : (extractPathFromName(ev.name) || {}).line || null;
+    const name = args.params || ev.name || args.allocatedName || 'anonymous';
+    const category = args.node_module || args.allocatedCategory || ev.cat || 'unknown';
+    return { key: `${name}::${url || category}::${line || ''}`, name, url, line, category };
+  };
+
+  for (const ev of events) {
+    const ts = Number(ev.ts);
+    const dt = ts - lastTs;
+    if (stack.length > 0 && dt > 0) {
+      const top = stack[stack.length - 1];
+      top.frame.selfMicros += dt;
+    }
+    lastTs = ts;
+    if (ts > maxTs) maxTs = ts;
+
+    if (ev.ph === 'B') {
+      const info = keyFor(ev);
+      let frame = frames.get(info.key);
+      if (!frame) {
+        frame = newFrame(info.key, info.name, info.url, info.line, info.category);
+        frames.set(info.key, frame);
+      }
+      stack.push({ frame, beginTs: ts });
+    } else if (ev.ph === 'E') {
+      const popped = stack.pop();
+      if (popped) {
+        popped.frame.totalMicros += ts - popped.beginTs;
+        popped.frame.calls += 1;
+      }
+    }
+  }
+
+  return { frames, durationMicros: maxTs - firstTs };
+}
+
+// --- Path 2: raw Hermes .cpuprofile (samples + stackFrames), no conversion ---
+//
+// `samples[i].sf` names the leaf stack frame active at sample i; `stackFrames`
+// is a flat map with a `parent` pointer per frame. Self time is credited to
+// the leaf; total time is credited to every frame on the leaf's ancestor
+// chain. No source-map resolution happens here — run the CLI conversion
+// first (see skill docs) whenever you have sourcemaps, and reserve this path
+// for when you don't.
+function analyzeRawHermes(profile) {
+  const { samples, stackFrames } = profile;
+  const frames = new Map();
+  const ancestorCache = new Map();
+
+  const ancestorsOf = (sf) => {
+    if (ancestorCache.has(sf)) return ancestorCache.get(sf);
+    const chain = [];
+    let cur = sf;
+    const guard = new Set();
+    while (cur != null && stackFrames[cur] && !guard.has(cur)) {
+      guard.add(cur);
+      chain.push(cur);
+      cur = stackFrames[cur].parent;
+    }
+    ancestorCache.set(sf, chain);
+    return chain;
+  };
+
+  const frameFor = (sf) => {
+    const raw = stackFrames[sf];
+    if (!raw) return null;
+    const recovered = extractPathFromName(raw.name);
+    const url = recovered ? recovered.url : null;
+    const line = raw.line != null ? Number(raw.line) : recovered ? recovered.line : null;
+    const key = `${raw.name}::${sf}`;
+    let frame = frames.get(key);
+    if (!frame) {
+      frame = newFrame(key, raw.name || 'anonymous', url, line, raw.category);
+      frames.set(key, frame);
+    }
+    return frame;
+  };
+
+  let firstTs = null;
+  let lastTs = null;
+  let prevTs = null;
+  for (const sample of samples) {
+    const ts = Number(sample.ts);
+    if (firstTs === null) firstTs = ts;
+    lastTs = ts;
+    const dt = prevTs === null ? 0 : Math.max(ts - prevTs, 0);
+    prevTs = ts;
+    if (dt === 0) continue;
+
+    const leaf = frameFor(sample.sf);
+    if (leaf) leaf.selfMicros += dt;
+
+    for (const sf of ancestorsOf(sample.sf)) {
+      const frame = frameFor(sf);
+      if (frame) {
+        frame.totalMicros += dt;
+        frame.calls += 1;
+      }
+    }
+  }
+
+  return { frames, durationMicros: (lastTs || 0) - (firstTs || 0) };
+}
+
+function loadProfile(profilePath) {
+  const raw = fs.readFileSync(profilePath, 'utf8');
+  const data = JSON.parse(raw);
+  if (Array.isArray(data)) {
+    return { format: 'converted', ...analyzeConverted(data) };
+  }
+  if (data && Array.isArray(data.samples) && data.stackFrames) {
+    return { format: 'raw-hermes', ...analyzeRawHermes(data) };
+  }
+  throw new Error(
+    'Unrecognised profile shape: expected either an array of B/E trace events ' +
+      '(the "-converted.json" from `yarn react-native-release-profiler`) or a raw ' +
+      'Hermes .cpuprofile object with `samples` + `stackFrames`.',
+  );
+}
+
+function buildReport(analysis, opts) {
+  const { frames, durationMicros, format } = analysis;
+  const scope = opts.scope;
+  const scopeRoots = scope
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const all = Array.from(frames.values());
+  for (const f of all) {
+    f.area = areaFor(f.url || f.name, scopeRoots);
+  }
+  all.sort((a, b) => b.selfMicros - a.selfMicros);
+
+  const inScope = all.filter((f) => f.area !== null);
+  const outOfScope = all.filter((f) => f.area === null);
+
+  const byArea = new Map();
+  for (const f of inScope) {
+    if (!byArea.has(f.area)) byArea.set(f.area, { area: f.area, selfMicros: 0, totalMicros: 0, frames: [] });
+    const bucket = byArea.get(f.area);
+    bucket.selfMicros += f.selfMicros;
+    bucket.totalMicros = Math.max(bucket.totalMicros, f.totalMicros);
+    bucket.frames.push(f);
+  }
+  const areas = Array.from(byArea.values()).sort((a, b) => b.selfMicros - a.selfMicros);
+
+  const durationMs = durationMicros / 1000;
+
+  return {
+    format,
+    scope,
+    durationMs,
+    durationSeconds: durationMs / 1000,
+    totalFrames: all.length,
+    inScopeSelfMicros: inScope.reduce((s, f) => s + f.selfMicros, 0),
+    outOfScopeSelfMicros: outOfScope.reduce((s, f) => s + f.selfMicros, 0),
+    areas,
+    topInScope: inScope.slice(0, opts.top),
+    topOutOfScope: outOfScope.slice(0, Math.min(10, opts.top)),
+  };
+}
+
+function ms(micros) {
+  return (micros / 1000).toFixed(2);
+}
+
+function pct(part, whole) {
+  if (!whole) return '0.0';
+  return ((part / whole) * 100).toFixed(1);
+}
+
+function renderMarkdown(report) {
+  const lines = [];
+  const scopeRoots = report.scope.split(',').map((s) => s.trim()).filter(Boolean);
+  const scopeLabel = scopeRoots.length > 1 ? `${scopeRoots.length} swaps/bridge-owned paths` : scopeRoots[0];
+  lines.push(`# CPU profile audit \u2014 scope: ${scopeLabel}`);
+  if (scopeRoots.length > 1) {
+    lines.push('');
+    lines.push('<details><summary>Scope roots</summary>');
+    lines.push('');
+    for (const r of scopeRoots) lines.push(`- \`${r}\``);
+    lines.push('');
+    lines.push('</details>');
+  }
+  lines.push('');
+  const totalSelf = report.inScopeSelfMicros + report.outOfScopeSelfMicros;
+  lines.push('| Metric | Value |');
+  lines.push('|---|---|');
+  lines.push(`| Format detected | ${report.format} |`);
+  lines.push(`| Capture length | ~${Math.round(report.durationSeconds)}s |`);
+  lines.push(`| Distinct frames sampled | ${report.totalFrames} |`);
+  lines.push(
+    `| Time spent in swaps/bridge | ${ms(report.inScopeSelfMicros)} ms (${pct(report.inScopeSelfMicros, totalSelf)}% of all sampled time) |`,
+  );
+  lines.push('');
+  lines.push('## By area (self time)');
+  lines.push('');
+  lines.push('| Area | Time (ms) | % of swaps time | # of hot spots |');
+  lines.push('|---|---|---|---|');
+  const totalInScope = report.inScopeSelfMicros || 1;
+  for (const a of report.areas) {
+    lines.push(`| ${a.area} | ${ms(a.selfMicros)} | ${pct(a.selfMicros, totalInScope)}% | ${a.frames.length} |`);
+  }
+  lines.push('');
+  lines.push('## Top in-scope frames by self time');
+  lines.push('');
+  lines.push('| # | Time (ms) | Total (ms) | Calls | Area | Function | Source |');
+  lines.push('|---|---|---|---|---|---|---|');
+  report.topInScope.forEach((f, i) => {
+    const src = f.url ? `${f.url}${f.line ? ':' + f.line : ''}` : '(unsymbolicated)';
+    lines.push(`| ${i + 1} | ${ms(f.selfMicros)} | ${ms(f.totalMicros)} | ${f.calls} | ${f.area} | \`${f.name}\` | ${src} |`);
+  });
+  if (report.topInScope.length === 0) {
+    lines.push('| \u2014 | \u2014 | \u2014 | \u2014 | \u2014 | *no frame under this scope matched* | \u2014 |');
+  }
+  lines.push('');
+  // Frames outside `--scope` are deliberately not listed here (not even as
+  // context) \u2014 this tool's job is swaps/bridge only. The "% of all sampled
+  // time" metric above already tells you how much of the capture they ate.
+  return lines.join('\n');
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help || !args.profile) {
+    printHelp();
+    process.exit(args.help ? 0 : 1);
+  }
+
+  const profilePath = path.resolve(args.profile);
+  if (!fs.existsSync(profilePath)) {
+    process.stderr.write(`No such file: ${profilePath}\n`);
+    process.exit(1);
+  }
+
+  let analysis;
+  try {
+    analysis = loadProfile(profilePath);
+  } catch (e) {
+    process.stderr.write(`Failed to parse ${profilePath}: ${e.message}\n`);
+    process.exit(1);
+  }
+
+  const report = buildReport(analysis, args);
+
+  const output = args.json ? JSON.stringify(report, null, 2) : renderMarkdown(report);
+  if (args.out) {
+    fs.writeFileSync(path.resolve(args.out), output, 'utf-8');
+    process.stderr.write(`Wrote report to ${path.resolve(args.out)}\n`);
+  } else {
+    process.stdout.write(output + '\n');
+  }
+}
+
+main();

--- a/domains/swaps/skills/swaps-cpu-profile-audit/scripts/run.sh
+++ b/domains/swaps/skills/swaps-cpu-profile-audit/scripts/run.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+#
+# run.sh — one-shot runner for the swaps-cpu-profile-audit skill
+# (domains/swaps/skills/swaps-cpu-profile-audit) against metamask-mobile.
+#
+# This script itself lives in the skill's own scripts/ directory (alongside
+# analyze-cpuprofile.cjs). Everything it EXTRACTS, CONVERTS, or WRITES —
+# staged input, extracted archives, the *-converted.json, the final Markdown
+# report — is written under a throwaway run folder created *inside the
+# target repo* (not the OS tmp directory). That run folder, and everything
+# under it, is removed automatically when the script exits, whether it
+# succeeds, fails, or is interrupted — nothing is left on disk afterwards.
+#
+# Why not the OS tmp directory: routing the working folder through
+# $TMPDIR/os.tmpdir() and then calling `yarn --cwd <repo> ...` from inside it
+# made Corepack resolve the wrong Yarn version — Corepack picks the pinned
+# version from the `packageManager` field by walking up from the shell's
+# *actual* cwd at invocation time, not from `--cwd`, so running from a tmp
+# folder with no package.json in its ancestry made it fall back to whatever
+# Corepack/Yarn happened to be active globally instead of the repo's pinned
+# version. Anchoring the run folder inside the repo (and always invoking
+# `yarn` with the repo itself as cwd) avoids that entirely.
+#
+# Usage:
+#   run.sh --repo <path-to-metamask-mobile> --profile <path> [--sourcemaps <path>] [--scope <substring>] [--top <n>]
+#
+# <path> for --profile can be:
+#   - a raw .cpuprofile
+#   - an already-converted *-converted.json
+#   - a .zip/.tar/.tar.gz archive containing one of the above (it will be
+#     extracted into the run folder first)
+#   - any of the above renamed to a non-standard extension (e.g.
+#     `sampling-profiler-trace123.cpuprofile.txt`, from a chat tool that only
+#     allows attaching `.txt`) — if no file matches the expected extensions,
+#     the script sniffs each staged file's JSON *content* to tell a
+#     converted trace (JSON array) from a raw Hermes capture (JSON object
+#     with `samples` + `stackFrames`), regardless of its name
+#
+# <path> for --sourcemaps (optional) can be:
+#   - a directory containing index.js.map / index.android.bundle.map
+#   - a .zip archive of a sourcemaps CI artifact (it will be extracted into
+#     the run folder first)
+#
+# All intermediate and output files are written under a per-run subdirectory
+# created inside the repo, e.g.:
+#   <repo>/.mms-swaps-cpu-audit-run.XXXXXX/
+# and deleted automatically (via an EXIT trap) before this script returns.
+#
+set -euo pipefail
+
+REPO=""
+PROFILE=""
+SOURCEMAPS=""
+SCOPE="components/UI/Bridge"
+TOP="40"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo) REPO="$2"; shift 2 ;;
+    --profile) PROFILE="$2"; shift 2 ;;
+    --sourcemaps) SOURCEMAPS="$2"; shift 2 ;;
+    --scope) SCOPE="$2"; shift 2 ;;
+    --top) TOP="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,30p' "$0"
+      exit 0
+      ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [ -z "$REPO" ] || [ -z "$PROFILE" ]; then
+  echo "Usage: run.sh --repo <path-to-metamask-mobile> --profile <path> [--sourcemaps <path>] [--scope <substring>] [--top <n>]" >&2
+  exit 1
+fi
+
+if [ ! -d "$REPO" ]; then
+  echo "No such repo directory: $REPO" >&2
+  exit 1
+fi
+if [ ! -e "$PROFILE" ]; then
+  echo "No such profile/archive: $PROFILE" >&2
+  exit 1
+fi
+REPO="$(cd "$REPO" && pwd)"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+RUNDIR="$(mktemp -d "$REPO/.mms-swaps-cpu-audit-run.XXXXXX")"
+cleanup() {
+  rm -rf "$RUNDIR"
+}
+trap cleanup EXIT
+mkdir -p "$RUNDIR/input" "$RUNDIR/sourcemaps"
+echo "Working directory (removed automatically when this script exits): $RUNDIR" >&2
+
+# --- Stage the profile into the run folder ----------------------------------
+case "$PROFILE" in
+  *.zip)
+    unzip -q "$PROFILE" -d "$RUNDIR/input"
+    ;;
+  *.tar.gz|*.tgz)
+    tar -xzf "$PROFILE" -C "$RUNDIR/input"
+    ;;
+  *.tar)
+    tar -xf "$PROFILE" -C "$RUNDIR/input"
+    ;;
+  *)
+    cp "$PROFILE" "$RUNDIR/input/"
+    ;;
+esac
+
+# --- Stage sourcemaps (optional) into the run folder ------------------------
+if [ -n "$SOURCEMAPS" ]; then
+  if [ -d "$SOURCEMAPS" ]; then
+    cp -R "$SOURCEMAPS"/. "$RUNDIR/sourcemaps/"
+  else
+    case "$SOURCEMAPS" in
+      *.zip) unzip -q "$SOURCEMAPS" -d "$RUNDIR/sourcemaps" ;;
+      *.tar.gz|*.tgz) tar -xzf "$SOURCEMAPS" -C "$RUNDIR/sourcemaps" ;;
+      *.tar) tar -xf "$SOURCEMAPS" -C "$RUNDIR/sourcemaps" ;;
+      *) cp "$SOURCEMAPS" "$RUNDIR/sourcemaps/" ;;
+    esac
+  fi
+fi
+
+# --- Locate (or produce) the converted JSON ---------------------------------
+CONVERTED="$(find "$RUNDIR/input" -iname '*-converted.json' -print -quit)"
+RAW_CPUPROFILE="$(find "$RUNDIR/input" -iname '*.cpuprofile' -print -quit)"
+RAW_JSON="$(find "$RUNDIR/input" -iname '*.json' ! -iname '*-converted.json' -print -quit)"
+
+# Extension-based detection above misses files whose real extension was
+# stripped or replaced (commonly `.cpuprofile.txt` / `.json.txt`, e.g. from a
+# chat tool that only allows attaching `.txt`). Fall back to sniffing file
+# *content*: a converted trace is a JSON array of B/E duration events; a raw
+# Hermes capture is a JSON object with `samples` + `stackFrames`. This is the
+# same shape check analyze-cpuprofile.cjs's loadProfile() already does, just
+# performed here first so we know which staged file to hand it when the
+# filename itself gives no hint.
+if [ -z "$CONVERTED" ] && [ -z "$RAW_CPUPROFILE" ] && [ -z "$RAW_JSON" ]; then
+  SNIFFED="$(node -e '
+    const fs = require("fs");
+    const path = require("path");
+    const dir = process.argv[1];
+    for (const entry of fs.readdirSync(dir)) {
+      const p = path.join(dir, entry);
+      if (!fs.statSync(p).isFile()) continue;
+      let data;
+      try {
+        data = JSON.parse(fs.readFileSync(p, "utf8"));
+      } catch {
+        continue;
+      }
+      if (Array.isArray(data)) {
+        process.stdout.write(p + "\tconverted\n");
+        break;
+      }
+      if (data && Array.isArray(data.samples) && data.stackFrames) {
+        process.stdout.write(p + "\traw\n");
+        break;
+      }
+    }
+  ' "$RUNDIR/input")"
+  if [ -n "$SNIFFED" ]; then
+    SNIFFED_PATH="${SNIFFED%%$'\t'*}"
+    SNIFFED_KIND="${SNIFFED##*$'\t'}"
+    echo "No file matched by extension; sniffed content of $SNIFFED_PATH as a $SNIFFED_KIND profile." >&2
+    if [ "$SNIFFED_KIND" = "converted" ]; then
+      CONVERTED="$SNIFFED_PATH"
+    else
+      RAW_CPUPROFILE="$SNIFFED_PATH"
+    fi
+  fi
+fi
+
+if [ -z "$CONVERTED" ] && [ -n "$RAW_CPUPROFILE" ]; then
+  echo "Converting raw .cpuprofile via yarn react-native-release-profiler (output stays in the run folder)..." >&2
+  # Always invoke yarn with the repo itself as cwd (not the run folder) so
+  # Corepack resolves the repo's pinned packageManager version correctly —
+  # see the header comment above for why this matters.
+  if [ -n "$SOURCEMAPS" ] && [ -n "$(ls -A "$RUNDIR/sourcemaps" 2>/dev/null)" ]; then
+    ( cd "$REPO" && yarn --cwd "$REPO" react-native-release-profiler --local "$RAW_CPUPROFILE" --sourcemap-path "$RUNDIR/sourcemaps" --output "$RUNDIR/input" )
+  else
+    echo "WARNING: no sourcemaps provided — findings will stay at the minified-bundle level and almost nothing will resolve to app/components/UI/Bridge/**." >&2
+    ( cd "$REPO" && yarn --cwd "$REPO" react-native-release-profiler --local "$RAW_CPUPROFILE" --output "$RUNDIR/input" )
+  fi
+  CONVERTED="$(find "$RUNDIR/input" -iname '*-converted.json' -print -quit)"
+fi
+
+if [ -z "$CONVERTED" ] && [ -n "$RAW_JSON" ]; then
+  # Already-converted JSON that just doesn't match the *-converted.json naming.
+  CONVERTED="$RAW_JSON"
+fi
+
+if [ -z "$CONVERTED" ]; then
+  echo "Could not find a converted JSON, raw .cpuprofile, or usable JSON under $RUNDIR/input" >&2
+  exit 1
+fi
+
+echo "Using profile: $CONVERTED" >&2
+
+# --- Locate the analyzer script (read-only; never copied/written) -----------
+# Prefer the copy co-located with this script (the skill's own source of
+# truth); fall back to whichever harness directory `yarn skills` synced into
+# the target repo, in case this runner is ever invoked standalone/copied
+# without its sibling analyze-cpuprofile.cjs.
+ANALYZER=""
+if [ -f "$SCRIPT_DIR/analyze-cpuprofile.cjs" ]; then
+  ANALYZER="$SCRIPT_DIR/analyze-cpuprofile.cjs"
+else
+  for AC in \
+    "$REPO/.claude/skills/mms-swaps-cpu-profile-audit/scripts/analyze-cpuprofile.cjs" \
+    "$REPO/.cursor/rules/mms-swaps-cpu-profile-audit/scripts/analyze-cpuprofile.cjs" \
+    "$REPO/.agents/skills/mms-swaps-cpu-profile-audit/scripts/analyze-cpuprofile.cjs"
+  do
+    if [ -f "$AC" ]; then ANALYZER="$AC"; break; fi
+  done
+fi
+
+if [ -z "$ANALYZER" ]; then
+  echo "analyze-cpuprofile.cjs not found next to run.sh, nor under .claude, .cursor, or .agents in $REPO." >&2
+  echo "Run 'yarn skills' in $REPO to (re)sync it, then retry." >&2
+  exit 1
+fi
+
+REPORT="$RUNDIR/report.md"
+node "$ANALYZER" --profile "$CONVERTED" --scope "$SCOPE" --top "$TOP" --out "$REPORT"
+
+# Capture the report content now — the run folder (including this file) is
+# removed by the EXIT trap as soon as the script returns.
+REPORT_CONTENT="$(cat "$REPORT")"
+
+echo "" >&2
+echo "Run folder will be removed automatically now that the report is generated (nothing is left on disk)." >&2
+echo "" >&2
+printf '%s\n' "$REPORT_CONTENT"

--- a/domains/swaps/skills/swaps-cpu-profile-audit/skill.md
+++ b/domains/swaps/skills/swaps-cpu-profile-audit/skill.md
@@ -1,0 +1,178 @@
+---
+name: swaps-cpu-profile-audit
+description: >-
+  Parse an already-recorded Hermes / React Native Release Profiler
+  `.cpuprofile` (ideally symbolicated with source maps) and audit it for slow
+  frames, scoping every finding and fix proposal to the swaps/bridge screen
+  and the modals or subpages it opens — quote select screen, post-trade
+  modal, batch sell, asset picker/token selector. Use when a user hands you a
+  `.cpuprofile` file (e.g. a `sampling-profiler-trace*.cpuprofile`, or its
+  already-converted `*-converted.json`) recorded per
+  `docs/readme/release-build-profiler.md` and asks to audit, analyze, explain,
+  or find why the swaps/bridge flow is slow based on that trace. This is an
+  offline, file-based analysis — no simulator, device, Metro, or `mm` session
+  is required, unlike `swaps-perf-audit` (which measures live render counts on
+  a running simulator). Findings and fix proposals are scoped strictly to
+  `app/components/UI/Bridge/**`; hot frames elsewhere in the trace are never
+  reported, not even as context. The report always leads with a timing table
+  (capture metrics + by-area self time) and a short outcome line, and only
+  adds a probable-cause/fix table when there's an actual swaps/bridge issue
+  to fix — no speculative text beyond that. MetaMask Mobile only.
+maturity: stable
+---
+
+# Swaps CPU Profile Audit
+
+Turns a captured Hermes CPU profile into a swaps/bridge-scoped performance
+audit: which frames under `app/components/UI/Bridge/**` actually burned time
+in the capture, which surface they belong to (main screen, quote select,
+post-trade, batch sell, asset picker, ...), and what to change. This skill
+owns the profile-parsing protocol and the swaps-tree scoping; the fix recipes
+themselves live in the `performance` skill, and the live on-device
+measurement counterpart is `swaps-perf-audit`.
+
+## When To Use
+
+Use when the user:
+
+- Hands you a `.cpuprofile` (or its converted JSON) and asks what's slow in
+  swaps/bridge, or to audit/analyze/explain it.
+- Asks "why is swaps slow" and already has a recorded trace, RC build
+  profiling session, or Release Profiler capture in hand.
+- Wants swaps performance fixes justified by trace evidence instead of a
+  static code sweep.
+
+Do not use for:
+
+- Recording a *new* profile live on a simulator/device, or driving the app —
+  that is manual, human-only work described in
+  `docs/readme/release-build-profiler.md` (shake the device, Start, reproduce,
+  Stop). This skill starts only once a `.cpuprofile` file already exists on
+  disk.
+- Live render-count / re-render measurement on a running simulator — use
+  `swaps-perf-audit`.
+- Non-swaps screens, or hot frames outside `app/components/UI/Bridge/**` —
+  never report or propose fixes for these, not even as context; point the
+  user at the general `performance` skill instead if they ask about
+  app-wide performance.
+- MetaMask Extension — Hermes/Release Profiler `.cpuprofile` capture doesn't
+  exist there; this skill installs only for `metamask-mobile`.
+
+## Workflow
+
+1. **Locate the inputs.** You need the `.cpuprofile` path. Source maps are
+   optional but strongly preferred — without them, frames stay at the
+   minified-bundle level and almost nothing will resolve to
+   `app/components/UI/Bridge/**`, which defeats the scoping this skill exists
+   to do. If the user has sourcemaps (from a local `--sourcemap-path` or a
+   `*-sourcemaps-<build>` CI artifact) but hasn't converted yet, do that next.
+2. **Symbolicate.** Convert the raw profile with the project's own tool,
+   which resolves bundle positions back to original `app/...` source paths:
+   ```bash
+   yarn react-native-release-profiler --local <profile.cpuprofile> --sourcemap-path <sourcemaps>
+   ```
+   This writes `<profile>-converted.json` next to the input. Skip this step
+   only if the user already has a converted JSON, or has no sourcemaps at
+   all (state clearly in the report that findings are then best-effort and
+   file/line attribution is unreliable).
+3. **Aggregate.** Run the bundled analyzer against the converted JSON (or the
+   raw `.cpuprofile` as a fallback — see the repo overlay for exact usage).
+   It reconstructs self time and total (inclusive) time per frame from the
+   sampling data, buckets in-scope frames by swaps surface
+   (`app/components/UI/Bridge/**` subfolder → BridgeView / QuoteSelectorView /
+   PostTradeBottomSheet / BatchSell\* / BridgeTokenSelector / ... — see the
+   repo overlay's area table), and drops out-of-scope frames from the printed
+   report entirely (it only surfaces what % of the capture they accounted
+   for, never a list of the actual out-of-scope files/functions). It also
+   reports the capture's actual duration (no ideal/minimum comparison for
+   now — just the raw timing).
+4. **Read the code at the hot frames.** A `file:line` with high self time is
+   a *symptom*, not a diagnosis — open the file, read the actual code at that
+   location and its call sites, and identify the concrete anti-pattern (dead
+   re-render, unmemoized sort/filter, unstable hook return, JSON.stringify in
+   a dependency array, etc.). Cross-reference the `performance` skill's
+   anti-pattern catalogue and per-pattern guides
+   (`mm-selector-memoization.md`, `mm-unstable-hook-return.md`,
+   `mm-redux-antipatterns.md`, `mm-hook-dependency-arrays.md`,
+   `mm-context-performance.md`, `mm-eager-work-on-mount.md`, etc.) for the fix
+   recipe rather than inventing one from scratch.
+5. **Always report the timing table; keep prose minimal.** Every report
+   leads with the timing data — the analyzer's `Metric | Value` block and its
+   by-area self-time breakdown — regardless of whether an issue was found.
+   Follow it with exactly one short line stating the outcome (whether
+   swaps/bridge code showed up as a meaningful cost). Never report frames
+   outside `app/components/UI/Bridge/**` — not as a fix target, not as
+   context, not at all; if the trace's biggest cost genuinely lives
+   elsewhere, simply omit it rather than mentioning it. Do not add
+   speculation, hedging, or suggestions about what to check/run next beyond
+   what's in Step 6 — the report is data plus outcome, nothing else.
+6. **If an issue was found, add a probable-cause/fix table — nothing more.**
+   One row per swaps-tree area with meaningful self time: the screen, the
+   probable cause in plain language (what's happening and why — not
+   "unmemoized selector" but e.g. "re-sorts the whole quote list every time
+   you interact with the screen", with the concrete anti-pattern and
+   `file:line`/self-ms/calls folded into that same cell), and the fix citing
+   the relevant `performance` skill guide. Do not append anything after this
+   table — no next-steps, no suggestion to re-run tests or capture a new
+   profile, no broader speculation. The only exception is a single factual
+   caveat line when something materially undermines the finding: no
+   sourcemaps were available (best-effort file/line attribution) or the
+   capture looks too short to cover the full journey (quote fetch, screen
+   transitions, animations). Skip that caveat whenever the capture and
+   findings look adequate.
+
+The exact commands, the swaps-tree area map, and the bundled analyzer's usage
+are in the repo overlay (`repos/metamask-mobile.md`).
+
+## Output format
+
+Always lead with the timing table (overview metrics + by-area self-time
+breakdown), then exactly one short outcome line. Never include a row/section
+for frames outside `app/components/UI/Bridge/**` — if the biggest cost in
+the trace lives elsewhere, leave it out entirely rather than noting it as
+context. Do not add anything beyond what's specified below — no
+speculation, no assumptions, no suggestions about what to check or run
+next.
+
+**No in-scope issue found:**
+
+```
+# CPU Profile Audit — swaps/bridge
+
+| Metric | Value |
+|---|---|
+| Capture length | ~<Xs> |
+| Time spent in swaps/bridge | <Y>ms (<Z>% of all sampled time) |
+
+| Area | Self time (ms) | % of swaps time | Hot spots |
+|---|---|---|---|
+| <Area> | <ms> | <%> | <n> |
+
+No meaningful swaps/bridge performance issue in this capture — <one-line factual summary, e.g. "only <Y>ms of self time total, from <what/where>">.
+```
+
+**Issue(s) found** — same two tables, plus a probable-cause/fix table. Keep
+it skimmable (a non-engineer should get the gist without decoding jargon);
+fold `file:line`/self-ms/calls detail into the "Probable cause" cell rather
+than adding separate columns:
+
+```
+# CPU Profile Audit — swaps/bridge
+
+| Metric | Value |
+|---|---|
+| Capture length | ~<Xs> |
+| Time spent in swaps/bridge | <Y>ms (<Z>% of all sampled time) |
+
+| Area | Self time (ms) | % of swaps time | Hot spots |
+|---|---|---|---|
+| <Area> | <ms> | <%> | <n> |
+
+Found <N> swaps/bridge issue(s) costing ~<Y>ms.
+
+| Screen | Probable cause | Fix |
+|---|---|---|
+| <Area, e.g. "Quote select screen"> | <plain-language root cause, e.g. "re-sorts the whole quote list every time you interact with the screen"> — <self>ms, <calls>x, `<file>:<line>` | <concrete fix> (see `<guide>.md`) |
+
+<optional single factual caveat line — only if sourcemaps were missing or the capture looked too short>
+```


### PR DESCRIPTION
## Description

Adds **`swaps-cpu-profile-audit`** under `domains/swaps/skills/`. The skill teaches AI agents how to turn an already-recorded Hermes / React Native Release Profiler `.cpuprofile` (ideally symbolicated with RC/release source maps) into a swaps/bridge-scoped CPU audit for **MetaMask Mobile**.

This is offline, file-based analysis. It does not drive a simulator, device, Metro, or `mm` session. Recording stays human-only (`docs/readme/release-build-profiler.md`). Live render-count measurement stays with `swaps-perf-audit`; fix recipes stay in the `performance` skill.

### What the skill covers

- **`skill.md`** — when to use / not use, the 6-step workflow (locate profile + sourcemaps → symbolicate → aggregate → read hot frames → timing-first report → probable-cause/fix table only if there is a real in-scope issue), and the required Markdown output format.
- **`repos/metamask-mobile.md`** — Mobile overlay: RC sourcemap sources, `yarn react-native-release-profiler` conversion, the Bridge area map (main screen, quote select, post-trade, batch sell, asset picker, related modals), and how to cite `performance` anti-pattern guides.
- **`scripts/analyze-cpuprofile.cjs`** — read-only Node analyzer (no deps, no network). Auto-detects converted Chrome-trace JSON or raw Hermes `.cpuprofile`, attributes self/total time, buckets in-scope frames by swaps surface, and prints a Markdown report. Default scope is swaps/bridge-owned Mobile paths (UI Bridge tree plus related redux, selectors, controller wiring, confirmations rows, etc.). Out-of-scope frames are never listed.
- **`scripts/run.sh`** — one-shot wrapper: stage profile/sourcemaps (including zip/tar and `.cpuprofile.txt` attachments), convert, aggregate, print the report, then delete a throwaway run folder inside the Mobile repo so Corepack resolves the pinned Yarn version.

Installs only for `metamask-mobile` as `mms-swaps-cpu-profile-audit`.

https://consensyssoftware.atlassian.net/browse/SWAPS-4932

## Type of Change

- [x] New skill
- [ ] Skill improvement/update
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## Skill Details (if adding a new skill)

**Provider Name:** MetaMask
**Skill Name:** `swaps-cpu-profile-audit` (domain: swaps)
**Brief Description:** Parse a recorded Hermes / React Native Release Profiler `.cpuprofile` and audit slow frames in MetaMask Mobile swaps/bridge (main screen, quote select, post-trade, batch sell, asset picker, and related swaps-owned code). Offline file analysis only — no device or `mm` session.

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/MetaMask/skills/blob/main/CONTRIBUTING.md) guidelines
- [x] My skill follows the [SKILL_TEMPLATE.md](https://github.com/MetaMask/skills/blob/main/.github/SKILL_TEMPLATE.md) format
- [x] I have tested this skill with an AI agent
- [x] My skill does not contain any secrets, private keys, or sensitive data
- [x] I have added appropriate documentation
- [x] My changes don't break existing skills

## Testing

- Walked the skill with an AI agent against the Mobile overlay and analyzer: confirmed batch-sell surfaces (`BatchSellReview`, `BatchSellTokenSelect`, `BatchSell*Modal`) are in the area map, and that the report protocol stays scoped (timing tables + outcome line; probable-cause/fix table only when an in-scope issue exists).
- `node domains/swaps/skills/swaps-cpu-profile-audit/scripts/analyze-cpuprofile.cjs --help` — analyzer starts and prints usage; it is read-only (reads the profile, writes only `--out` if asked).
- `bash domains/swaps/skills/swaps-cpu-profile-audit/scripts/run.sh --help` — wrapper usage; run folder is created under the target repo and removed on EXIT.
- Layout matches the installer schema: `skill.md` + `repos/metamask-mobile.md` + `scripts/` (allowed sibling dirs). Frontmatter has `name`, `description`, `maturity: stable`. Installs as `mms-swaps-cpu-profile-audit` for `metamask-mobile` only.

## Additional Context

Companion to `swaps-perf-audit` (live render counts on a running simulator) and the `performance` skill (anti-pattern fix recipes). This skill starts only after a `.cpuprofile` already exists on disk.

Reviewer note: `skill.md` still describes scope as strictly `app/components/UI/Bridge/**`, while `analyze-cpuprofile.cjs` defaults to a broader swaps/bridge-owned path set (redux, selectors, controller messengers, confirmations rows, etc.). The analyzer is the source of truth for what gets reported.