### PR TITLE
docs(testing): clarify extension integration homes

### DIFF
--- a/domains/testing/knowledge/extension-testing-layers.md
+++ b/domains/testing/knowledge/extension-testing-layers.md
@@ -2,9 +2,10 @@
 name: extension-testing-layers
 domain: testing
 description: >
-  MetaMask Extension test-layer policy. Prefer unit for pure logic, E2E for
-  real browser/extension/dapp boundaries. Integration is underused (stub in
-  v1). Canonical source for extension-testing and cross-domain citations.
+  MetaMask Extension test-layer policy. Prefer unit for isolated logic,
+  integration for UI/state or composed-background seams, and E2E for real
+  browser/extension/dapp boundaries. Canonical source for extension-testing
+  and cross-domain citations.
 ---
 
 # Extension Testing Layers
@@ -17,8 +18,8 @@ Do not duplicate this policy in skill `references/` — open this file (installe
 as `knowledge/extension-testing-layers.md` beside testing skills).
 
 **Entrypoint:** Install **`extension-testing`**. That skill routes to unit,
-integration (stub), and E2E create/maintain references. Do not treat the
-deprecated standalone `unit-testing` / `e2e-testing` skills as the primary guide.
+integration, and E2E create/maintain references. Do not treat the deprecated
+standalone `unit-testing` / `e2e-testing` skills as the primary guide.
 
 **Placement audits:** Cross-layer inventory (unit ↔ integration ↔ e2e) is
 **phase 2** — not part of v1. Until then, use this decision tree when choosing
@@ -41,44 +42,61 @@ Is this scenario worth covering? (distinct realistic regression)
 ├─ No → GAP / ACCEPT (document why)
 └─ Yes → Already covered at any correct layer?
    ├─ Yes → KEEP
-   └─ No → Pure logic / helpers / selectors / controllers / RTL unit UI?
+   └─ No → Pure logic / helpers / selectors / isolated controller / narrow RTL UI?
       ├─ Yes → Write or update colocated *.test.ts(x) (extension-testing → unit)
