### PR TITLE
feat: improve swaps cpu audit skill to include info for wider context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Rewrite `CONTRIBUTING.md` and skill template for MetaMask/skills layout.
+- `swaps-cpu-profile-audit` now audits the whole capture instead of swaps-owned files only: non-swaps frames that ran while the user was on a swaps screen are classified by their relation to the swaps call stacks (called by swaps, hosts the swaps screen, or concurrent with it), bucketed into named context areas, and reported alongside swaps rows. Every reported row carries an `Owned by swaps` column, and fix depth is gated on it. New `--context-min-pct` and `--swaps-only` analyzer flags.
+- `swaps-cpu-profile-audit` reports swaps-owned areas, non-swaps areas on the swaps path, and non-swaps areas running concurrently as separate tables, so the per-area swaps detail is no longer diluted by context rows. The swaps table gained an inclusive-time column, and the report explains that self time on a leaf means a screen can trigger heavy work while showing ~0 ms of its own. Non-swaps rows in the fix table are now capped to the few that matter.
 
 ### Fixed
 

--- a/domains/swaps/skills/swaps-cpu-profile-audit/repos/metamask-mobile.md
+++ b/domains/swaps/skills/swaps-cpu-profile-audit/repos/metamask-mobile.md
@@ -8,7 +8,11 @@ parent: swaps-cpu-profile-audit
 Audits a `.cpuprofile` already captured via
 [`docs/readme/release-build-profiler.md`](../../../../../../docs/readme/release-build-profiler.md).
 Nothing here touches a device, a simulator, Metro, or an `mm` session — it is
-pure file analysis. Subject: `app/components/UI/Bridge/**`.
+pure file analysis. Subject: the swaps/bridge experience — swaps-owned code
+(`app/components/UI/Bridge/**` plus the swaps redux/selector/controller/util
+paths listed in `DEFAULT_SCOPE_ROOTS`) **and** the non-swaps code that burned
+JS-thread time in the same capture, each row tagged with whether swaps owns
+it.
 
 ## Recording (human, not this skill)
 
@@ -29,10 +33,12 @@ to drive a device yourself.
 
 Ask for (or find) the `.cpuprofile` path — typically named
 `sampling-profiler-trace*.cpuprofile` or similar. Source maps are optional but
-the entire point of this skill is scoping findings to
-`app/components/UI/Bridge/**`, which needs original file paths — without a
-source map, frames stay at the minified-bundle level and almost nothing will
-match. If the user doesn't have sourcemaps yet, get them one of two ways:
+the entire point of this skill is attributing time to real files — deciding
+what is swaps-owned, what area it belongs to, and how it relates to the swaps
+call stacks — which needs original file paths. Without a source map, frames
+stay at the minified-bundle level, nothing matches an ownership root, and
+every row collapses to "unknown". If the user doesn't have sourcemaps yet,
+get them one of two ways:
 
 **From a local RC build (matches the profile exactly, and is what the
 Performance Profiler UI itself requires — `METAMASK_ENVIRONMENT=rc`):**
@@ -54,34 +60,75 @@ artifacts from the `Build Mobile App` (`build.yml`) workflow —
 `android-sourcemaps-main-rc` (contains `index.android.bundle.map`). Download
 and unzip.
 
-Two traps, either of which silently produces an unusable or missing map:
+Four traps, each of which silently produces an unusable, mismatched or missing
+map:
 
 - **A `yarn watch` / Metro dev-server map does not work here.** Metro's
-  `/index.map` endpoint (what `react-native-release-profiler`'s
-  `--generate-sourcemap` falls back to) serves a **dev** bundle map, which
-  does not correctly symbolicate a **release** Hermes profile — different
-  minification, different module IDs. Always use the Release/RC-build map
-  above, not a running watcher.
+  `/index.map` endpoint serves a **dev** bundle map, which does not correctly
+  symbolicate a **release** Hermes profile — different minification, different
+  module IDs. Always use the Release/RC-build map above, not a running
+  watcher.
+- **Omitting `--sourcemap-path` does not mean "no source map".** The CLI then
+  calls its own `findSourcemap()`: it looks for an Android **debug** build map
+  under `android/app/build/**`, and otherwise downloads `/index.map` from
+  whatever Metro is listening on `--port` (default `8081`). So if you have
+  `yarn watch` running, an innocent-looking mapless conversion quietly feeds
+  the transformer a dev map — which crashes it
+  (`TypeError: Cannot read properties of undefined (reading 'map')` from
+  `source-map-consumer`) or, worse, succeeds with wrong attributions. To
+  convert genuinely without a map, stop Metro or pass a dead port
+  (`--port 0`), which is exactly what `scripts/run.sh` does.
 - **`yarn gen-bundle:ios` / `gen-bundle:android` do not pass
   `--sourcemap-output`** (as of this writing) — running them produces a
   bundle with no map at all. Don't use them for this.
+- **The map has to come from the build that produced the capture.** A map
+  built from a different commit still "works" — every position resolves to
+  *something* — but the names and lines belong to different code. The tell is a
+  report where function names don't match what's at that `file:line`, or where
+  frames that clearly ran resolve with no self time while `[root]` swallows the
+  capture. Check the two files' dates and the commit each came from; if they
+  disagree, say so in the report's caveat line and treat all `file:line`
+  attribution as unreliable rather than reasoning from it.
 
 If no source maps exist at all, proceed anyway (Step 2 is skippable) but say
-so explicitly in the final report — the audit becomes best-effort.
+so explicitly in the final report — the audit becomes best-effort, and the
+ownership column in particular cannot be trusted.
 
 ## Step 2 — Symbolicate (skip only if already converted, or no sourcemaps)
 
 ```bash
 cd <metamask-mobile>
-yarn react-native-release-profiler --local /path/to/profile.cpuprofile --sourcemap-path /path/to/sourcemaps
+yarn react-native-release-profiler \
+  --local /path/to/profile.cpuprofile \
+  --sourcemap-path /path/to/sourcemaps/index.js.map
 ```
 
-This writes `<profile>-converted.json` in the current directory — a JSON
-**array** of Chrome-trace Begin/End duration events, each carrying
-`args.url` / `args.line` / `args.column` resolved to original `app/...`
-source when the source map covers that frame. Without `--sourcemap-path`, run
-the same command anyway — it still produces a converted JSON, just with
-unresolved (minified) names/paths.
+Three things about this CLI, all of which bite:
+
+- **`--sourcemap-path` takes the `.map` file, not a directory or a zip.** The
+  transformer behind it does `readFile()` + `JSON.parse()` on that path, so a
+  directory fails with `EISDIR` and a zip fails to parse. Unzip a CI
+  sourcemaps artifact first and point at `index.js.map` (iOS) or
+  `index.android.bundle.map` (Android) inside it.
+- **There is no output-path flag.** `--output` / `--dstPath` do not exist
+  (passing one makes Commander exit with `unknown option`); the destination is
+  hardcoded to `.`, so the file always lands in the **current working
+  directory**. `cd` to where you want it, and expect the name
+  `<profile-basename-without-.cpuprofile>-converted.json`.
+- **Omitting `--sourcemap-path` makes it look for a map on its own** — see the
+  second trap in Step 1. Add `--port 0` (or stop Metro) when you deliberately
+  want a mapless conversion.
+
+The full option list, for reference: `--local`, `--filename`,
+`--sourcemap-path`, `--generate-sourcemap`, `--port`, `--appId`,
+`--appIdSuffix`, `--fromDownload`, `--raw`.
+
+The result is a JSON **array** of Chrome-trace Begin/End duration events,
+each carrying `args.url` / `args.line` / `args.column` resolved to original
+`app/...` source when the source map covers that frame. Without a source map
+you still get a converted JSON, but `args.url` holds the raw Hermes frame
+*name* rather than a path, so ownership and area attribution degrade to
+whatever the minified names happen to reveal.
 
 ## Step 3 — Aggregate with the bundled analyzer
 
@@ -113,18 +160,58 @@ It is **read-only** — plain Node, no dependencies, no network, no repo
 writes — so it needs no sandbox permission beyond reading the profile file
 and this repo. It auto-detects the input shape (converted JSON array, or a
 raw un-converted `.cpuprofile` object as a fallback) and prints a Markdown
-report to stdout: capture duration, a by-area self-time breakdown, and the
-top in-scope (`app/components/UI/Bridge/**`) frames. Frames outside that
-scope are never itemized — the "Time spent in swaps/bridge" line's
-percentage is the only signal about them, on purpose, since this skill's
-whole job is staying scoped to swaps. Useful flags:
+report to stdout with four parts:
+
+1. **Metrics** — format detected, capture duration, distinct frames,
+   attributable JS work, the runtime/idle total that was excluded from it,
+   then the JS work split three ways: swaps-owned (with the widest inclusive
+   swaps span underneath it), non-swaps on the swaps path, non-swaps running
+   concurrently.
+2. **Swaps-owned areas (self time)** — `Area | Time | % of swaps time |
+   Inclusive | # of hot spots`. The inclusive column is what saves you when
+   swaps self time is ~0: it shows the work swaps code set in motion.
+3. **Non-swaps areas on the swaps path** and **Non-swaps areas running
+   concurrently** — separate tables, so swaps detail is never diluted by
+   context. Reuse all three tables in the final report.
+4. **Runtime & idle** — `[root]` (wall time with no JS running) and GC, kept
+   visible but out of every percentage. Never a fix-table row.
+5. **Top swaps-owned frames** and **Top non-swaps frames** — ranked by self
+   time, with `file:line`, for the code reading in Step 5.
+
+Areas that neither did work nor triggered any are dropped entirely, so an
+empty row is a real signal rather than a formatting artefact.
+
+Useful flags:
 
 | Flag | Default | Purpose |
 |---|---|---|
-| `--scope <substring>` | `components/UI/Bridge` | What counts as "in scope". Rarely needs changing. |
+| `--scope <substring>` | the swaps-owned path list (`DEFAULT_SCOPE_ROOTS`) | Comma-separated substrings that define swaps ownership. Rarely needs changing; widen it only if swaps has taken over new paths not yet in the script. |
 | `--top <n>` | `40` | How many ranked frames to list per section. |
+| `--context-min-pct <n>` | `0.5` | Noise floor for non-swaps rows, as a % of attributable JS work (idle/GC excluded). Raise it on a noisy capture; drop to `0` to see everything. |
+| `--trigger-min-pct <n>` | `5` | How much work a *zero-self-time* swaps area must have triggered (inclusive, as a % of JS work) to earn a row. Stops screens whose module merely got evaluated — a batch-sell modal the user never opened — from appearing at `0.00 ms`. |
+| `--swaps-only` | off | Suppress the non-swaps and runtime tables (the aggregate metrics still show how much time they took). Only for a deliberately narrow swaps-only pass. |
 | `--json` | off | Emit the aggregated JSON instead of Markdown (for further scripting). |
 | `--out <path>` | stdout | Write the report to a file instead of printing it. |
+
+### Why swaps self time can read `0.00 ms`
+
+Self time is credited to the stack's leaf, and a React screen is rarely the
+leaf — it calls the reconciler, selectors and dependencies, which do the work.
+So `Swaps-owned code: 0.00 ms` alongside a large `Inclusive (ms)` means *swaps
+triggered the cost without spending it*, which is still a swaps finding: look
+at the `Called by swaps` rows and at the swaps call sites. Genuine "swaps did
+nothing" looks different — no swaps area rows at all, because nothing swaps
+owns even appeared on the stacks.
+
+Three other things produce a misleadingly small swaps number, all worth ruling
+out before writing the report:
+
+- **Most of the capture was idle.** Check the `Runtime & idle` row; if `[root]`
+  dominates, the user recorded mostly sitting still, and only the JS-work
+  numbers mean anything.
+- **The source map did not match the build.** See Step 1's fourth trap.
+- **The interesting interaction happened outside the capture window.** Compare
+  the capture length against the journey being audited.
 
 The report header prints the capture's actual duration as a plain value in
 the "Metric | Value" table — no ideal/minimum comparison for now, just the
