### PR TITLE
fix(cli): write Cursor rules as .mdc, the only extension Cursor reads

### DIFF
--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -133,7 +133,7 @@ describe('managed skill pruning', () => {
   test('removes only stale installer-managed skills across project targets', () => {
     const targets = [
       ['.claude/skills', 'SKILL.md'],
-      ['.cursor/rules', 'RULE.md'],
+      ['.cursor/rules', 'RULE.mdc'],
       ['.agents/skills', 'SKILL.md'],
     ];
     const stale = [];

--- a/tools/install
+++ b/tools/install
@@ -264,10 +264,16 @@ write_claude() {
 write_cursor() {
   local out_name="$1" description="$2" content="$3"
   local dir="$CURSOR_DIR/$out_name"
-  local file="$dir/RULE.md"
-  action "cursor: .cursor/rules/$out_name/RULE.md"
+  local file="$dir/RULE.mdc"
+  action "cursor: .cursor/rules/$out_name/RULE.mdc"
   $DRY_RUN && return
   mkdir -p "$dir"
+  # An older installer wrote RULE.md here. Cursor ignores that extension, and leaving
+  # the file behind means the tree carries two copies of the same rule.
+  local legacy="$dir/RULE.md"
+  if [[ -f "$legacy" ]] && grep -Fqx -- "$MANAGED_BANNER" "$legacy"; then
+    rm -f "$legacy"
+  fi
   {
     echo '---'
     yaml_field description "$description"
@@ -409,7 +415,14 @@ expected_project_skill_contains() {
 is_managed_project_skill() {
   local dir="$1" label="$2" marker
   case "$label" in
-    .cursor/rules) marker="$dir/RULE.md" ;;
+    .cursor/rules)
+      # RULE.md is the pre-.mdc layout, still recognised so --prune-stale can clean
+      # up trees an older installer wrote.
+      for marker in "$dir/RULE.mdc" "$dir/RULE.md"; do
+        [[ -f "$marker" ]] && grep -Fqx -- "$MANAGED_BANNER" "$marker" && return 0
+      done
+      return 1
+      ;;
     *) marker="$dir/SKILL.md" ;;
   esac
   [[ -f "$marker" ]] && grep -Fqx -- "$MANAGED_BANNER" "$marker"


### PR DESCRIPTION
## Overview

`tools/install` writes Cursor rules to `.cursor/rules/mms-<skill>/RULE.md`. **On Cursor's documented behavior, it has never read them** — project rules must be `.mdc`; a plain `.md` there is ignored. A fresh `--repo metamask-extension` install at `cce2ee1` emits **89 `.md`, 0 `.mdc`**. The two other properties I checked match documented modes, so the extension alone explains it.

`write_cursor` now emits `RULE.mdc`, deleting the legacy `RULE.md` only when it carries the managed banner, so hand-written rules survive. `is_managed_project_skill` still accepts `RULE.md`, or `--prune-stale` would orphan older trees.

## Showcase

This branch emits **26 `.mdc`, 0 `RULE.md`**; re-installing over an old tree migrates all 26, leaving a hand-written `RULE.md` intact. Reverting only `tools/install` while keeping the new `test/cli.test.mjs` expectation turns the suite red (64 pass, 1 fail) — the test discriminates.

**Not established:** I have not run Cursor against an installed tree, so inertness is a prediction from the docs, not an observation.