-      └─ No → Needs jsdom app↔controller harness under test/integration/?
-         ├─ Yes (v1 stub) → Prefer unit or E2E unless an existing integration
-         │        suite already covers the seam; expand integration guidance later
-         └─ No → Needs a real browser / extension / dapp / multi-window boundary?
-            ├─ Yes → E2E (extension-testing → e2e)
-            │        Justify briefly: what browser/extension boundary is required.
-            └─ No → GAP / ACCEPT (do not invent E2E)
+      └─ No → Needs full UI + real Redux without a browser?
+         ├─ Yes → UI integration under test/integration/
+         │        (extension-testing → integration)
+         └─ No → Needs real MetaMaskController + child-controller composition?
+            ├─ Yes → Composed-background integration in
+            │        app/scripts/metamask-controller*.test.js
+            │        (extension-testing → integration)
+            └─ No → Needs a real browser / extension / dapp / multi-window boundary?
+               ├─ Yes → E2E (extension-testing → e2e)
+               │        Justify briefly: what browser/extension boundary is required.
+               └─ No → GAP / ACCEPT (do not invent E2E)
 ```
 
 ## Defaults
 
-| Layer           | Owns                                                                                         | File pattern                          |
-| --------------- | -------------------------------------------------------------------------------------------- | ------------------------------------- |
-| **Unit**        | Pure helpers, controllers, selectors, Redux/RTL component contracts                          | colocated `*.test.ts(x)`              |
-| **Integration** | jsdom harness crossing app↔controller (underused; stub in v1)                                | `test/integration/**/*.test.tsx`      |
-| **E2E**         | Real browser/extension/dapp/window journeys after unit (and integration) are insufficient    | `test/e2e/tests/**/*.spec.ts`         |
+| Layer           | Owns                                                                                                  | Existing homes                                                                                      |
+| --------------- | ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| **Unit**        | Pure helpers, isolated controllers, selectors, narrow Redux/RTL component contracts                   | colocated `*.test.ts(x)`                                                                            |
+| **Integration** | Full UI + real Redux with mocked background RPC; or real composed background with mocked external I/O | `test/integration/**/*.test.tsx`; `app/scripts/metamask-controller*.test.js`                         |
+| **E2E**         | Real browser/extension/dapp/window journeys after unit and integration are insufficient               | `test/e2e/tests/**/*.spec.ts`                                                                       |
 
 ## Unit tests
 
 Keep unit tests for:
 
 - Pure helpers and local utilities
-- Controllers, messengers, selectors
+- Isolated controllers, messengers, selectors
 - Component contracts exercised with Jest + RTL (not full browser)
 
 How to write/run: `extension-testing` → `references/unit.md`.
 
-## Integration tests (v1 stub)
+## Integration tests
 
-`test/integration/` exists but is sparsely used. In v1:
+Extension has two existing integration homes for different seams:
 
-- Prefer **unit** or **E2E** unless you are extending an existing integration suite
-- Do not invent a new integration harness without team agreement
-- Full integration writing guidance is deferred (phase 2 expansion)
+- **UI integration:** `test/integration/**/*.test.tsx` renders the real UI root
+  with a real Redux store. Mock the background RPC and external HTTP boundaries.
+- **Composed-background integration:**
+  `app/scripts/metamask-controller.test.js` and
+  `app/scripts/metamask-controller.actions.test.js` construct the real
+  `MetaMaskController` and child-controller graph. Mock external I/O such as
+  network requests, browser APIs, providers, and encryption.
 
-How to open the stub: `extension-testing` → `references/integration.md`.
+These are two homes in the same layer, not two new layers. Pick the home that
+owns the failing boundary. Do not require UI integration coverage to be
+duplicated in `MetaMaskController` tests, and do not invent a new integration
+folder or file suffix without team agreement.
+
+The composed-background files run through the unit Jest command because of the
+repository's existing Jest configuration; their layer is defined by the
+boundary they exercise, not by the command name.
+
+How to write/run: `extension-testing` → `references/integration.md`.
 
 ## When E2E is justified
 
@@ -98,6 +116,7 @@ Invalid reasons alone:
 
 - “It is a user journey” when unit/RTL can cover the behavior
 - Pure controller/helper logic
+- Composed `MetaMaskController` wiring that can run in the existing Node tests
 - Preferring E2E because fixtures already exist nearby without a boundary need
 
 How to write/maintain: `extension-testing` → `references/e2e.md`.

--- a/domains/testing/skills/extension-testing/references/integration.md
+++ b/domains/testing/skills/extension-testing/references/integration.md
@@ -1,26 +1,106 @@
-# Extension integration tests (stub — v1)
+# Extension integration tests
 
-**Status:** Light stub. `test/integration/` exists and is underused. Full writing
-guidance is deferred (phase 2).
+Integration owns behavior that crosses a meaningful in-process boundary but
+does not require a real browser. Extension already has two integration homes;
+choose between them by the seam under test.
 
-## When to use (v1)
+## Choose the home
 
-- Extending an **existing** suite under `test/integration/`
-- The behavior is already covered nearby in integration style and unit/E2E would
-  be a worse fit
+| Behavior under test | Existing home |
+| --- | --- |
+| Full UI tree consuming real Redux state, with background RPC mocked | `test/integration/**/*.test.tsx` |
+| Real `MetaMaskController` and child-controller composition, with external I/O mocked | `app/scripts/metamask-controller.test.js` or `app/scripts/metamask-controller.actions.test.js` |
 
-## When not to use (v1)
+These homes are part of the same Integration layer. Do not add a new
+`*.integration.test.ts` convention or a Mobile-style harness tree. Do not add
+the same scenario to both homes unless they protect distinct boundaries.
 
-- New coverage by default → prefer [`unit.md`](unit.md) or
-  [`e2e.md`](e2e.md) per `knowledge/extension-testing-layers.md`
-- Do not invent a new harness or broad `jest.mock` surface without team agreement
+## UI + state integration
+
+Use this home when the regression is visible through the full UI and Redux
+state, but no browser, extension window, service worker, or dapp boundary is
+required.
+
+### Existing pattern
+
+- Render with `integrationTestRender` from `test/lib/render-helpers.js`.
+- Run the real `Root` component and real Redux store.
+- Supply realistic preloaded state and vary only scenario-specific fields.
+- Mock the background RPC (`submitRequestToBackground`) and external HTTP with
+  nock.
+- Interact through React Testing Library and assert observable UI behavior.
+
+Keep hooks, selectors, reducers, and relevant child components real. Native,
+WASM, or animation stubs are acceptable when jsdom cannot execute them. Treat
+other hook or child-component mocks as exceptions and explain why they are
+required.
+
+Before adding coverage, inspect the nearest suites and shared helpers under
+`test/integration/`. Reuse their state builders and mocks rather than creating
+a parallel harness.
+
+Run:
+
+```bash
+yarn test:integration
+yarn test:integration:coverage
+```
+
+## Composed-background integration
+
+Use this home when isolated controller tests are insufficient because the
+regression depends on `MetaMaskController` initialization, messenger wiring,
+delegation between child controllers, or composed state transitions.
+
+### Existing pattern
+
+- Add the scenario next to the relevant existing `describe` in
+  `app/scripts/metamask-controller.test.js`.
+- Use `app/scripts/metamask-controller.actions.test.js` for the action-facing
+  surface already covered there.
+- Construct and call the real `MetaMaskController` and relevant child
+  controllers.
+- Reuse existing test tools such as `createTestProviderTools`, `mockEncryptor`,
+  nock, browser API mocks, and shared setup helpers.
+- Mock external I/O boundaries only: network requests, browser APIs, providers,
+  hardware/native bridges, encryption, or unavailable services.
+- Drive behavior through public methods/actions and assert observable return
+  values, controller state, emitted actions/events, or delegated calls.
+
+Do not replace a real child controller with a mock when its composition is the
+behavior being tested. If only one controller's logic matters, keep the test
+colocated with that controller and use [`unit.md`](unit.md).
+
+These files currently run through the unit Jest configuration. That command
+name does not change the boundary they exercise:
+
+```bash
+yarn test:unit app/scripts/metamask-controller.test.js
+yarn test:unit app/scripts/metamask-controller.actions.test.js
+```
+
+## When E2E is still required
+
+Use [`e2e.md`](e2e.md) when confidence requires a real browser/extension
+boundary, such as popup or notification windows, dapp/provider injection, MV3
+service-worker lifecycle, browser permissions, or built-extension wiring.
+
+“This is a user journey” is not enough when either integration home exercises
+the responsible boundary with equivalent confidence.
+
+## Hard rules
+
+1. Pick the home by boundary, not by nearby file convention.
+2. Keep external I/O deterministic; do not call live services.
+3. Reuse existing setup and helpers before adding mocks or fixtures.
+4. Do not create a third integration home without team agreement.
+5. Keep one scenario focused on one observable contract.
 
 ## Pointers
 
-- Suites: `test/integration/**/*.test.tsx`
-- Config: `jest.integration.config.js`
-- Commands: `yarn test:integration`, `yarn test:integration:coverage`
-- Philosophy: `docs/testing.md`
-
-When integration guidance is expanded, this file becomes a router (writing /
-harness / reference) similar to Mobile’s `references/integration.md`.
+- UI suites: `test/integration/**/*.test.tsx`
+- UI render helper: `test/lib/render-helpers.js`
+- UI config: `jest.integration.config.js`
+- Composed background: `app/scripts/metamask-controller.test.js`
+- Composed actions: `app/scripts/metamask-controller.actions.test.js`
+- Testing philosophy: `docs/testing.md`

--- a/domains/testing/skills/extension-testing/references/unit.md
+++ b/domains/testing/skills/extension-testing/references/unit.md
@@ -434,6 +434,12 @@ it('has initial balance', () => {
 
 Reference: [MetaMask Controller Guidelines](https://github.com/MetaMask/core/blob/main/docs/controller-guidelines.md)
 
+Use this unit reference when one controller can be exercised in isolation. If
+the behavior depends on real `MetaMaskController` initialization, messenger
+wiring, or delegation across child controllers, use the composed-background
+home in [`integration.md`](integration.md), even though those existing files
+currently run through the unit Jest command.
+
 #### Controller Lifecycle Testing
 
 - **ALWAYS test controller initialization with default state**

--- a/domains/testing/skills/extension-testing/repos/metamask-extension.md
+++ b/domains/testing/skills/extension-testing/repos/metamask-extension.md
@@ -13,6 +13,11 @@ Follow the router in the skill body. Layer policy: installed
 ## In-repo docs (source of truth for paths)
 
 - Unit philosophy: `docs/testing.md`
+- UI integration: `test/integration/**/*.test.tsx` with
+  `test/lib/render-helpers.js`
+- Composed-background integration:
+  `app/scripts/metamask-controller.test.js` and
+  `app/scripts/metamask-controller.actions.test.js`
 - E2E agent index: `test/e2e/AGENTS.md`
 - Driver API: `test/e2e/webdriver/README.md`
 - Visual (`mm` CLI): `test/e2e/playwright/llm-workflow/README.md` — use
@@ -26,6 +31,7 @@ Follow the router in the skill body. Layer policy: installed
 ```bash
 yarn test:unit path/to/file.test.ts
 yarn test:integration