@@ -178,15 +265,21 @@ bash "$RC" \
   --sourcemaps /path/to/sourcemaps-dir-or.zip   # optional
 ```
 
+It forwards `--scope`, `--top`, `--context-min-pct`, `--trigger-min-pct` and
+`--swaps-only` to the
+analyzer, and omits any you don't pass so the analyzer's own defaults apply.
+
 It prints the same Markdown report `analyze-cpuprofile.cjs` would produce
 directly, so Step 4 below still applies unchanged — by the time it returns,
 its run folder has already been removed.
 
-## Step 4 — Area map (how self time attributes to a swaps surface)
+## Step 4 — Area map (how self time attributes to a surface)
 
-The analyzer buckets any in-scope frame by matching its resolved source path
-against `app/components/UI/Bridge/**` subfolders, most-specific first. This
-mirrors the directory as of the time this was written — re-run
+### Swaps-owned areas
+
+The analyzer buckets any swaps-owned frame by matching its resolved source
+path against `app/components/UI/Bridge/**` subfolders, most-specific first.
+This mirrors the directory as of the time this was written — re-run
 `find app/components/UI/Bridge -maxdepth 2 -type d` if it looks stale, and
 update `AREA_MAP` in the script if the tree has been restructured:
 
@@ -215,13 +308,54 @@ when one shows up hot, check its call sites (`grep -rn "useTheHookName("
 app/components/UI/Bridge`) to say which screen actually pays for it in the
 report.
 
+### Non-swaps context areas
+
+Everything the swaps roots don't match is bucketed by `CONTEXT_AREA_MAP` —
+also substring-matched, most-specific first — into readable areas rather than
+one "other" pile. It covers the surfaces that realistically show up in a
+capture recorded on a swaps screen:
+
+| Path fragment (examples) | Reported area |
+|---|---|
+| `react-native/Libraries/Renderer`, `node_modules/react/`, `node_modules/scheduler` | React Native renderer / React runtime / React scheduler |
+| `react-native-reanimated`, `react-native-gesture-handler` | Reanimated (animations) / Gesture handler |
+| `@react-navigation`, `app/components/Nav`, `app/core/NavigationService` | React Navigation (library) / Navigation (app nav stack) / Navigation service |
+| `react-redux`, `@reduxjs/toolkit`, `redux`, `reselect`, `redux-persist`, `app/store`, `app/selectors` | react-redux / Redux Toolkit / Redux runtime / Reselect / redux-persist / Redux store (app) / App selectors |
+| `controllers/token-detection`, `token-balances`, `token-rates`, `currency-rate`, `account-tracker` | \<respective\> (polling) — the usual source of `Concurrent` time |
+| `app/core/Engine`, `@metamask/*-controller(s)` | Engine / controller wiring, or the named controller |
+| `app/component-library` | Design system (component-library) |
+| `app/components/UI/Tokens`, `AssetOverview`, `Views/confirmations`, `components/hooks` | Token list UI / Asset overview / Confirmations / Shared app hooks |
+| `app/core/Analytics`, `app/util/metrics`, `app/util` | Analytics / metrics, App utils |
+| anything else under `node_modules/<pkg>` | `<pkg> (dependency)` |
+| any other app path | first three path segments (e.g. `app/components/Views/Settings`) |
+| no resolved path | Unknown (unsymbolicated) |
+
+Add an entry to `CONTEXT_AREA_MAP` when a real audit produces a fallback
+label that reads poorly — the fallbacks are deliberately generic, not a
+statement that the code doesn't matter.
+
+### Relation to swaps
+
+Independently of the area, each frame carries how it related to the swaps
+call stacks during the capture (`Swaps-owned`, `Called by swaps`,
+`Hosts swaps screen`, `Concurrent (off swaps path)` — defined in `skill.md`).
+Computed from the stacks themselves: self time accrued with a swaps frame
+below it on the stack makes a frame `Called by swaps`; being on the stack when
+swaps code was entered makes it `Hosts swaps screen`; never sharing a stack
+with swaps code makes it `Concurrent`. When an area mixes relations, the
+by-area table shows whichever relation holds the most self time, and the
+per-frame table keeps the exact split.
+
+If the user needs to route a non-swaps finding, `.github/CODEOWNERS` maps the
+file path to the owning team (last matching pattern wins), e.g.
+`app/components/Nav/NavigationProvider @MetaMask/mobile-platform`.
+
 ## Step 5 — Diagnose and propose fixes
 
-For every in-scope hot frame, read the actual source at `file:line` (and its
-immediate call site) before writing a finding — self/total time tells you
-*where*, not *why*. Match what you read against the `performance` skill's
-verified anti-pattern catalogue and cite its fix recipe rather than
-improvising:
+For every hot frame, read the actual source at `file:line` (and its immediate
+call site) before writing a finding — self/total time tells you *where*, not
+*why*. Match what you read against the `performance` skill's verified
+anti-pattern catalogue and cite its fix recipe rather than improvising:
 
 | Symptom in the code | Guide |
 |---|---|
@@ -238,39 +372,65 @@ These guides live in the `performance` skill
 (`domains/performance/skills/performance/references/`) — read the specific
 guide before proposing the fix in your report, don't just cite the filename.
 
+How far to go depends on ownership:
+
+- **Swaps-owned (`Owned by swaps = Yes`)** — full diagnosis and a concrete
+  fix, citing the guide.
+- **`Called by swaps`** — read the swaps call site first. If swaps calls it
+  too often, or with an unstable argument/dependency, the fix is a swaps fix
+  even though the hot frame isn't swaps code; say so. Only when the callee
+  itself is simply slow does it become the other team's.
+- **`Hosts swaps screen`** — describe what the swaps screen makes the host do
+  (mount cost, prop churn, provider re-render). Fix cell stays a pointer.
+- **`Concurrent (off swaps path)`** — name the mechanism (poll interval,
+  subscription, animation) and leave it as context for the user to route. Do
+  not write a patch plan for it.
+
 ## Worked example
 
 ```bash
 $ yarn react-native-release-profiler --local ~/Downloads/sampling-profiler-trace-1699999999.cpuprofile \
-    --sourcemap-path ~/Downloads/ios-sourcemaps-main-rc
+    --sourcemap-path ~/Downloads/ios-sourcemaps-main-rc/index.js.map
 Successfully converted to Chrome tracing format and pulled the file to ./sampling-profiler-trace-1699999999-converted.json
 
 $ node .agents/skills/mms-swaps-cpu-profile-audit/scripts/analyze-cpuprofile.cjs \
     --profile ./sampling-profiler-trace-1699999999-converted.json
-# CPU profile audit — scope: `components/UI/Bridge`
+# CPU profile audit — swaps/bridge + on-screen context
 
 | Metric | Value |
 |---|---|
 | Format detected | converted |
 | Capture length | ~5s |
 | Distinct frames sampled | 42 |
-| Time spent in swaps/bridge | 1234.56 ms (82.3% of all sampled time) |
+| JS work sampled (attributable) | 1500.00 ms |
+| Runtime & idle (root span, GC) | 2100.00 ms (58.3% of capture) — excluded from the splits below |
+| Swaps-owned code | 1010.50 ms (67.4% of JS work) |
+| ↳ widest swaps-owned span (inclusive) | 1402.00 ms — work swaps code set in motion, including callees |
+| Non-swaps code on the swaps path | 401.20 ms (26.7% of JS work) |
+| Non-swaps code running concurrently | 88.30 ms (5.9% of JS work) |
 
-## By area (self time)
-| Area | Time (ms) | % of swaps time | # of hot spots |
-|---|---|---|---|
-| Quote select screen | 612.40 | 41.2% | 6 |
-| Asset picker (token selector modal) | 398.10 | 26.8% | 4 |
+## Swaps-owned areas (self time)
+| Area | Time (ms) | % of swaps time | Inclusive (ms) | # of hot spots |
+|---|---|---|---|---|
+| Quote select screen | 612.40 | 60.6% | 1402.00 | 6 |
+| Asset picker (token selector modal) | 398.10 | 39.4% | 611.00 | 4 |
+
+## Non-swaps areas on the swaps path (self time)
+| Area | Relation to swaps | Time (ms) | % of JS work | # of hot spots |
+|---|---|---|---|---|
+| Navigation (app nav stack) | Hosts swaps screen | 260.00 | 17.3% | 3 |
 ...
 ```
 
-This raw table is aggregated data, not the finished audit — read it, then
-open the top frame in "Quote select screen" (say,
-`app/components/UI/Bridge/components/QuoteSelectorView/index.tsx:88`), read
-what it's actually doing, and turn it into a plain-language row in the final
-report's probable-cause/fix table (see `skill.md`'s Output format; the
-`Metric`/`By area` tables above are reused as-is in the final report):
+These raw tables are aggregated data, not the finished audit — read them,
+then open the top frame in each meaningful area (say
+`app/components/UI/Bridge/components/QuoteSelectorView/index.tsx:88` and
+`app/components/Nav/Main/MainNavigator.js:210`), read what each is actually
+doing, and turn them into plain-language rows in the final report's
+probable-cause/fix table (see `skill.md`'s Output format; the `Metric`/`By
+area` tables above are reused as-is in the final report):
 
-| Screen | Probable cause | Fix |
-|---|---|---|
-| Quote select screen | Re-sorts the entire quote list every time the screen re-renders — sort comparator is inline and not memoized — 612ms, 6x, `QuoteSelectorView/index.tsx:88` | Wrap in `useMemo` keyed on the quote list identity (see `mm-unstable-hook-return.md` if the list itself has no stable reference either) |
+| Screen / area | Owned by swaps | Probable cause | Fix |
+|---|---|---|---|
+| Quote select screen | Yes | Re-sorts the entire quote list every time the screen re-renders — sort comparator is inline and not memoized — 612ms, 6x, `QuoteSelectorView/index.tsx:88` | Wrap in `useMemo` keyed on the quote list identity (see `mm-unstable-hook-return.md` if the list itself has no stable reference either) |
+| Navigation (app nav stack) | No | The tab navigator re-renders its whole screen tree while the swaps screen mounts, so opening swaps pays for every sibling screen — 260ms, 3x, `Main/MainNavigator.js:210` | Not swaps-owned; owned by the navigation/platform area — raise it with them |

--- a/domains/swaps/skills/swaps-cpu-profile-audit/scripts/analyze-cpuprofile.cjs
+++ b/domains/swaps/skills/swaps-cpu-profile-audit/scripts/analyze-cpuprofile.cjs
@@ -1,8 +1,25 @@
 #!/usr/bin/env node
 //
 // analyze-cpuprofile.js — aggregate self/total JS time from a Hermes /
-// React Native Release Profiler CPU capture, scoped to the swaps/bridge
-// screen tree (app/components/UI/Bridge/** in metamask-mobile).
+// React Native Release Profiler CPU capture recorded on the swaps/bridge
+// screens, splitting it into swaps-owned code (the paths in
+// DEFAULT_SCOPE_ROOTS, i.e. app/components/UI/Bridge/** plus the swaps
+// redux/selector/controller/util paths) and the surrounding non-swaps
+// context that also burned time during the capture.
+//
+// Every frame is classified by its relation to the swaps call stacks, so a
+// slow dependency that swaps merely *uses* (navigation, redux store, design
+// system, a controller) is attributed instead of silently dropped:
+//
+//   Swaps-owned       frame's source path matches a swaps scope root
+//   Called by swaps   non-swaps frame that ran with a swaps frame below it
+//                     on the stack (swaps code invoked it)
+//   Hosts swaps       non-swaps frame that was on the stack when a swaps
+//                     frame was pushed (it renders/hosts the swaps screen —
+//                     React reconciler, navigator, providers)
+//   Concurrent        non-swaps frame that never shares a stack with swaps
+//                     code (background/polling work that still competes for
+//                     the JS thread while the user sits on a swaps screen)
 //
 // Read-only: it only reads the profile (and prints/writes a report). It
 // never touches a device, Metro, or the repository.
@@ -10,7 +27,7 @@
 // Input (auto-detected):
 //   1. Preferred — the Chrome-trace JSON produced by:
 //        yarn react-native-release-profiler --local <profile.cpuprofile> \
-//          --sourcemap-path <sourcemaps-dir-or-file>
+//          --sourcemap-path <sourcemaps-dir>/index.js.map
 //      i.e. a JSON ARRAY of Begin/End duration events (the "*-converted.json"
 //      file). With sourcemaps applied, `args.url`/`args.line`/`args.column`
 //      point at ORIGINAL app source, which is what makes swaps-tree scoping
@@ -24,10 +41,11 @@
 //
 // Usage:
 //   node analyze-cpuprofile.js --profile <path> \
-//     [--scope <substring>] [--top <n>] [--out <path>] [--json]
+//     [--scope <substring>] [--top <n>] [--context-min-pct <n>] \
+//     [--trigger-min-pct <n>] [--swaps-only] [--out <path>] [--json]
 //
 // Exit code is always 0 on a successful parse (there is nothing to "fail" —
-// an empty in-scope result is a valid, reportable finding). Exit 1 on a
+// an empty swaps-owned result is a valid, reportable finding). Exit 1 on a
 // missing/unparseable file.
 
 'use strict';
@@ -63,12 +81,22 @@ const DEFAULT_SCOPE_ROOTS = [
 ];
 
 function parseArgs(argv) {
-  const args = { scope: DEFAULT_SCOPE_ROOTS.join(','), top: 40, json: false };
+  const args = {
+    scope: DEFAULT_SCOPE_ROOTS.join(','),
+    top: 40,
+    contextMinPct: 0.5,
+    triggerMinPct: 5,
+    swapsOnly: false,
+    json: false,
+  };
   for (let i = 0; i < argv.length; i += 1) {
     const a = argv[i];
     if (a === '--profile') args.profile = argv[++i];
     else if (a === '--scope') args.scope = argv[++i];
     else if (a === '--top') args.top = Number(argv[++i]);
+    else if (a === '--context-min-pct') args.contextMinPct = Number(argv[++i]);
+    else if (a === '--trigger-min-pct') args.triggerMinPct = Number(argv[++i]);
+    else if (a === '--swaps-only') args.swapsOnly = true;
     else if (a === '--out') args.out = argv[++i];
     else if (a === '--json') args.json = true;
     else if (a === '--help' || a === '-h') args.help = true;
@@ -151,13 +179,154 @@ const AREA_MAP = [
   ['utils/', 'Bridge utils'],
 ];
 
-function areaFor(sourcePath, scopeRoots) {
-  if (!sourcePath) return null;
-  if (!scopeRoots.some((root) => sourcePath.includes(root))) return null;
+// Non-swaps code that shows up in a capture recorded on the swaps screens.
+// Ordered, most-specific first; matched as a substring of the resolved source
+// path. This exists so a slow dependency the swaps screens merely *use*
+// (navigation, redux, the design system, a controller) is named in the report
+// instead of being dropped, and so the report can say plainly that it is not
+// swaps-owned. Anything not listed falls back to a path-derived label
+// (see contextAreaFor), so the map only needs the high-signal cases.
+const CONTEXT_AREA_MAP = [
+  // Rendering / animation runtimes
+  ['react-native/Libraries/Renderer', 'React Native renderer'],
+  ['react-native-reanimated', 'Reanimated (animations)'],
+  ['react-native-gesture-handler', 'Gesture handler'],
+  ['node_modules/react/', 'React runtime'],
+  ['node_modules/scheduler', 'React scheduler'],
+  ['react-native/Libraries', 'React Native core'],
+  // Navigation
+  ['@react-navigation', 'React Navigation (library)'],
+  ['app/components/Nav', 'Navigation (app nav stack)'],
+  ['app/core/NavigationService', 'Navigation service'],
+  // State management
+  ['node_modules/react-redux', 'react-redux'],
+  ['node_modules/@reduxjs/toolkit', 'Redux Toolkit'],
+  ['node_modules/redux', 'Redux runtime'],
+  ['node_modules/reselect', 'Reselect'],
+  ['node_modules/redux-persist', 'redux-persist'],
+  ['app/store', 'Redux store (app)'],
+  ['app/selectors', 'App selectors'],
+  // Engine / controllers. The polling controllers are listed separately
+  // because they are the usual source of "Concurrent" time — work that runs
+  // on a timer regardless of which screen the user is on.
+  ['controllers/token-detection', 'Token detection (polling)'],
+  ['controllers/token-balances', 'Token balances (polling)'],
+  ['controllers/token-rates', 'Token rates (polling)'],
+  ['controllers/currency-rate', 'Currency rates (polling)'],
+  ['controllers/account-tracker', 'Account tracker (polling)'],
+  ['controllers/nft', 'NFT controllers'],
+  ['app/core/Engine', 'Engine / controller wiring'],
+  ['@metamask/transaction-controller', 'TransactionController'],
+  ['@metamask/assets-controllers', 'Assets controllers (tokens/prices)'],
+  ['@metamask/accounts-controller', 'AccountsController'],
+  ['@metamask/network-controller', 'NetworkController'],
+  ['@metamask/keyring', 'Keyring'],
+  // UI shared surfaces
+  ['app/component-library', 'Design system (component-library)'],
+  ['app/components/UI/Tokens', 'Token list UI'],
+  ['app/components/UI/AssetOverview', 'Asset overview'],
+  ['app/components/Views/confirmations', 'Confirmations'],
+  ['app/components/hooks', 'Shared app hooks'],
+  // Cross-cutting app code
+  ['app/core/Analytics', 'Analytics / metrics'],
+  ['app/util/metrics', 'Analytics / metrics'],
+  ['app/util', 'App utils'],
+  ['node_modules/lodash', 'lodash'],
+  ['node_modules/bn.js', 'bn.js / big-number math'],
+  ['node_modules/bignumber.js', 'bn.js / big-number math'],
+];
+
+const RELATION = {
+  SWAPS: 'Swaps-owned',
+  CALLED_BY_SWAPS: 'Called by swaps',
+  HOSTS_SWAPS: 'Hosts swaps screen',
+  CONCURRENT: 'Concurrent (off swaps path)',
+  RUNTIME: 'Runtime / idle',
+};
+
+// Ranking used when collapsing the mixed relations inside one area bucket
+// down to a single label, and when ordering rows of equal weight.
+const RELATION_RANK = {
+  [RELATION.SWAPS]: 0,
+  [RELATION.CALLED_BY_SWAPS]: 1,
+  [RELATION.HOSTS_SWAPS]: 2,
+  [RELATION.CONCURRENT]: 3,
+  [RELATION.RUNTIME]: 4,
+};
+
+// Synthetic bookkeeping frames the engine emits: `[root]`, `[global]`,
+// `[GC young gen]`, `(program)`, `(garbage collector)`, ... They are not
+// anyone's code. `[root]` in particular owns all the wall time when no JS is
+// running, so on a capture where the user mostly sat still it dwarfs every
+// real frame. Counting it as normal self time makes every percentage
+// meaningless and (because a swaps frame is pushed under it at some point)
+// mislabels pure idle as time spent hosting the swaps screen — so these
+// frames are split out and excluded from the attributable totals.
+const SYNTHETIC_FRAME_NAME =
+  /^(\[[^\]]*\]|\((?:root|program|idle|anonymous|garbage collector|unknown)\))$/iu;
+
+function isRuntimeFrame(frame) {
+  const name = (frame.name || '').trim();
+  if (SYNTHETIC_FRAME_NAME.test(name)) return true;
+  // Only trust the category when nothing resolved to a real file: a frame with
+  // a source path is somebody's code regardless of how it was categorised.
+  if (frame.url) return false;
+  const category = (frame.category || '').toLowerCase();
+  return category === 'gc' || category === 'metadata';
+}
+
+function runtimeAreaFor(frame) {
+  const name = (frame.name || '').trim();
+  if (/gc|garbage/iu.test(name) || (frame.category || '').toLowerCase() === 'gc') {
+    return 'Garbage collection';
+  }
+  if (/^\[?root\]?$/iu.test(name) || /^\((?:root|program|idle)\)$/iu.test(name)) {
+    return 'Idle / unattributed (root span)';
+  }
+  return `Runtime (${name || 'unnamed'})`;
+}
+
+function isSwapsOwned(sourcePath, scopeRoots) {
+  if (!sourcePath) return false;
+  return scopeRoots.some((root) => sourcePath.includes(root));
+}
+
+function swapsAreaFor(sourcePath) {
   for (let i = 0; i < AREA_MAP.length; i += 1) {
     if (sourcePath.includes(AREA_MAP[i][0])) return AREA_MAP[i][1];
   }
   return 'Bridge (other / unmapped subfolder)';
+}
+
+// Label for a frame that is NOT swaps-owned. Falls back to a path-derived
+// bucket so unmapped code still lands somewhere readable and reportable
+// rather than being lumped into one giant "other".
+function contextAreaFor(sourcePath) {
+  if (!sourcePath) return 'Unknown (unsymbolicated)';
+  for (let i = 0; i < CONTEXT_AREA_MAP.length; i += 1) {
+    if (sourcePath.includes(CONTEXT_AREA_MAP[i][0])) return CONTEXT_AREA_MAP[i][1];
+  }
+  const pkg = /node_modules\/((?:@[^/]+\/)?[^/]+)/.exec(sourcePath);
+  if (pkg) return `${pkg[1]} (dependency)`;
+  const segments = sourcePath.replace(/^\.?\//, '').split('/').filter(Boolean);
+  if (segments.length > 1) return segments.slice(0, 3).join('/');
+  return sourcePath;
+}
+
+// Classifies a frame after the whole capture has been replayed: swaps-owned
+// by path, otherwise by how its stacks related to swaps code.
+function classify(frame, scopeRoots) {
+  const sourcePath = frame.url || frame.name;
+  if (isSwapsOwned(sourcePath, scopeRoots)) {
+    return { ownedBySwaps: true, relation: RELATION.SWAPS, area: swapsAreaFor(sourcePath) };
+  }
+  if (isRuntimeFrame(frame)) {
+    return { ownedBySwaps: false, relation: RELATION.RUNTIME, area: runtimeAreaFor(frame) };
+  }
+  let relation = RELATION.CONCURRENT;
+  if (frame.selfUnderSwapsMicros > 0) relation = RELATION.CALLED_BY_SWAPS;
+  else if (frame.hostsSwaps) relation = RELATION.HOSTS_SWAPS;
+  return { ownedBySwaps: false, relation, area: contextAreaFor(frame.url) };
 }
 
 // Best-effort recovery of `(path:line:col)` out of a Hermes-style function
@@ -169,8 +338,24 @@ function extractPathFromName(name) {
   return { url: m[1], line: Number(m[2]), column: Number(m[3]) };
 }
 
-function newFrame(key, name, url, line, category) {
-  return { key, name, url: url || null, line: line || null, category: category || 'unknown', selfMicros: 0, totalMicros: 0, calls: 0 };
+function newFrame(key, name, url, line, category, swapsOwned) {
+  return {
+    key,
+    name,
+    url: url || null,
+    line: line || null,
+    category: category || 'unknown',
+    selfMicros: 0,
+    totalMicros: 0,
+    calls: 0,
+    // Self time this frame accrued while a swaps-owned frame sat below it on
+    // the stack — i.e. swaps code called into it.
+    selfUnderSwapsMicros: 0,
+    // True if this frame was on the stack when a swaps-owned frame was
+    // pushed — i.e. it renders/hosts the swaps screen.
+    hostsSwaps: false,
+    swapsOwned,
+  };
 }
 
 // --- Path 1: converted Chrome-trace JSON (array of B/E duration events) ---
@@ -180,17 +365,27 @@ function newFrame(key, name, url, line, category) {
 // so a single-pass stack replay recovers both self time (whichever frame is
 // on top of the stack between two consecutive events owns that time slice)
 // and total/inclusive time (span from a frame's B to its matching E).
-function analyzeConverted(events) {
+//
+// The same replay records each frame's relation to swaps code: how much self
+// time it burned with a swaps frame below it on the stack, and whether it was
+// itself on the stack when swaps code was entered.
+function analyzeConverted(events, scopeRoots) {
   const frames = new Map();
   const stack = [];
+  let swapsDepth = 0;
   let lastTs = events.length > 0 ? Number(events[0].ts) : 0;
   const firstTs = lastTs;
   let maxTs = lastTs;
 
   const keyFor = (ev) => {
     const args = ev.args || {};
-    const url = args.url || (extractPathFromName(ev.name) || {}).url || null;
-    const line = args.line != null ? Number(args.line) : (extractPathFromName(ev.name) || {}).line || null;
+    // When no source map was applied, the transformer sets `args.url` to the
+    // raw Hermes frame *name* (`fn(path:line:col)`), not a path — so prefer
+    // the path recovered out of that shape, and fall back to `args.url` only
+    // when it really is a plain path (the symbolicated case).
+    const recovered = extractPathFromName(args.url) || extractPathFromName(ev.name);
+    const url = recovered ? recovered.url : args.url || null;
+    const line = args.line != null ? Number(args.line) : recovered ? recovered.line : null;
     const name = args.params || ev.name || args.allocatedName || 'anonymous';
     const category = args.node_module || args.allocatedCategory || ev.cat || 'unknown';
     return { key: `${name}::${url || category}::${line || ''}`, name, url, line, category };
@@ -200,8 +395,9 @@ function analyzeConverted(events) {
     const ts = Number(ev.ts);
     const dt = ts - lastTs;
     if (stack.length > 0 && dt > 0) {
-      const top = stack[stack.length - 1];
-      top.frame.selfMicros += dt;
+      const top = stack[stack.length - 1].frame;
+      top.selfMicros += dt;
+      if (!top.swapsOwned && swapsDepth > 0) top.selfUnderSwapsMicros += dt;
     }
     lastTs = ts;
     if (ts > maxTs) maxTs = ts;
@@ -210,8 +406,18 @@ function analyzeConverted(events) {
       const info = keyFor(ev);
       let frame = frames.get(info.key);
       if (!frame) {
-        frame = newFrame(info.key, info.name, info.url, info.line, info.category);
+        const swapsOwned = isSwapsOwned(info.url || info.name, scopeRoots);
+        frame = newFrame(info.key, info.name, info.url, info.line, info.category, swapsOwned);
         frames.set(info.key, frame);
+      }
+      if (frame.swapsOwned) {
+        // Only the 0 -> 1 transition needs the walk: everything pushed while
+        // swaps is already on the stack is "called by swaps" anyway, which
+        // outranks "hosts swaps" in classify().
+        if (swapsDepth === 0) {
+          for (const entry of stack) entry.frame.hostsSwaps = true;
+        }
+        swapsDepth += 1;
       }
       stack.push({ frame, beginTs: ts });
     } else if (ev.ph === 'E') {
@@ -219,6 +425,7 @@ function analyzeConverted(events) {
       if (popped) {
         popped.frame.totalMicros += ts - popped.beginTs;
         popped.frame.calls += 1;
+        if (popped.frame.swapsOwned) swapsDepth = Math.max(0, swapsDepth - 1);
       }
     }
   }
@@ -231,10 +438,12 @@ function analyzeConverted(events) {
 // `samples[i].sf` names the leaf stack frame active at sample i; `stackFrames`
 // is a flat map with a `parent` pointer per frame. Self time is credited to
 // the leaf; total time is credited to every frame on the leaf's ancestor
-// chain. No source-map resolution happens here — run the CLI conversion
-// first (see skill docs) whenever you have sourcemaps, and reserve this path
-// for when you don't.
-function analyzeRawHermes(profile) {
+// chain. Relation to swaps is read off the same chain: a swaps frame among
+// the leaf's ancestors means the leaf was called by swaps, and any frame with
+// a swaps frame between it and the leaf hosts swaps code. No source-map
+// resolution happens here — run the CLI conversion first (see skill docs)
+// whenever you have sourcemaps, and reserve this path for when you don't.
+function analyzeRawHermes(profile, scopeRoots) {
   const { samples, stackFrames } = profile;
   const frames = new Map();
   const ancestorCache = new Map();
@@ -262,7 +471,14 @@ function analyzeRawHermes(profile) {
     const key = `${raw.name}::${sf}`;
     let frame = frames.get(key);
     if (!frame) {
-      frame = newFrame(key, raw.name || 'anonymous', url, line, raw.category);
+      frame = newFrame(
+        key,
+        raw.name || 'anonymous',
+        url,
+        line,
+        raw.category,
+        isSwapsOwned(url || raw.name, scopeRoots),
+      );
       frames.set(key, frame);
     }
     return frame;
@@ -279,35 +495,77 @@ function analyzeRawHermes(profile) {
     prevTs = ts;
     if (dt === 0) continue;
 
-    const leaf = frameFor(sample.sf);
-    if (leaf) leaf.selfMicros += dt;
-
-    for (const sf of ancestorsOf(sample.sf)) {
-      const frame = frameFor(sf);
-      if (frame) {
-        frame.totalMicros += dt;
-        frame.calls += 1;
+    // chain[0] is the leaf; higher indices walk up towards the root, so a
+    // frame's ancestors sit *below* it on the conceptual stack.
+    const chain = ancestorsOf(sample.sf).map(frameFor).filter(Boolean);
+    let swapsBelowLeaf = false;
+    let swapsSeenTowardsLeaf = false;
+    for (let i = 0; i < chain.length; i += 1) {
+      const frame = chain[i];
+      if (swapsSeenTowardsLeaf && !frame.swapsOwned) frame.hostsSwaps = true;
+      if (frame.swapsOwned) {
+        swapsSeenTowardsLeaf = true;
+        if (i > 0) swapsBelowLeaf = true;
       }
+      frame.totalMicros += dt;
+      frame.calls += 1;
+    }
+
+    const leaf = chain[0];
+    if (leaf) {
+      leaf.selfMicros += dt;
+      if (!leaf.swapsOwned && swapsBelowLeaf) leaf.selfUnderSwapsMicros += dt;
     }
   }
 
   return { frames, durationMicros: (lastTs || 0) - (firstTs || 0) };
 }
 
-function loadProfile(profilePath) {
+function loadProfile(profilePath, scopeRoots) {
   const raw = fs.readFileSync(profilePath, 'utf8');
   const data = JSON.parse(raw);
   if (Array.isArray(data)) {
-    return { format: 'converted', ...analyzeConverted(data) };
+    return { format: 'converted', ...analyzeConverted(data, scopeRoots) };
   }
   if (data && Array.isArray(data.samples) && data.stackFrames) {
-    return { format: 'raw-hermes', ...analyzeRawHermes(data) };
+    return { format: 'raw-hermes', ...analyzeRawHermes(data, scopeRoots) };
   }
   throw new Error(
     'Unrecognised profile shape: expected either an array of B/E trace events ' +
       '(the "-converted.json" from `yarn react-native-release-profiler`) or a raw ' +
       'Hermes .cpuprofile object with `samples` + `stackFrames`.',
   );
+}
+
+function bucketByArea(framesList) {
+  const byArea = new Map();
+  for (const f of framesList) {
+    if (!byArea.has(f.area)) {
+      byArea.set(f.area, {
+        area: f.area,
+        ownedBySwaps: f.ownedBySwaps,
+        selfMicros: 0,
+        totalMicros: 0,
+        byRelation: new Map(),
+        frames: [],
+      });
+    }
+    const bucket = byArea.get(f.area);
+    bucket.selfMicros += f.selfMicros;
+    bucket.totalMicros = Math.max(bucket.totalMicros, f.totalMicros);
+    bucket.byRelation.set(f.relation, (bucket.byRelation.get(f.relation) || 0) + f.selfMicros);
+    bucket.frames.push(f);
+  }
+  // One area can mix relations (e.g. a navigator that both hosts the swaps
+  // screen and gets called back into by it). Report the relation holding the
+  // most self time; the per-frame tables keep the exact detail.
+  for (const bucket of byArea.values()) {
+    bucket.relation = Array.from(bucket.byRelation.entries()).sort(
+      (a, b) => b[1] - a[1] || RELATION_RANK[a[0]] - RELATION_RANK[b[0]],
+    )[0][0];
+    delete bucket.byRelation;
+  }
+  return Array.from(byArea.values()).sort((a, b) => b.selfMicros - a.selfMicros);
 }
 
 function buildReport(analysis, opts) {
@@ -319,36 +577,72 @@ function buildReport(analysis, opts) {
     .filter(Boolean);
   const all = Array.from(frames.values());
   for (const f of all) {
-    f.area = areaFor(f.url || f.name, scopeRoots);
+    Object.assign(f, classify(f, scopeRoots));
   }
   all.sort((a, b) => b.selfMicros - a.selfMicros);
 
-  const inScope = all.filter((f) => f.area !== null);
-  const outOfScope = all.filter((f) => f.area === null);
+  const swapsFrames = all.filter((f) => f.ownedBySwaps);
+  const runtimeFrames = all.filter((f) => !f.ownedBySwaps && f.relation === RELATION.RUNTIME);
+  const contextFrames = all.filter((f) => !f.ownedBySwaps && f.relation !== RELATION.RUNTIME);
+  const onPath = contextFrames.filter((f) => f.relation !== RELATION.CONCURRENT);
+  const concurrent = contextFrames.filter((f) => f.relation === RELATION.CONCURRENT);
 
-  const byArea = new Map();
-  for (const f of inScope) {
-    if (!byArea.has(f.area)) byArea.set(f.area, { area: f.area, selfMicros: 0, totalMicros: 0, frames: [] });
-    const bucket = byArea.get(f.area);
-    bucket.selfMicros += f.selfMicros;
-    bucket.totalMicros = Math.max(bucket.totalMicros, f.totalMicros);
-    bucket.frames.push(f);
-  }
-  const areas = Array.from(byArea.values()).sort((a, b) => b.selfMicros - a.selfMicros);
+  const sumSelf = (list) => list.reduce((s, f) => s + f.selfMicros, 0);
+  const swapsSelfMicros = sumSelf(swapsFrames);
+  const contextSelfMicros = sumSelf(contextFrames);
+  const runtimeSelfMicros = sumSelf(runtimeFrames);
+  // "Attributable" = real JS work someone owns. Idle and GC are excluded so
+  // the splits below describe the work, not how long the user sat still.
+  const attributableSelfMicros = swapsSelfMicros + contextSelfMicros;
+  const totalSelfMicros = attributableSelfMicros + runtimeSelfMicros;
+
+  const minMicros = ((opts.contextMinPct || 0) / 100) * attributableSelfMicros;
+  // A frame with no self time did no work of its own, so it is only a finding
+  // when the work it *triggered* is significant — a screen whose module merely
+  // got evaluated would otherwise show up as a row that means nothing. Hence a
+  // much higher bar for zero-self rows than the ordinary noise floor.
+  const triggerMinMicros = ((opts.triggerMinPct || 0) / 100) * attributableSelfMicros;
+  const reportableSwaps = swapsFrames.filter(
+    (f) => f.selfMicros > 0 || f.totalMicros >= triggerMinMicros,
+  );
+  const reportableContext = opts.swapsOnly
+    ? []
+    : contextFrames.filter((f) => f.selfMicros >= minMicros);
+  const reportableRuntime = opts.swapsOnly ? [] : runtimeFrames.filter((f) => f.selfMicros > 0);
 
   const durationMs = durationMicros / 1000;
 
   return {
     format,
     scope,
+    swapsOnly: Boolean(opts.swapsOnly),
+    contextMinPct: opts.contextMinPct,
+    triggerMinPct: opts.triggerMinPct,
     durationMs,
     durationSeconds: durationMs / 1000,
     totalFrames: all.length,
-    inScopeSelfMicros: inScope.reduce((s, f) => s + f.selfMicros, 0),
-    outOfScopeSelfMicros: outOfScope.reduce((s, f) => s + f.selfMicros, 0),
-    areas,
-    topInScope: inScope.slice(0, opts.top),
-    topOutOfScope: outOfScope.slice(0, Math.min(10, opts.top)),
+    totalSelfMicros,
+    attributableSelfMicros,
+    runtimeSelfMicros,
+    swapsSelfMicros,
+    // Widest inclusive swaps span: a lower bound on how much work swaps code
+    // set in motion, which is the number that matters when swaps self time is
+    // ~0 but swaps frames are all over the stacks.
+    swapsInclusiveMicros: swapsFrames.reduce((m, f) => Math.max(m, f.totalMicros), 0),
+    contextOnPathSelfMicros: sumSelf(onPath),
+    contextConcurrentSelfMicros: sumSelf(concurrent),
+    // Kept under the previous names so anything already reading --json keeps
+    // working; the split area lists below are the new, wider view.
+    inScopeSelfMicros: swapsSelfMicros,
+    outOfScopeSelfMicros: contextSelfMicros,
+    areas: bucketByArea(reportableSwaps),
+    contextPathAreas: bucketByArea(reportableContext.filter((f) => f.relation !== RELATION.CONCURRENT)),
+    contextConcurrentAreas: bucketByArea(
+      reportableContext.filter((f) => f.relation === RELATION.CONCURRENT),
+    ),
+    runtimeAreas: bucketByArea(reportableRuntime),
+    topInScope: reportableSwaps.slice(0, opts.top),
+    topContext: reportableContext.slice(0, opts.top),
   };
 }
 
@@ -361,11 +655,18 @@ function pct(part, whole) {
   return ((part / whole) * 100).toFixed(1);
 }
 
+function sourceOf(frame) {
+  if (!frame.url) return '(unsymbolicated)';
+  return `${frame.url}${frame.line ? ':' + frame.line : ''}`;
+}
+
 function renderMarkdown(report) {
   const lines = [];
   const scopeRoots = report.scope.split(',').map((s) => s.trim()).filter(Boolean);
   const scopeLabel = scopeRoots.length > 1 ? `${scopeRoots.length} swaps/bridge-owned paths` : scopeRoots[0];
-  lines.push(`# CPU profile audit \u2014 scope: ${scopeLabel}`);
+  lines.push('# CPU profile audit \u2014 swaps/bridge + on-screen context');
+  lines.push('');
+  lines.push(`Swaps ownership determined by: ${scopeLabel}.`);
   if (scopeRoots.length > 1) {
     lines.push('');
     lines.push('<details><summary>Scope roots</summary>');
@@ -375,40 +676,150 @@ function renderMarkdown(report) {
     lines.push('</details>');
   }
   lines.push('');
-  const totalSelf = report.inScopeSelfMicros + report.outOfScopeSelfMicros;
+  const totalSelf = report.totalSelfMicros || 1;
+  const jsWork = report.attributableSelfMicros || 1;
   lines.push('| Metric | Value |');
   lines.push('|---|---|');
   lines.push(`| Format detected | ${report.format} |`);
   lines.push(`| Capture length | ~${Math.round(report.durationSeconds)}s |`);
   lines.push(`| Distinct frames sampled | ${report.totalFrames} |`);
+  lines.push(`| JS work sampled (attributable) | ${ms(report.attributableSelfMicros)} ms |`);
   lines.push(
-    `| Time spent in swaps/bridge | ${ms(report.inScopeSelfMicros)} ms (${pct(report.inScopeSelfMicros, totalSelf)}% of all sampled time) |`,
+    `| Runtime & idle (root span, GC) | ${ms(report.runtimeSelfMicros)} ms (${pct(report.runtimeSelfMicros, totalSelf)}% of capture) \u2014 excluded from the splits below |`,
+  );
+  lines.push(
+    `| Swaps-owned code | ${ms(report.swapsSelfMicros)} ms (${pct(report.swapsSelfMicros, jsWork)}% of JS work) |`,
+  );
+  lines.push(
+    `| \u21b3 widest swaps-owned span (inclusive) | ${ms(report.swapsInclusiveMicros)} ms \u2014 work swaps code set in motion, including callees |`,
+  );
+  lines.push(
+    `| Non-swaps code on the swaps path | ${ms(report.contextOnPathSelfMicros)} ms (${pct(report.contextOnPathSelfMicros, jsWork)}% of JS work) |`,
+  );
+  lines.push(
+    `| Non-swaps code running concurrently | ${ms(report.contextConcurrentSelfMicros)} ms (${pct(report.contextConcurrentSelfMicros, jsWork)}% of JS work) |`,
   );
   lines.push('');
-  lines.push('## By area (self time)');
+  lines.push('## Swaps-owned areas (self time)');
   lines.push('');
-  lines.push('| Area | Time (ms) | % of swaps time | # of hot spots |');
-  lines.push('|---|---|---|---|');
-  const totalInScope = report.inScopeSelfMicros || 1;
+  lines.push('| Area | Time (ms) | % of swaps time | Inclusive (ms) | # of hot spots |');
+  lines.push('|---|---|---|---|---|');
   for (const a of report.areas) {
-    lines.push(`| ${a.area} | ${ms(a.selfMicros)} | ${pct(a.selfMicros, totalInScope)}% | ${a.frames.length} |`);
+    lines.push(
+      `| ${a.area} | ${ms(a.selfMicros)} | ${pct(a.selfMicros, report.swapsSelfMicros)}% | ${ms(a.totalMicros)} | ${a.frames.length} |`,
+    );
+  }
+  if (report.areas.length === 0) {
+    lines.push(
+      `| *no swaps-owned frame did measurable work, nor triggered \u2265${report.triggerMinPct}% of JS work* | \u2014 | \u2014 | \u2014 | \u2014 |`,
+    );
+  }
+  if (report.swapsSelfMicros === 0 && report.swapsInclusiveMicros > 0) {
+    lines.push('');
+    lines.push(
+      '> Swaps-owned frames appear in the stacks but never as the leaf: they' +
+        ' burned no time themselves, and the cost sits in what they called.' +
+        ' Read the `Inclusive (ms)` column and the non-swaps tables below to' +
+        ' see where it went, and check the swaps call sites before concluding' +
+        ' this is another team\u2019s problem.',
+    );
   }
   lines.push('');
-  lines.push('## Top in-scope frames by self time');
+  if (!report.swapsOnly) {
+    const contextTable = (title, note, areas, withRelation) => {
+      lines.push(`## ${title}`);
+      lines.push('');
+      if (note) {
+        lines.push(note);
+        lines.push('');
+      }
+      if (withRelation) {
+        lines.push('| Area | Relation to swaps | Time (ms) | % of JS work | # of hot spots |');
+        lines.push('|---|---|---|---|---|');
+      } else {
+        lines.push('| Area | Time (ms) | % of JS work | # of hot spots |');
+        lines.push('|---|---|---|---|');
+      }
+      for (const a of areas) {
+        lines.push(
+          withRelation
+            ? `| ${a.area} | ${a.relation} | ${ms(a.selfMicros)} | ${pct(a.selfMicros, jsWork)}% | ${a.frames.length} |`
+            : `| ${a.area} | ${ms(a.selfMicros)} | ${pct(a.selfMicros, jsWork)}% | ${a.frames.length} |`,
+        );
+      }
+      if (areas.length === 0) {
+        const empty = `*nothing above the ${report.contextMinPct}% noise floor*`;
+        lines.push(withRelation ? `| ${empty} | \u2014 | \u2014 | \u2014 | \u2014 |` : `| ${empty} | \u2014 | \u2014 | \u2014 |`);
+      }
+      lines.push('');
+    };
+    contextTable(
+      'Non-swaps areas on the swaps path (self time)',
+      'Not swaps-owned, but either called by swaps code or hosting/rendering the swaps screen.',
+      report.contextPathAreas,
+      true,
+    );
+    contextTable(
+      'Non-swaps areas running concurrently (self time)',
+      'Never shares a stack with swaps code \u2014 it competed for the JS thread while the user was on a swaps screen.',
+      report.contextConcurrentAreas,
+      false,
+    );
+    if (report.runtimeAreas.length > 0) {
+      lines.push('## Runtime & idle (nobody\u2019s code)');
+      lines.push('');
+      lines.push(
+        'Engine bookkeeping, not a team\u2019s work. `[root]` is wall time with no' +
+          ' JS on the stack (the user sitting still), so it is excluded from' +
+          ' every percentage above. GC volume can still be a symptom worth' +
+          ' mentioning \u2014 never a row in the fix table.',
+      );
+      lines.push('');
+      lines.push('| Area | Time (ms) | % of capture |');
+      lines.push('|---|---|---|');
+      for (const a of report.runtimeAreas) {
+        lines.push(`| ${a.area} | ${ms(a.selfMicros)} | ${pct(a.selfMicros, totalSelf)}% |`);
+      }
+      lines.push('');
+    }
+  }
+  lines.push('## Top swaps-owned frames by self time');
   lines.push('');
   lines.push('| # | Time (ms) | Total (ms) | Calls | Area | Function | Source |');
   lines.push('|---|---|---|---|---|---|---|');
   report.topInScope.forEach((f, i) => {
-    const src = f.url ? `${f.url}${f.line ? ':' + f.line : ''}` : '(unsymbolicated)';
-    lines.push(`| ${i + 1} | ${ms(f.selfMicros)} | ${ms(f.totalMicros)} | ${f.calls} | ${f.area} | \`${f.name}\` | ${src} |`);
+    lines.push(
+      `| ${i + 1} | ${ms(f.selfMicros)} | ${ms(f.totalMicros)} | ${f.calls} | ${f.area} | \`${f.name}\` | ${sourceOf(f)} |`,
+    );
   });
   if (report.topInScope.length === 0) {
     lines.push('| \u2014 | \u2014 | \u2014 | \u2014 | \u2014 | *no frame under this scope matched* | \u2014 |');
   }
   lines.push('');
-  // Frames outside `--scope` are deliberately not listed here (not even as
-  // context) \u2014 this tool's job is swaps/bridge only. The "% of all sampled
-  // time" metric above already tells you how much of the capture they ate.
+  if (report.swapsOnly) {
+    lines.push('*Non-swaps context suppressed (`--swaps-only`).*');
+    return lines.join('\n');
+  }
+  lines.push('## Top non-swaps frames by self time (context)');
+  lines.push('');
+  lines.push(
+    'Not owned by the swaps team. Reported because they burned JS-thread time' +
+      ' during a capture taken on the swaps screens \u2014 either on the swaps call' +
+      ' path or concurrently with it.',
+  );
+  lines.push('');
+  lines.push('| # | Time (ms) | Total (ms) | Calls | Relation to swaps | Area | Function | Source |');
+  lines.push('|---|---|---|---|---|---|---|---|');
+  report.topContext.forEach((f, i) => {
+    lines.push(
+      `| ${i + 1} | ${ms(f.selfMicros)} | ${ms(f.totalMicros)} | ${f.calls} | ${f.relation} | ${f.area} | \`${f.name}\` | ${sourceOf(f)} |`,
+    );
+  });
+  if (report.topContext.length === 0) {
+    lines.push(
+      `| \u2014 | \u2014 | \u2014 | \u2014 | \u2014 | \u2014 | *no non-swaps frame above the ${report.contextMinPct}% noise floor* | \u2014 |`,
+    );
+  }
   return lines.join('\n');
 }
 
@@ -425,9 +836,14 @@ function main() {
     process.exit(1);
   }
 
+  const scopeRoots = args.scope
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
   let analysis;
   try {
-    analysis = loadProfile(profilePath);
+    analysis = loadProfile(profilePath, scopeRoots);
   } catch (e) {
     process.stderr.write(`Failed to parse ${profilePath}: ${e.message}\n`);
     process.exit(1);

--- a/domains/swaps/skills/swaps-cpu-profile-audit/scripts/run.sh
+++ b/domains/swaps/skills/swaps-cpu-profile-audit/scripts/run.sh
@@ -6,10 +6,13 @@
 # This script itself lives in the skill's own scripts/ directory (alongside
 # analyze-cpuprofile.cjs). Everything it EXTRACTS, CONVERTS, or WRITES —
 # staged input, extracted archives, the *-converted.json, the final Markdown
-# report — is written under a throwaway run folder created *inside the
+# report — ends up under a throwaway run folder created *inside the
 # target repo* (not the OS tmp directory). That run folder, and everything
 # under it, is removed automatically when the script exits, whether it
 # succeeds, fails, or is interrupted — nothing is left on disk afterwards.
+# (The profiler CLI has no output-path flag: it always writes its converted
+# JSON into the process cwd, i.e. the repo root, so this script moves that
+# file into the run folder immediately after conversion.)
 #
 # Why not the OS tmp directory: routing the working folder through
 # $TMPDIR/os.tmpdir() and then calling `yarn --cwd <repo> ...` from inside it
@@ -22,7 +25,14 @@
 # `yarn` with the repo itself as cwd) avoids that entirely.
 #
 # Usage:
-#   run.sh --repo <path-to-metamask-mobile> --profile <path> [--sourcemaps <path>] [--scope <substring>] [--top <n>]
+#   run.sh --repo <path-to-metamask-mobile> --profile <path> [--sourcemaps <path>]
+#          [--scope <substring>] [--top <n>] [--context-min-pct <n>]
+#          [--trigger-min-pct <n>] [--swaps-only]
+#
+# --scope, --context-min-pct, --trigger-min-pct and --swaps-only are forwarded to
+# analyze-cpuprofile.cjs untouched, and omitted entirely when not given so the
+# analyzer applies its own defaults (notably its full list of swaps-owned
+# paths, which is wider than the Bridge screen tree alone).
 #
 # <path> for --profile can be:
 #   - a raw .cpuprofile
@@ -37,9 +47,13 @@
 #     with `samples` + `stackFrames`), regardless of its name
 #
 # <path> for --sourcemaps (optional) can be:
-#   - a directory containing index.js.map / index.android.bundle.map
+#   - the source map file itself (index.js.map / index.android.bundle.map)
+#   - a directory containing one of those
 #   - a .zip archive of a sourcemaps CI artifact (it will be extracted into
 #     the run folder first)
+# In every case this script resolves it down to a single .map FILE before
+# calling the profiler CLI, which JSON-parses whatever it is handed and so
+# cannot take a directory.
 #
 # All intermediate and output files are written under a per-run subdirectory
 # created inside the repo, e.g.:
@@ -51,18 +65,23 @@ set -euo pipefail
 REPO=""
 PROFILE=""
 SOURCEMAPS=""
-SCOPE="components/UI/Bridge"
 TOP="40"
+# Collected as an array so unset options are simply not forwarded, leaving the
+# analyzer's own defaults in charge.
+ANALYZER_OPTS=()
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --repo) REPO="$2"; shift 2 ;;
     --profile) PROFILE="$2"; shift 2 ;;
     --sourcemaps) SOURCEMAPS="$2"; shift 2 ;;
-    --scope) SCOPE="$2"; shift 2 ;;
+    --scope) ANALYZER_OPTS+=(--scope "$2"); shift 2 ;;
+    --context-min-pct) ANALYZER_OPTS+=(--context-min-pct "$2"); shift 2 ;;
+    --trigger-min-pct) ANALYZER_OPTS+=(--trigger-min-pct "$2"); shift 2 ;;
+    --swaps-only) ANALYZER_OPTS+=(--swaps-only); shift ;;
     --top) TOP="$2"; shift 2 ;;
     -h|--help)
-      sed -n '2,30p' "$0"
+      sed -n '2,60p' "$0"
       exit 0
       ;;
     *) echo "Unknown arg: $1" >&2; exit 1 ;;
@@ -70,7 +89,7 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -z "$REPO" ] || [ -z "$PROFILE" ]; then
-  echo "Usage: run.sh --repo <path-to-metamask-mobile> --profile <path> [--sourcemaps <path>] [--scope <substring>] [--top <n>]" >&2
+  echo "Usage: run.sh --repo <path-to-metamask-mobile> --profile <path> [--sourcemaps <path>] [--scope <substring>] [--top <n>] [--context-min-pct <n>] [--trigger-min-pct <n>] [--swaps-only]" >&2
   exit 1
 fi
 
@@ -174,15 +193,49 @@ if [ -z "$CONVERTED" ] && [ -z "$RAW_CPUPROFILE" ] && [ -z "$RAW_JSON" ]; then
 fi
 
 if [ -z "$CONVERTED" ] && [ -n "$RAW_CPUPROFILE" ]; then
-  echo "Converting raw .cpuprofile via yarn react-native-release-profiler (output stays in the run folder)..." >&2
-  # Always invoke yarn with the repo itself as cwd (not the run folder) so
-  # Corepack resolves the repo's pinned packageManager version correctly —
-  # see the header comment above for why this matters.
-  if [ -n "$SOURCEMAPS" ] && [ -n "$(ls -A "$RUNDIR/sourcemaps" 2>/dev/null)" ]; then
-    ( cd "$REPO" && yarn --cwd "$REPO" react-native-release-profiler --local "$RAW_CPUPROFILE" --sourcemap-path "$RUNDIR/sourcemaps" --output "$RUNDIR/input" )
+  # --sourcemap-path must point at the source map FILE, not at a directory:
+  # the transformer behind the CLI does readFile() + JSON.parse() on it, so a
+  # directory (such as the one we just unzipped a CI artifact into) fails with
+  # EISDIR. Pick the map out of whatever was staged.
+  SOURCEMAP_FILE=""
+  if [ -n "$SOURCEMAPS" ]; then
+    for NAME in index.js.map index.android.bundle.map; do
+      SOURCEMAP_FILE="$(find "$RUNDIR/sourcemaps" -type f -name "$NAME" -print -quit)"
+      if [ -n "$SOURCEMAP_FILE" ]; then break; fi
+    done
+    if [ -z "$SOURCEMAP_FILE" ]; then
+      SOURCEMAP_FILE="$(find "$RUNDIR/sourcemaps" -type f -name '*.map' -print -quit)"
+    fi
+    if [ -n "$SOURCEMAP_FILE" ]; then
+      echo "Using source map: $SOURCEMAP_FILE" >&2
+    else
+      echo "WARNING: --sourcemaps was given but contains no .map file (expected index.js.map or index.android.bundle.map)." >&2
+    fi
+  fi
+
+  # The CLI has no --output/--dstPath flag — it always writes
+  # <profile-basename>-converted.json into the *process cwd*, and that cwd has
+  # to be the repo so Corepack resolves the pinned Yarn version (see the
+  # header comment). So predict the name and move the result into the run
+  # folder afterwards, keeping the repo clean.
+  CONVERTED_NAME="$(basename "$RAW_CPUPROFILE")"
+  CONVERTED_NAME="${CONVERTED_NAME%.cpuprofile}-converted.json"
+  echo "Converting raw .cpuprofile via yarn react-native-release-profiler..." >&2
+  if [ -n "$SOURCEMAP_FILE" ]; then
+    ( cd "$REPO" && yarn --cwd "$REPO" react-native-release-profiler --local "$RAW_CPUPROFILE" --sourcemap-path "$SOURCEMAP_FILE" )
   else
-    echo "WARNING: no sourcemaps provided — findings will stay at the minified-bundle level and almost nothing will resolve to app/components/UI/Bridge/**." >&2
-    ( cd "$REPO" && yarn --cwd "$REPO" react-native-release-profiler --local "$RAW_CPUPROFILE" --output "$RUNDIR/input" )
+    echo "WARNING: converting without source maps — frames stay at the minified-bundle level, so nothing resolves to a real file path and the ownership/area columns collapse to \"unknown\"." >&2
+    # With no --sourcemap-path, the CLI tries to *invent* one: it looks for an
+    # Android debug build map and otherwise downloads `/index.map` from a
+    # running Metro server on --port (default 8081). A Metro dev-bundle map
+    # cannot symbolicate a release Hermes capture — it either crashes the
+    # transformer or produces confidently wrong attributions — so point --port
+    # at a port nothing listens on. The fetch then fails, and the CLI
+    # continues mapless, which is the honest outcome here.
+    ( cd "$REPO" && yarn --cwd "$REPO" react-native-release-profiler --local "$RAW_CPUPROFILE" --port 0 )
+  fi
+  if [ -f "$REPO/$CONVERTED_NAME" ]; then
+    mv "$REPO/$CONVERTED_NAME" "$RUNDIR/input/"
   fi
   CONVERTED="$(find "$RUNDIR/input" -iname '*-converted.json' -print -quit)"
 fi
@@ -224,7 +277,7 @@ if [ -z "$ANALYZER" ]; then
 fi
 
 REPORT="$RUNDIR/report.md"
-node "$ANALYZER" --profile "$CONVERTED" --scope "$SCOPE" --top "$TOP" --out "$REPORT"
+node "$ANALYZER" --profile "$CONVERTED" --top "$TOP" --out "$REPORT" "${ANALYZER_OPTS[@]+"${ANALYZER_OPTS[@]}"}"
 
 # Capture the report content now — the run folder (including this file) is
 # removed by the EXIT trap as soon as the script returns.

--- a/domains/swaps/skills/swaps-cpu-profile-audit/skill.md
+++ b/domains/swaps/skills/swaps-cpu-profile-audit/skill.md
@@ -3,33 +3,45 @@ name: swaps-cpu-profile-audit
 description: >-
   Parse an already-recorded Hermes / React Native Release Profiler
   `.cpuprofile` (ideally symbolicated with source maps) and audit it for slow
-  frames, scoping every finding and fix proposal to the swaps/bridge screen
-  and the modals or subpages it opens — quote select screen, post-trade
-  modal, batch sell, asset picker/token selector. Use when a user hands you a
-  `.cpuprofile` file (e.g. a `sampling-profiler-trace*.cpuprofile`, or its
-  already-converted `*-converted.json`) recorded per
-  `docs/readme/release-build-profiler.md` and asks to audit, analyze, explain,
-  or find why the swaps/bridge flow is slow based on that trace. This is an
-  offline, file-based analysis — no simulator, device, Metro, or `mm` session
-  is required, unlike `swaps-perf-audit` (which measures live render counts on
-  a running simulator). Findings and fix proposals are scoped strictly to
-  `app/components/UI/Bridge/**`; hot frames elsewhere in the trace are never
-  reported, not even as context. The report always leads with a timing table
-  (capture metrics + by-area self time) and a short outcome line, and only
-  adds a probable-cause/fix table when there's an actual swaps/bridge issue
-  to fix — no speculative text beyond that. MetaMask Mobile only.
+  frames on the swaps/bridge screen and the modals or subpages it opens —
+  quote select screen, post-trade modal, batch sell, asset picker/token
+  selector. Use when a user hands you a `.cpuprofile` file (e.g. a
+  `sampling-profiler-trace*.cpuprofile`, or its already-converted
+  `*-converted.json`) recorded per `docs/readme/release-build-profiler.md` and
+  asks to audit, analyze, explain, or find why the swaps/bridge flow is slow
+  based on that trace. This is an offline, file-based analysis — no simulator,
+  device, Metro, or `mm` session is required, unlike `swaps-perf-audit` (which
+  measures live render counts on a running simulator). The audit accounts for
+  ALL time in the capture, not just swaps-owned code: non-swaps frames that
+  ran while the user sat on a swaps screen (navigation, redux, design system,
+  polling controllers, React internals) are reported too, each labelled with
+  whether the swaps team owns it and how it relates to the swaps call stacks.
+  The report always leads with a timing table (capture metrics + by-area self
+  time with an ownership column) and a short outcome line, and only adds a
+  probable-cause/fix table when there is an actual issue — deep fixes are
+  proposed for swaps-owned rows, while non-owned rows are named and routed.
+  MetaMask Mobile only.
 maturity: stable
 ---
 
 # Swaps CPU Profile Audit
 
-Turns a captured Hermes CPU profile into a swaps/bridge-scoped performance
-audit: which frames under `app/components/UI/Bridge/**` actually burned time
-in the capture, which surface they belong to (main screen, quote select,
-post-trade, batch sell, asset picker, ...), and what to change. This skill
-owns the profile-parsing protocol and the swaps-tree scoping; the fix recipes
-themselves live in the `performance` skill, and the live on-device
-measurement counterpart is `swaps-perf-audit`.
+Turns a captured Hermes CPU profile into a performance audit of the
+swaps/bridge experience: which frames actually burned time in the capture,
+which surface they belong to (main screen, quote select, post-trade, batch
+sell, asset picker, ...), **whether the swaps team owns them**, and what to
+change. This skill owns the profile-parsing protocol, the swaps-tree area
+map, and the ownership/relation classification; the fix recipes themselves
+live in the `performance` skill, and the live on-device measurement
+counterpart is `swaps-perf-audit`.
+
+Auditing only swaps-owned files misses a whole class of real regressions: a
+capture taken on the swaps screen can be dominated by a slow navigator
+transition, a re-rendering provider, an unmemoized shared selector, or a
+polling controller — none of it under `app/components/UI/Bridge/**`, all of
+it felt by the user as "swaps is slow". So the analyzer classifies **every**
+frame in the capture, and the report names the non-swaps contributors instead
+of dropping them.
 
 ## When To Use
 
@@ -41,6 +53,8 @@ Use when the user:
   profiling session, or Release Profiler capture in hand.
 - Wants swaps performance fixes justified by trace evidence instead of a
   static code sweep.
+- Needs to know whether the cost on a swaps screen is actually the swaps
+  team's to fix, or belongs to another team's code.
 
 Do not use for:
 
@@ -51,41 +65,99 @@ Do not use for:
   disk.
 - Live render-count / re-render measurement on a running simulator — use
   `swaps-perf-audit`.
-- Non-swaps screens, or hot frames outside `app/components/UI/Bridge/**` —
-  never report or propose fixes for these, not even as context; point the
-  user at the general `performance` skill instead if they ask about
-  app-wide performance.
+- A capture that was not recorded on the swaps/bridge screens, or a general
+  app-wide performance sweep — the whole model here assumes the user was
+  sitting on a swaps surface while recording, which is what makes non-swaps
+  frames in the trace attributable at all. Point them at the general
+  `performance` skill instead.
 - MetaMask Extension — Hermes/Release Profiler `.cpuprofile` capture doesn't
   exist there; this skill installs only for `metamask-mobile`.
+
+## How ownership and relation are decided
+
+Two independent axes, both computed by the analyzer:
+
+**Owned by swaps** — the frame's resolved source path matches one of the
+swaps-owned roots (`app/components/UI/Bridge/**` plus the swaps redux slice,
+selectors, bridge controller/messenger wiring, bridge utils, and the
+swaps/bridge confirmation rows). This is a path-list decision, so it is
+stable and does not depend on the trace.
+
+**Relation to swaps** — where the frame sat relative to swaps code in the
+recorded call stacks:
+
+| Relation | Meaning | Typical example |
+|---|---|---|
+| `Swaps-owned` | The frame is swaps code | `BridgeView`, `useQuotes` |
+| `Called by swaps` | Non-swaps frame that ran with a swaps frame below it on the stack — swaps code invoked it | `useSelector`, a shared hook, a design-system component rendered by swaps |
+| `Hosts swaps screen` | Non-swaps frame that was on the stack when swaps code was entered — it renders/hosts the screen | React reconciler, navigator, redux `Provider` |
+| `Concurrent (off swaps path)` | Non-swaps frame that never shares a stack with swaps code — it competes for the JS thread anyway | Token detection / balance polling, analytics flush |
+| `Runtime / idle` | Engine bookkeeping owned by nobody, excluded from every percentage | `[root]` (wall time with no JS running), `[GC young gen]` |
+
+The distinction drives what you do with a finding: `Called by swaps` is often
+still a swaps bug (swaps calls it too often, or with unstable arguments),
+`Hosts swaps screen` usually means the screen makes the host do too much
+work, and `Concurrent` is someone else's timer stealing frames while the user
+is mid-swap.
+
+### Self time vs inclusive time — read both
+
+Self time answers "which frame was executing", so it lands on the *leaf* of
+the stack. A React component that renders a heavy tree therefore often shows
+**0 ms of self time** while the cost piles up in the reconciler, a selector,
+or a dependency it called. `Swaps-owned code: 0.00 ms` never means "swaps did
+nothing" on its own — check the inclusive column and the
+`Called by swaps` rows before concluding anything, because "swaps triggers
+expensive work" is a swaps finding even when no swaps frame is hot.
+
+Two corollaries for reading the analyzer output honestly:
+
+- **Idle is not work.** `[root]` owns all the wall time when no JS is running,
+  which on a capture where the user paused can be most of it. The analyzer
+  splits it (and GC) into `Runtime / idle` and excludes it from every
+  percentage, so "% of JS work" means what it says. Never put an idle or GC
+  row in the fix table.
+- **A zero-self area with a trivial inclusive span means nothing.** Usually
+  it is just a module getting evaluated (a screen the user never opened).
+  The analyzer only keeps a zero-self swaps row when the work it triggered
+  clears `--trigger-min-pct` (default 5% of JS work); do not reintroduce
+  those rows by hand.
 
 ## Workflow
 
 1. **Locate the inputs.** You need the `.cpuprofile` path. Source maps are
    optional but strongly preferred — without them, frames stay at the
-   minified-bundle level and almost nothing will resolve to
-   `app/components/UI/Bridge/**`, which defeats the scoping this skill exists
-   to do. If the user has sourcemaps (from a local `--sourcemap-path` or a
-   `*-sourcemaps-<build>` CI artifact) but hasn't converted yet, do that next.
+   minified-bundle level, so nothing resolves to a real path and both the
+   ownership and area columns collapse to "unknown". If the user has
+   sourcemaps (from a local `--sourcemap-path` or a `*-sourcemaps-<build>` CI
+   artifact) but hasn't converted yet, do that next.
 2. **Symbolicate.** Convert the raw profile with the project's own tool,
    which resolves bundle positions back to original `app/...` source paths:
    ```bash
-   yarn react-native-release-profiler --local <profile.cpuprofile> --sourcemap-path <sourcemaps>
+   # --sourcemap-path takes the .map FILE, not a directory or a zip.
+   # The output lands in the CURRENT DIRECTORY — the CLI has no output flag.
+   yarn react-native-release-profiler --local <profile.cpuprofile> \
+     --sourcemap-path <sourcemaps>/index.js.map
    ```
-   This writes `<profile>-converted.json` next to the input. Skip this step
-   only if the user already has a converted JSON, or has no sourcemaps at
-   all (state clearly in the report that findings are then best-effort and
-   file/line attribution is unreliable).
+   This writes `<profile-basename>-converted.json` into the directory you ran
+   it from. Never omit `--sourcemap-path` just to "see what happens": without
+   it the CLI silently substitutes a map of its own (an Android *debug* build
+   map, or `/index.map` downloaded from a running Metro server), which cannot
+   symbolicate a release Hermes capture — it either crashes the transformer or
+   produces confidently wrong file attributions. See the repo overlay for the
+   exact commands and traps. Skip this step only if the user already has a
+   converted JSON, or has no sourcemaps at all (state clearly in the report
+   that findings are then best-effort and file/line attribution is
+   unreliable).
 3. **Aggregate.** Run the bundled analyzer against the converted JSON (or the
    raw `.cpuprofile` as a fallback — see the repo overlay for exact usage).
    It reconstructs self time and total (inclusive) time per frame from the
-   sampling data, buckets in-scope frames by swaps surface
+   sampling data, then emits four separate tables: swaps-owned areas
    (`app/components/UI/Bridge/**` subfolder → BridgeView / QuoteSelectorView /
    PostTradeBottomSheet / BatchSell\* / BridgeTokenSelector / ... — see the
-   repo overlay's area table), and drops out-of-scope frames from the printed
-   report entirely (it only surfaces what % of the capture they accounted
-   for, never a list of the actual out-of-scope files/functions). It also
-   reports the capture's actual duration (no ideal/minimum comparison for
-   now — just the raw timing).
+   repo overlay's area table), non-swaps areas on the swaps path, non-swaps
+   areas running concurrently, and runtime/idle. Areas that did no work and
+   triggered none are dropped, so every row you see earned its place.
 4. **Read the code at the hot frames.** A `file:line` with high self time is
    a *symptom*, not a diagnosis — open the file, read the actual code at that
    location and its call sites, and identify the concrete anti-pattern (dead
@@ -96,65 +168,75 @@ Do not use for:
    `mm-redux-antipatterns.md`, `mm-hook-dependency-arrays.md`,
    `mm-context-performance.md`, `mm-eager-work-on-mount.md`, etc.) for the fix
    recipe rather than inventing one from scratch.
-5. **Always report the timing table; keep prose minimal.** Every report
-   leads with the timing data — the analyzer's `Metric | Value` block and its
-   by-area self-time breakdown — regardless of whether an issue was found.
-   Follow it with exactly one short line stating the outcome (whether
-   swaps/bridge code showed up as a meaningful cost). Never report frames
-   outside `app/components/UI/Bridge/**` — not as a fix target, not as
-   context, not at all; if the trace's biggest cost genuinely lives
-   elsewhere, simply omit it rather than mentioning it. Do not add
-   speculation, hedging, or suggestions about what to check/run next beyond
-   what's in Step 6 — the report is data plus outcome, nothing else.
-6. **If an issue was found, add a probable-cause/fix table — nothing more.**
-   One row per swaps-tree area with meaningful self time: the screen, the
-   probable cause in plain language (what's happening and why — not
-   "unmemoized selector" but e.g. "re-sorts the whole quote list every time
-   you interact with the screen", with the concrete anti-pattern and
-   `file:line`/self-ms/calls folded into that same cell), and the fix citing
-   the relevant `performance` skill guide. Do not append anything after this
-   table — no next-steps, no suggestion to re-run tests or capture a new
-   profile, no broader speculation. The only exception is a single factual
-   caveat line when something materially undermines the finding: no
-   sourcemaps were available (best-effort file/line attribution) or the
+5. **For each hot non-swaps frame, work out what pulled it in.** Do not stop
+   at the relation label — establish the concrete link before reporting it.
+   For `Called by swaps`, find the swaps call site (`grep` the hook/component
+   name under `app/components/UI/Bridge`) and say which swaps surface drives
+   it, since the fix is frequently on the swaps side. For `Hosts swaps
+   screen`, say what the screen makes the host do (mount cost, prop churn,
+   provider re-render). For `Concurrent (off swaps path)`, name the mechanism
+   (a poll, a subscription, an animation) — that row is context for the user,
+   not a swaps task.
+6. **Always report the timing tables; keep prose minimal.** Every report leads
+   with the timing data — the analyzer's `Metric | Value` block, then the
+   swaps-owned area table, then the two non-swaps tables — regardless of
+   whether an issue was found. Follow it with exactly one short line stating
+   the outcome: where the capture's JS work actually went, and whether the
+   expensive part is swaps-owned. Do not add speculation, hedging, or
+   suggestions about what to check/run next beyond what's in Step 7 — the
+   report is data plus outcome, nothing else.
+7. **If an issue was found, add a probable-cause/fix table — nothing more.**
+   Each row carries an `Owned by swaps` cell so the reader sees at a glance
+   what the swaps team can act on. Order rows by self time, swaps-owned first.
+   Per row: the screen or area, the probable cause in plain language (what's
+   happening and why — not "unmemoized selector" but e.g. "re-sorts the whole
+   quote list every time you interact with the screen", with the relation,
+   `file:line`, self-ms and calls folded into that same cell), and the fix.
+   Depth differs by ownership: for `Owned by swaps = Yes`, give the concrete
+   fix citing the relevant `performance` skill guide; for `No`, keep the fix
+   cell to a short pointer plus who should take it (the owning area/team —
+   `.github/CODEOWNERS` maps the file path to a team if the user needs to
+   route it), and do not write a detailed patch plan for code another team
+   maintains.
+
+   Be ruthless about what earns a row — the table exists to be acted on, and
+   every row that can't be is noise that buries the ones that can:
+   - Every swaps-owned area with real self time, or with a large inclusive
+     span, gets its own row. This detail is the point of the audit.
+   - Non-swaps areas: only the few that genuinely matter (roughly ≥5% of JS
+     work each, and rarely more than three rows). A dependency at 0.6% is not
+     a finding.
+   - Never a row for `Runtime / idle`, `[root]`, or GC. If GC volume looks
+     symptomatic, it belongs in the cause cell of the row that caused it, not
+     in a row of its own.
+   - Never a row you cannot explain in plain language. If you couldn't read
+     the code behind it (unsymbolicated, or a minified dependency internal),
+     say so in the caveat line instead of inventing a row.
+
+   Do not append anything after this table — no next-steps, no suggestion to
+   re-run tests or capture a new profile, no broader speculation. The only
+   exception is a single factual caveat line when something materially
+   undermines the finding: no sourcemaps were available, the source map did
+   not match the build that produced the capture (wrong function names,
+   everything resolving to `[root]`), most of the capture was idle, or the
    capture looks too short to cover the full journey (quote fetch, screen
    transitions, animations). Skip that caveat whenever the capture and
    findings look adequate.
 
-The exact commands, the swaps-tree area map, and the bundled analyzer's usage
-are in the repo overlay (`repos/metamask-mobile.md`).
+The exact commands, the swaps-tree area map, the context area map, and the
+bundled analyzer's usage are in the repo overlay
+(`repos/metamask-mobile.md`).
 
 ## Output format
 
-Always lead with the timing table (overview metrics + by-area self-time
-breakdown), then exactly one short outcome line. Never include a row/section
-for frames outside `app/components/UI/Bridge/**` — if the biggest cost in
-the trace lives elsewhere, leave it out entirely rather than noting it as
-context. Do not add anything beyond what's specified below — no
-speculation, no assumptions, no suggestions about what to check or run
-next.
+Lead with the metrics table, then the swaps-owned area table, then the two
+non-swaps tables (omit either if it has no rows), then exactly one short
+outcome line. Keep the tables separate — swaps-owned detail is the subject of
+the audit, and the non-swaps tables are context around it. Do not add anything
+beyond what's specified below — no speculation, no assumptions, no suggestions
+about what to check or run next.
 
-**No in-scope issue found:**
-
-```
-# CPU Profile Audit — swaps/bridge
-
-| Metric | Value |
-|---|---|
-| Capture length | ~<Xs> |
-| Time spent in swaps/bridge | <Y>ms (<Z>% of all sampled time) |
-
-| Area | Self time (ms) | % of swaps time | Hot spots |
-|---|---|---|---|
-| <Area> | <ms> | <%> | <n> |
-
-No meaningful swaps/bridge performance issue in this capture — <one-line factual summary, e.g. "only <Y>ms of self time total, from <what/where>">.
-```
-
-**Issue(s) found** — same two tables, plus a probable-cause/fix table. Keep
-it skimmable (a non-engineer should get the gist without decoding jargon);
-fold `file:line`/self-ms/calls detail into the "Probable cause" cell rather
-than adding separate columns:
+**No issue found:**
 
 ```
 # CPU Profile Audit — swaps/bridge
@@ -162,17 +244,62 @@ than adding separate columns:
 | Metric | Value |
 |---|---|
 | Capture length | ~<Xs> |
-| Time spent in swaps/bridge | <Y>ms (<Z>% of all sampled time) |
+| JS work sampled | <Y>ms |
+| Idle / GC (excluded from the splits) | <Y>ms (<Z>% of capture) |
+| Swaps-owned code | <Y>ms (<Z>% of JS work) |
+| Non-swaps code on the swaps path | <Y>ms (<Z>%) |
+| Non-swaps code running concurrently | <Y>ms (<Z>%) |
 
-| Area | Self time (ms) | % of swaps time | Hot spots |
+**Swaps-owned areas**
+
+| Area | Self time (ms) | % of swaps time | Inclusive (ms) |
 |---|---|---|---|
-| <Area> | <ms> | <%> | <n> |
+| <Area> | <ms> | <%> | <ms> |
 
-Found <N> swaps/bridge issue(s) costing ~<Y>ms.
+No meaningful performance issue in this capture — <one-line factual summary, e.g. "only <Y>ms of JS work in <Xs>, most of it <what>">.
+```
 
-| Screen | Probable cause | Fix |
+**Issue(s) found** — same tables, plus a probable-cause/fix table. Keep it
+skimmable (a non-engineer should get the gist without decoding jargon); fold
+relation/`file:line`/self-ms/calls detail into the "Probable cause" cell
+rather than adding separate columns:
+
+```
+# CPU Profile Audit — swaps/bridge
+
+| Metric | Value |
+|---|---|
+| Capture length | ~<Xs> |
+| JS work sampled | <Y>ms |
+| Idle / GC (excluded from the splits) | <Y>ms (<Z>% of capture) |
+| Swaps-owned code | <Y>ms (<Z>% of JS work) |
+| Non-swaps code on the swaps path | <Y>ms (<Z>%) |
+| Non-swaps code running concurrently | <Y>ms (<Z>%) |
+
+**Swaps-owned areas**
+
+| Area | Self time (ms) | % of swaps time | Inclusive (ms) |
+|---|---|---|---|
+| <Area> | <ms> | <%> | <ms> |
+
+**Non-swaps areas on the swaps path**
+
+| Area | Relation to swaps | Self time (ms) | % of JS work |
+|---|---|---|---|
+| <Area> | Called by swaps / Hosts swaps screen | <ms> | <%> |
+
+**Non-swaps areas running concurrently**
+
+| Area | Self time (ms) | % of JS work |
 |---|---|---|
-| <Area, e.g. "Quote select screen"> | <plain-language root cause, e.g. "re-sorts the whole quote list every time you interact with the screen"> — <self>ms, <calls>x, `<file>:<line>` | <concrete fix> (see `<guide>.md`) |
+| <Area> | <ms> | <%> |
 
-<optional single factual caveat line — only if sourcemaps were missing or the capture looked too short>
+Found <N> issue(s) costing ~<Y>ms, of which <M> are swaps-owned.
+
+| Screen / area | Owned by swaps | Probable cause | Fix |
+|---|---|---|---|
+| <Area, e.g. "Quote select screen"> | Yes | <plain-language root cause, e.g. "re-sorts the whole quote list every time you interact with the screen"> — <self>ms, <calls>x, `<file>:<line>` | <concrete fix> (see `<guide>.md`) |
+| <Area, e.g. "Navigation (app nav stack)"> | No | <plain-language root cause + how it relates to swaps, e.g. "the navigator re-renders the whole tab stack while the swaps screen mounts"> — <self>ms, <calls>x, `<file>:<line>` | <short pointer>; owned by <area/team>, raise it with them |
+
+<optional single factual caveat line — only if source maps were missing or mismatched, the capture was mostly idle, or it looked too short>
 ```


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

- `swaps-cpu-profile-audit` now audits the whole capture instead of swaps-owned files only: non-swaps frames that ran while the user was on a swaps screen are classified by their relation to the swaps call stacks (called by swaps, hosts the swaps screen, or concurrent with it), bucketed into named context areas, and reported alongside swaps rows. Every reported row carries an `Owned by swaps` column, and fix depth is gated on it. New `--context-min-pct` and `--swaps-only` analyzer flags.
- `swaps-cpu-profile-audit` reports swaps-owned areas, non-swaps areas on the swaps path, and non-swaps areas running concurrently as separate tables, so the per-area swaps detail is no longer diluted by context rows. The swaps table gained an inclusive-time column, and the report explains that self time on a leaf means a screen can trigger heavy work while showing ~0 ms of its own. Non-swaps rows in the fix table are now capped to the few that matter.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] New skill
- [x] Skill improvement/update
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## Skill Details (if adding a new skill)

**Provider Name:** 
**Skill Name:** 
**Brief Description:** 

## Checklist

<!-- Mark completed items with an "x" -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/MetaMask/skills/blob/main/CONTRIBUTING.md) guidelines
- [x] My skill follows the [SKILL_TEMPLATE.md](https://github.com/MetaMask/skills/blob/main/.github/SKILL_TEMPLATE.md) format
- [x] I have tested this skill with an AI agent
- [x] My skill does not contain any secrets, private keys, or sensitive data
- [x] I have added appropriate documentation
- [x] My changes don't break existing skills

## Testing

<!-- Describe how you tested this skill -->
Run multiple audits to ensure the report is accurate.

## Additional Context

<!-- Add any other context or screenshots about the PR here -->
