### PR TITLE
docs(testing): ban nested findBy inside waitFor in CV skill

### DIFF
--- a/domains/testing/skills/mobile-testing/references/component-view.md
+++ b/domains/testing/skills/mobile-testing/references/component-view.md
@@ -125,6 +125,8 @@ For run-by-name, watch mode, or other options, see `component-view/reference.md`
 
 13. **Await the content, not just its container** — a container arriving on screen says nothing about values inside it that have their own async source (a child query, a debounce, a skeleton). Await the gated value with `findBy*`, then re-query the container and scope the remaining synchronous assertions with `within()`.
 
+14. **Do not nest `find*` inside `waitFor`** — `findBy*` already *is* `waitFor` + `getBy` (default timeout 1000 ms). Nesting them shares that budget, so CI can fail with a bare `Timed out in waitFor.` and no assertion detail. Use `await findBy*` **or** `waitFor(() => { getBy*; expect(...) })` with an explicit `{ timeout }` when you need extra time. Never `waitFor(async () => { await findBy*(...) })`.
+
 
 ## Reference files (when to use)
 

--- a/domains/testing/skills/mobile-testing/references/component-view/navigation-mocking.md
+++ b/domains/testing/skills/mobile-testing/references/component-view/navigation-mocking.md
@@ -179,9 +179,7 @@ afterEach(() => {
 
 it('user sees trending tokens section with mocked data', async () => {
   const { findByText, queryByTestId } = renderTrendingViewWithRoutes();
-  await waitFor(async () => {
-    expect(await findByText('Ethereum')).toBeOnTheScreen();
-  });
+  expect(await findByText('Ethereum')).toBeOnTheScreen();
   // assert rows with assertTrendingTokenRowsVisibility(...)
 });
 

--- a/domains/testing/skills/mobile-testing/references/component-view/reference.md
+++ b/domains/testing/skills/mobile-testing/references/component-view/reference.md
@@ -72,6 +72,7 @@ Before declaring the task done, go through this checklist for every test written
 | 12  | **Pull-to-refresh uses `refreshControl.props.onRefresh`** — not `fireEvent(scrollView, 'refresh')`                                                                                                                                                            | Call the prop handler inside `act`                                     |
 | 13  | **Unit→CV migrations keep assert specificity** — deleted unit payload fields (`tabId`, formatted dates, full analytics) still appear in the CV replacement                                                                                                   | Restore dropped fields in CV or KEEP a focused unit; see unit-cv-overlap |
 | 14  | **Awaits cover the asserted content, not just its container** — after `await findByTestId(CONTAINER)`, no synchronous `getBy*` asserts a value that has its own async source (child query, debounce, skeleton)                                                | Await the gated value with `findBy*` first, then re-query the container and scope the sync asserts |
+| 15  | **No nested `find*` inside `waitFor`** — no `waitFor(async () => { await findBy*(...) })`. `findBy*` already polls with the same 1s default timeout                                                                                                         | Use `await findBy*` **or** `waitFor(() => { getBy*; expect(...) })` with `{ timeout }` |
 
 ---
 
@@ -90,6 +91,7 @@ Before declaring the task done, go through this checklist for every test written
 | `No QueryClient set`                                                   | Missing provider — not in Engine mock                                                                | Add to mocks.ts or wrap with QueryClientProvider in renderer                                                        |
 | Flakey number assertions                                               | Non-deterministic exchange rates                                                                     | Add `deterministicFiat: true`                                                                                       |
 | Test passes locally, fails in CI                                       | Time-sensitive assertions, stale press under CI load, or a sync assert on content that is still loading | Use `waitFor` / `findBy`; re-query before press when the UI re-renders on a timer; await each async-gated value    |
+| `Timed out in waitFor.` with no assertion detail                       | Nested `find*` inside `waitFor` — both share the 1s default; the outer waiter expires first             | Use `await findBy*` **or** `waitFor(() => getBy*)` with `{ timeout }`; never `waitFor(async () => findBy*)`      |
 | Pull-to-refresh never refetches                                        | `fireEvent(scrollView, 'refresh')` did not hit the handler                                           | `await act(async () => { await scrollView.props.refreshControl.props.onRefresh(); })`                             |
 | Sheet / branch `testID` missing                                        | Remote feature flag off in Redux; UI routes elsewhere                                                | Override `RemoteFeatureFlagController` / preset so the gated UI mounts                                            |
 
@@ -125,6 +127,17 @@ expect(getByTestId('cta-button')).toBeDisabled();
 // After interaction
 fireEvent.press(getByTestId('some-button'));
 await waitFor(() => expect(getByText('Result')).toBeOnTheScreen());
+
+// findBy* already waits — do not wrap it in waitFor
+expect(await findByText('Token A')).toBeOnTheScreen();
+
+// waitFor + getBy* when you need extra time or a length check
+await waitFor(
+  () => {
+    expect(getAllByTestId(MyViewSelectorsIDs.ROW)).toHaveLength(3);
+  },
+  { timeout: 5000 },
+);
 
 // Navigation assertion
 await findByTestId(`route-${Routes.SOME_SCREEN}`);
@@ -212,6 +225,20 @@ const settledRow = getByTestId(MyViewSelectorsIDs.ROW_CONTAINER);
 expect(within(settledRow).getByText('$60')).toBeOnTheScreen();
 // Static props in the same row render immediately, so a neighbouring assert
 // passing proves nothing about the gated one.
+
+// ❌ Nest find* inside waitFor — double polling, both default to 1s
+await waitFor(async () => {
+  expect(await findByText('Token A')).toBeOnTheScreen();
+});
+// ✅ One waiter: findBy* already polls
+expect(await findByText('Token A')).toBeOnTheScreen();
+// ✅ Or waitFor + synchronous getBy* when you need extra time or a count
+await waitFor(
+  () => {
+    expect(getAllByTestId(MyViewSelectorsIDs.ROW)).toHaveLength(3);
+  },
+  { timeout: 5000 },
+);
 
 // ❌ Custom nested navigator only to assert navigation occurred
 extraRoutes: [{ name: Routes.FEATURE.ROOT, Component: NestedStackProbe }];

--- a/domains/testing/skills/mobile-testing/references/component-view/writing-tests.md
+++ b/domains/testing/skills/mobile-testing/references/component-view/writing-tests.md
@@ -75,6 +75,27 @@ expect(within(positionsTab).getByText('$60')).toBeOnTheScreen();
 
 When a test like this fails, the render dump shows the container present with empty `pointerEvents="none"` views where the value belongs — those are the skeleton placeholders.
 
+**Do not nest `find*` inside `waitFor`** — `findBy*` already polls (`waitFor` + `getBy`, default 1000 ms). An outer `waitFor` uses the same budget, so under CI load the outer timeout fires first with a useless `Timed out in waitFor.` Pick one waiter:
+
+```typescript
+// ✅ findBy* already waits
+expect(await findByText('Token A')).toBeOnTheScreen();
+
+// ✅ waitFor + synchronous getBy* when you need extra time or a count
+await waitFor(
+  () => {
+    const rows = getAllByTestId(MyViewSelectorsIDs.ROW);
+    expect(rows).toHaveLength(3);
+  },
+  { timeout: 5000 },
+);
+
+// ❌ double polling — both timers are 1s; the outer one wins in CI
+await waitFor(async () => {
+  expect(await findByText('Token A')).toBeOnTheScreen();
+});
+```
+
 **RefreshControl** — Prefer calling the prop handler; `fireEvent(scrollView, 'refresh')` often never hits `onRefresh` in RNTL:
 
 ```typescript
@@ -175,10 +196,8 @@ it('calls quote API with custom slippage when user has set 5% and quote is reque
 it('user sees all items with complete data after async load', async () => {
   const { findByText, findByTestId } = renderMyFeatureWithRoutes();
 
-  // Wait for the first item to confirm data has loaded
-  await waitFor(async () => {
-    expect(await findByText('Token A')).toBeOnTheScreen();
-  });
+  // Wait for the first item to confirm data has loaded (findBy* already polls)
+  expect(await findByText('Token A')).toBeOnTheScreen();
 
   // Validate all fields of each item in the base mock dataset
   const tokenARow = await findByTestId('token-row-item-eip155:1/erc20:0xAAA');


### PR DESCRIPTION
## Description

Component view tests that wrap `findBy*` in `waitFor` double-poll with the same 1s default timeout. Under CI load the outer waiter expires first and the log is only `Timed out in waitFor.` with no assertion detail (seen on `WatchlistFullScreenView.view.test.tsx`).

The mobile-testing CV skill still *taught* that nested shape in the data-completeness and nock examples. This change:

- Adds golden rule 14: do not nest `find*` inside `waitFor`
- Adds self-review item 15 and a diagnosing-failures row for the bare timeout
- Replaces the nested examples with `await findBy*` (or `waitFor` + `getBy*` + `{ timeout }`)
- Documents the antipattern in What NOT to Do

## Type of Change

- [x] Skill improvement/update
- [ ] New skill
- [ ] Bug fix
- [x] Documentation update
- [ ] Other (please describe):

## Skill Details (if adding a new skill)

**Provider Name:** 
**Skill Name:** 
**Brief Description:** 

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/MetaMask/skills/blob/main/CONTRIBUTING.md) guidelines
- [x] My skill follows the [SKILL_TEMPLATE.md](https://github.com/MetaMask/skills/blob/main/.github/SKILL_TEMPLATE.md) format
- [x] I have tested this skill with an AI agent
- [x] My skill does not contain any secrets, private keys, or sensitive data
- [x] I have added appropriate documentation
- [x] My changes don't break existing skills

## Testing

N/A — documentation-only. Verified remaining `waitFor(async () => findBy*)` occurrences in the CV skill are the new ❌ examples.

## Additional Context

Canonical skill: `testing/mobile-testing` → `references/component-view.md` (and `component-view/writing-tests.md`, `reference.md`, `navigation-mocking.md`).

After merge, run `yarn skills` in metamask-mobile so local agents pick this up. The in-repo copy at `docs/testing/component-view-tests.md` is separate and still has the old example until that file is synced.


Made with [Cursor](https://cursor.com)