+yarn test:unit app/scripts/metamask-controller.test.js
 yarn build:test   # or yarn start:test while iterating
 yarn test:e2e:single test/e2e/tests/.../foo.spec.ts --browser=chrome
 yarn lint:changed:fix
@@ -34,5 +40,5 @@ yarn lint:changed:fix
 ## Skill references
 
 - Unit: [`../references/unit.md`](../references/unit.md)
-- Integration stub: [`../references/integration.md`](../references/integration.md)
+- Integration: [`../references/integration.md`](../references/integration.md)
 - E2E router: [`../references/e2e.md`](../references/e2e.md)

--- a/domains/testing/skills/extension-testing/skill.md
+++ b/domains/testing/skills/extension-testing/skill.md
@@ -1,11 +1,12 @@
 ---
 name: extension-testing
 description: >
-  Single MetaMask Extension testing entrypoint. Routes unit, integration (stub),
-  and Selenium E2E create/maintain work (flakiness, POM anti-patterns) to the
-  right references. Use when writing, fixing, reviewing Extension tests; when
-  the user mentions FixtureBuilderV2, page objects, E2E flake, POM anti-patterns,
-  MMQA testing-skills tickets, or asks which Extension testing skill to install.
+  Single MetaMask Extension testing entrypoint. Routes unit, UI and
+  composed-background integration, and Selenium E2E create/maintain work
+  (flakiness, POM anti-patterns) to the right references. Use when writing,
+  fixing, reviewing, or placing Extension tests; when the user mentions
+  MetaMaskController, FixtureBuilderV2, page objects, E2E flake, POM
+  anti-patterns, or asks which Extension testing skill to install.
 maturity: stable
 ---
 
@@ -36,7 +37,7 @@ Mobile layers, and cross-layer placement audits (phase 2). Keep those separate.
 - Skill installed via `yarn skills` / `@metamask/skills` for
   `testing/extension-testing`
 - Familiarity with Extension test layout: colocated `*.test.ts(x)`,
-  `test/integration/`, `test/e2e/`
+  `test/integration/`, `app/scripts/metamask-controller*.test.js`, `test/e2e/`
 - For E2E: a test build (`yarn build:test` or `yarn start:test`) and Chrome (or
   Firefox MV2) available
 
@@ -52,8 +53,8 @@ before writing any test. `references/layers.md` is only a redirect stub.
 
 | If the work is… | Open |
 | --- | --- |
-| Pure logic / helpers / selectors / controllers / RTL unit | [`references/unit.md`](references/unit.md) |
-| jsdom app↔controller under `test/integration/` (underused) | [`references/integration.md`](references/integration.md) |
+| Pure logic / helpers / selectors / isolated controller / narrow RTL unit | [`references/unit.md`](references/unit.md) |
+| Full UI + real Redux under `test/integration/`, or real `MetaMaskController` composition under `app/scripts/` | [`references/integration.md`](references/integration.md) |
 | Create or update Selenium E2E / POM / fixtures | [`references/e2e.md`](references/e2e.md) → writing-tests |
 | Fix flaky E2E or POM bad practices / audit anti-patterns | [`references/e2e.md`](references/e2e.md) → maintain / flakiness / pom-antipatterns |
 
@@ -65,16 +66,20 @@ doc sends you there.
 
 1. **Layer gate first.** Prefer **unit → integration (only when justified) →
    E2E**. Document why unit is insufficient before proposing new E2E.
-2. E2E is legitimate for real browser/extension/dapp/window boundaries — do not
+2. Integration has two existing homes. Use `test/integration/` for real UI +
+   Redux with mocked background RPC; use `app/scripts/metamask-controller*.test.js`
+   for real composed-background wiring with external I/O mocked. Do not
+   duplicate every scenario across both homes or invent a new integration tree.
+3. E2E is legitimate for real browser/extension/dapp/window boundaries — do not
    copy Mobile’s “almost never E2E” gate.
-3. For E2E, inspect existing specs, page objects, flows, and fixtures in the
+4. For E2E, inspect existing specs, page objects, flows, and fixtures in the
    feature folder before proposing code.
-4. E2E POM methods must not use `try/catch`. Locators belong in page objects,
+5. E2E POM methods must not use `try/catch`. Locators belong in page objects,
    not flows or specs. Specs must not call the driver for UI actions. Avoid
    hardcoded delays without a justifying comment.
-5. Maintain mode: diagnose with `references/e2e/flakiness.md`, enforce structure
+6. Maintain mode: diagnose with `references/e2e/flakiness.md`, enforce structure
    with `references/e2e/pom-antipatterns.md`. Prefer waits and mocks over retries.
-6. Bugbot is a **local** safety net only (`.cursor/BUGBOT.md`), never a PR merge
+7. Bugbot is a **local** safety net only (`.cursor/BUGBOT.md`), never a PR merge
    gate — see `pom-antipatterns.md`. Get the code right in this skill first.
 
 ## Examples
@@ -82,6 +87,16 @@ doc sends you there.
 ```
 User: Add a unit test for the deep-link parser helper
 Agent: layers → unit → references/unit.md
+```
+
+```
+User: Verify MetaMaskController routes watchAsset through the composed controllers
+Agent: layers → integration (composed background) → references/integration.md
+```
+
+```
+User: Verify a Redux-driven confirmation alert without a browser
+Agent: layers → integration (UI + state) → references/integration.md
 ```
 
 ```


### PR DESCRIPTION
## Description

Clarify the existing MetaMask Extension integration boundaries without introducing a new testing layer or runner.

- Route full UI + real Redux scenarios to `test/integration/`.
- Route composed `MetaMaskController` and child-controller wiring to the existing Node tests under `app/scripts/`.
- Keep isolated controller logic in unit tests and real browser/extension boundaries in E2E.
- Document that the composed-background tests remain on the unit Jest command despite owning an integration boundary.

## Type of Change

- [ ] New skill
- [x] Skill improvement/update
- [ ] Bug fix
- [x] Documentation update
- [ ] Other (please describe):

<!--
## Skill Details (if adding a new skill)

**Provider Name:**
**Skill Name:**
**Brief Description:**
-->

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/MetaMask/skills/blob/main/CONTRIBUTING.md) guidelines
- [x] My skill follows the [SKILL_TEMPLATE.md](https://github.com/MetaMask/skills/blob/main/.github/SKILL_TEMPLATE.md) format
- [ ] I have tested this skill with an AI agent
- [x] My skill does not contain any secrets, private keys, or sensitive data
- [x] I have added appropriate documentation
- [x] My changes don't break existing skills

## Testing

- `yarn audit:skills` (0 errors; pre-existing warnings only)
- `yarn test` (65 tests passed)
- `git diff --check`

## Additional Context

This deliberately does not add a Mobile-style component-view or controller integration harness. It documents two existing homes within Extension's current three-layer model and prevents controller-composition coverage from defaulting to E2E.

Made with [Cursor](https://cursor.com)