### PR TITLE
feat: install a base skill set by default

### DIFF
--- a/.github/scripts/lint-skill-entry.mjs
+++ b/.github/scripts/lint-skill-entry.mjs
@@ -33,8 +33,13 @@ const ROOT = process.env.SKILLS_LINT_ROOT
   : path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 
 const allowedSiblings = new Set(ALLOWED_SIBLING_DIRS);
-const TRUTHY = new Set(['1', 'true', 'yes', 'on']);
-const FALSY = new Set(['0', 'false', 'no', 'off']);
+// Must match the other three implementations exactly: tools/install `is_truthy`,
+// tools/sync `domain_has_base`, and bin/metamask-skills.mjs `isTruthy` all accept
+// only 1/true/yes. `on`/`off` were accepted here alone, so `base: on` linted clean
+// as a base skill while the installer silently skipped it — the precise failure
+// these rules exist to prevent.
+const TRUTHY = new Set(['1', 'true', 'yes']);
+const FALSY = new Set(['0', 'false', 'no']);
 
 export function lintSkill(skill) {
   const errors = [];
@@ -83,7 +88,18 @@ export function lintSkill(skill) {
     warnings.push(`\`base\` "${raw.base}" is neither truthy nor falsy (treated as false)`);
   }
 
-  const isBase = raw.base !== undefined && TRUTHY.has(String(raw.base).toLowerCase());
+  // Accepted for the transition, but flag it: content still on `mandatory` installs
+  // correctly today and would silently stop being a base skill the moment the alias
+  // is removed from tools/install.
+  if (raw.mandatory !== undefined) {
+    warnings.push('`mandatory` is the pre-rename key for `base`; rename it to `base`');
+  }
+
+  const isBase =
+    (raw.base !== undefined && TRUTHY.has(String(raw.base).toLowerCase())) ||
+    (raw.base === undefined &&
+      raw.mandatory !== undefined &&
+      TRUTHY.has(String(raw.mandatory).toLowerCase()));
 
   // `base: true` installs for every engineer in every applicable repo, so it
   // cannot also be experimental — that would push unfinished guidance to
@@ -92,8 +108,13 @@ export function lintSkill(skill) {
     errors.push('`base: true` conflicts with `maturity: experimental` — a base skill installs for everyone, so promote it to stable or remove `base`');
   }
 
+  // An error, not a warning. Only errors set a non-zero exit code, so as a warning
+  // this never failed a job — a thin base description would sit invisibly inside a
+  // green check, and "CI warns until it is rewritten" would not actually hold. A
+  // base skill permanently occupies listing context for every engineer, so one that
+  // cannot self-trigger is pure cost.
   if (isBase && raw.description && raw.description.length < BASE_DESCRIPTION_MIN) {
-    warnings.push(
+    errors.push(
       `\`description\` is only ${raw.description.length} chars; a base skill needs enough trigger cues to be selected (aim for ${BASE_DESCRIPTION_MIN}+, saying what it does and when to use it)`,
     );
   }

--- a/.github/scripts/lint-skill-entry.mjs
+++ b/.github/scripts/lint-skill-entry.mjs
@@ -16,6 +16,7 @@ import { fileURLToPath } from 'node:url';
 import { collectSkills, parseFrontmatter } from '../../bin/metamask-skills.mjs';
 import {
   ALLOWED_SIBLING_DIRS,
+  BASE_DESCRIPTION_MIN,
   DESCRIPTION_MAX,
   INSTALLED_PREFIX,
   KNOWN_FRONTMATTER,
@@ -71,15 +72,30 @@ export function lintSkill(skill) {
     errors.push(`\`maturity\` "${raw.maturity}" must be one of: ${MATURITY_VALUES.join(', ')}`);
   }
 
-  // `scope` and `mandatory` change installer behaviour, and a typo in either is a silent
+  // `scope` and `base` change installer behaviour, and a typo in either is a silent
   // no-op today: the key is accepted, no enum runs, and the skill installs in a way the
-  // author did not intend. `scope: users` falls back to project scope; `mandatory: ture`
+  // author did not intend. `scope: users` falls back to project scope; `base: ture`
   // is falsy. Warnings rather than errors — the blocking surface stays small.
   if (raw.scope !== undefined && !SCOPE_VALUES.includes(raw.scope)) {
     warnings.push(`\`scope\` "${raw.scope}" is not one of: ${SCOPE_VALUES.join(', ')} (installs as project scope)`);
   }
-  if (raw.mandatory !== undefined && !TRUTHY.has(String(raw.mandatory).toLowerCase()) && !FALSY.has(String(raw.mandatory).toLowerCase())) {
-    warnings.push(`\`mandatory\` "${raw.mandatory}" is neither truthy nor falsy (treated as false)`);
+  if (raw.base !== undefined && !TRUTHY.has(String(raw.base).toLowerCase()) && !FALSY.has(String(raw.base).toLowerCase())) {
+    warnings.push(`\`base\` "${raw.base}" is neither truthy nor falsy (treated as false)`);
+  }
+
+  const isBase = raw.base !== undefined && TRUTHY.has(String(raw.base).toLowerCase());
+
+  // `base: true` installs for every engineer in every applicable repo, so it
+  // cannot also be experimental — that would push unfinished guidance to
+  // everyone. Promote the skill to stable first, or drop `base`.
+  if (isBase && raw.maturity === 'experimental') {
+    errors.push('`base: true` conflicts with `maturity: experimental` — a base skill installs for everyone, so promote it to stable or remove `base`');
+  }
+
+  if (isBase && raw.description && raw.description.length < BASE_DESCRIPTION_MIN) {
+    warnings.push(
+      `\`description\` is only ${raw.description.length} chars; a base skill needs enough trigger cues to be selected (aim for ${BASE_DESCRIPTION_MIN}+, saying what it does and when to use it)`,
+    );
   }
 
   // On-demand-only contract: a source skill must not force persistent loading.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Install a **base skill set by default**. Skills marked `base: true` in frontmatter install on every automatic `postinstall` regardless of domain selection, so a fresh clone lands a useful set with no configuration. `yarn skills` is unchanged and still installs every domain. Opt out with `SKILLS_AUTO_UPDATE=0`. ([#135](https://github.com/MetaMask/skills/pull/135))
+- Lint rules for base skills: a `base: true` skill cannot also be `experimental`, and its `description` must be long enough to self-trigger (`BASE_DESCRIPTION_MIN`). Both are errors, so CI fails rather than warning invisibly. ([#135](https://github.com/MetaMask/skills/pull/135))
+- Validate `--domain` / `SKILLS_DOMAINS` against the domains that actually exist. A typo previously installed the base set and exited 0, which reads as success. ([#135](https://github.com/MetaMask/skills/pull/135))
 - Add `swaps-cpu-profile-audit` skill for MetaMask Mobile: parse a recorded Hermes / React Native Release Profiler `.cpuprofile` and audit slow frames in swaps/bridge. ([#123](https://github.com/MetaMask/skills/pull/123))
 - Add opt-in stale project skill pruning via `--prune-stale` and `SKILLS_PRUNE_STALE=1`.
 - docs(testing): document CV stale-press flakiness plus high-leverage assert patterns (migration parity, filter both-sides example, loading/skeleton honesty, RefreshControl + flag overrides) in `mobile-testing` component-view and placement refs.
 
 ### Changed
 
+- **Breaking:** frontmatter key `mandatory` renamed to `base`. Update any skill still using `mandatory:`. ([#135](https://github.com/MetaMask/skills/pull/135))
+- **Breaking:** `postinstall` now syncs by default. It previously required `SKILLS_AUTO_UPDATE=1`; the opt-out is now `SKILLS_AUTO_UPDATE=0`. An explicitly empty `SKILLS_AUTO_UPDATE=` keeps its old meaning (off) rather than being read as unset. ([#135](https://github.com/MetaMask/skills/pull/135))
+- `base:` truthiness is consistent across all four implementations. The linter alone accepted `on`/`off`, so `base: on` linted clean while the installer skipped the skill. ([#135](https://github.com/MetaMask/skills/pull/135))
 - Rewrite `CONTRIBUTING.md` and skill template for MetaMask/skills layout.
 - `swaps-cpu-profile-audit` now audits the whole capture instead of swaps-owned files only: non-swaps frames that ran while the user was on a swaps screen are classified by their relation to the swaps call stacks (called by swaps, hosts the swaps screen, or concurrent with it), bucketed into named context areas, and reported alongside swaps rows. Every reported row carries an `Owned by swaps` column, and fix depth is gated on it. New `--context-min-pct` and `--swaps-only` analyzer flags.
 - `swaps-cpu-profile-audit` reports swaps-owned areas, non-swaps areas on the swaps path, and non-swaps areas running concurrently as separate tables, so the per-area swaps detail is no longer diluted by context rows. The swaps table gained an inclusive-time column, and the report explains that self time on a leaf means a screen can trigger heavy work while showing ~0 ms of its own. Non-swaps rows in the fix table are now capped to the few that matter.
 
 ### Fixed
 
+- `tools/sync` now execs the `tools/install` that shipped beside it in the pinned package, instead of preferring `$METAMASK_SKILLS_DIR/tools/install`. That path defaults to the `.skills-cache` clone tracking `origin/main` with no tag or commit pin, so an automatic `postinstall` could execute unreviewed shell from whatever was on `main` at that moment — bypassing lockfile pinning and release gating. The cache still supplies `domains/` content; it no longer supplies executable code. ([#135](https://github.com/MetaMask/skills/pull/135))
+- Cap the delegated sync subprocess so a stalled child cannot hang `yarn install` indefinitely, and report an `ETIMEDOUT` explicitly rather than returning a bare exit 1. ([#135](https://github.com/MetaMask/skills/pull/135))
+- Append `-oBatchMode=yes` to any existing `GIT_SSH_COMMAND` instead of replacing it. `GIT_TERMINAL_PROMPT`/`GIT_ASKPASS` cover HTTPS only — `ssh` reads `/dev/tty` directly — but overwriting the variable would break a custom key, an agent, or a `ProxyCommand` on the private overlay clone these guards exist to protect. ([#135](https://github.com/MetaMask/skills/pull/135))
+- A saved `SKILLS_DOMAINS=` (written by the old picker for the "all" choice) is no longer read as "no saved selection". Those engineers were silently dropped to base-only, and because pruning is off by default their other skills stayed on disk and went stale rather than visibly disappearing. ([#135](https://github.com/MetaMask/skills/pull/135))
+- `.skills.local` readers strip inline comments consistently. The Bash side kept the ` # comment` tail while the JS side stripped it, so a documented `SKILLS_DOMAINS=perps # my choice` resolved to the domain `perps#mychoice`. ([#135](https://github.com/MetaMask/skills/pull/135))
+- `--select` with no valid entries now installs the base set instead of every domain. An empty result resolved to `all`, so mistyping the numbers did the opposite of narrowing the selection. ([#135](https://github.com/MetaMask/skills/pull/135))
 - Preserve `METAMASK_SKILLS_DIR` and `CONSENSYS_SKILLS_DIR` entries when `sync --save` rewrites `.skills.local`.
 
 ## [0.2.0]

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ metamask-skills list          # discover installable skills for the current repo
 metamask-skills search test   # search skill names and descriptions
 metamask-skills describe testing/mobile-testing
 metamask-skills sync          # infer repo + target, refresh cache, install skills
-metamask-skills postinstall   # refresh cache; run sync only when SKILLS_AUTO_UPDATE=1
+metamask-skills postinstall   # refresh cache; sync by default (SKILLS_AUTO_UPDATE=0 opts out)
 metamask-skills install       # lower-level installer wrapper
 ```
 

--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ maturity: stable          # experimental | stable | deprecated (default stable)
 
 Extra metadata blocks (e.g. OpenClaw-style `metadata:` with emoji and
 homepage) are preserved through install — only `name`, `description`,
-`maturity`, `mandatory`, and `scope` are read by the CLI.
+`maturity`, `base`, and `scope` are read by the CLI.
 
 The 1,536-character ceiling is a repo budget rather than an operator limit — the
 description is always-on context for every installed skill, so it is capped

--- a/bin/metamask-skills.mjs
+++ b/bin/metamask-skills.mjs
@@ -263,6 +263,13 @@ function isGitDir(dir) {
 // Override per call with an explicit `timeout`.
 const SPAWN_TIMEOUT_MS = 300_000;
 
+// `delegate()` wraps a Bash script that itself makes several capped calls, so its
+// budget has to exceed a single spawn's. If both used SPAWN_TIMEOUT_MS the outer
+// timer would fire first — after the wrapper's own startup cost — and kill a
+// legitimately slow clone from the outside, dropping the engineer to the stale
+// bundled snapshot. That is the exact outcome the cap above is written to avoid.
+const DELEGATE_TIMEOUT_MS = SPAWN_TIMEOUT_MS * 2;
+
 function run(cmd, args, options = {}) {
   return spawnSync(cmd, args, {
     stdio: options.stdio ?? 'pipe',
@@ -446,10 +453,33 @@ function delegate(script, target, repo, args, options = {}) {
   }
   delegatedArgs.push(...args);
 
+  // Capped for the same reason as run(): this runs from postinstall, so a stalled
+  // child would hang `yarn install` indefinitely. SIGKILL rather than the default
+  // SIGTERM because the child is Bash — it does not reliably forward a term signal
+  // to an in-flight `git`, which would leave an orphan holding the index lock.
   const result = spawnSync(bash, delegatedArgs, {
     stdio: options.stdio ?? 'inherit',
+    timeout: DELEGATE_TIMEOUT_MS,
+    killSignal: 'SIGKILL',
+    ...options,
     env: { ...env, ...options.env },
   });
+
+  // On timeout spawnSync reports status === null, which would otherwise be
+  // indistinguishable from an ordinary failure. Say so explicitly: the whole point
+  // of the cap is a reportable failure rather than a silent hang.
+  if (result.error?.code === 'ETIMEDOUT') {
+    const seconds = Math.round((options.timeout ?? DELEGATE_TIMEOUT_MS) / 1000);
+    process.stderr.write(
+      `metamask-skills: ${script} exceeded ${seconds}s and was terminated. ` +
+        'Skills were not updated; the bundled snapshot is still in place.\n',
+    );
+    return 1;
+  }
+  if (result.error) {
+    process.stderr.write(`metamask-skills: failed to run ${script}: ${result.error.message}\n`);
+    return 1;
+  }
   return result.status ?? 1;
 }
 

--- a/bin/metamask-skills.mjs
+++ b/bin/metamask-skills.mjs
@@ -143,6 +143,19 @@ function hasArg(args, flag) {
   return args.includes(flag);
 }
 
+// Append BatchMode to whatever ssh configuration the engineer already has, rather
+// than replacing it. Overwriting would break a custom key, a 1Password/Secretive
+// agent or a ProxyCommand — on the `git@github.com:Consensys/skills.git` clone that
+// these guards exist to protect, and on the explicit `yarn skills` path too, since
+// buildDelegatedEnv() is shared.
+function sshCommandWithBatchMode(env = process.env) {
+  const base = env.GIT_SSH_COMMAND?.trim();
+  if (!base) {
+    return 'ssh -oBatchMode=yes';
+  }
+  return /(^|\s)-o\s*BatchMode=/u.test(base) ? base : `${base} -oBatchMode=yes`;
+}
+
 function isTruthy(value) {
   return /^(1|true|yes)$/iu.test(value ?? '');
 }
@@ -247,7 +260,12 @@ function isGitDir(dir) {
 //   - A credential prompt. A fetch against a private source (the Consensys
 //     overlay) can block on stdin forever, hanging the install with no output.
 //     GIT_TERMINAL_PROMPT=0 and an empty GIT_ASKPASS turn that into an
-//     immediate, reportable failure.
+//     immediate, reportable failure. Those two cover HTTPS only — ssh reads
+//     /dev/tty directly for passphrase and host-key prompts and ignores both, so
+//     GIT_SSH_COMMAND adds BatchMode. The private Consensys overlay is documented
+//     as an ssh clone and gets `git pull --ff-only` on every automatic sync, so
+//     this is the path most likely to block. (The delegate() timeout bounds such a
+//     hang; BatchMode prevents it.)
 //   - An unbounded wait. A stalled connection would hang just as long, so every
 //     spawn is capped. Callers can override with an explicit `timeout`.
 //
@@ -276,7 +294,13 @@ function run(cmd, args, options = {}) {
     encoding: 'utf8',
     timeout: SPAWN_TIMEOUT_MS,
     ...options,
-    env: { ...process.env, GIT_TERMINAL_PROMPT: '0', GIT_ASKPASS: '', ...options.env },
+    env: {
+      ...process.env,
+      GIT_TERMINAL_PROMPT: '0',
+      GIT_ASKPASS: '',
+      GIT_SSH_COMMAND: sshCommandWithBatchMode(),
+      ...options.env,
+    },
   });
 }
 
@@ -415,7 +439,12 @@ function buildDelegatedEnv(target) {
   // a private repo. Without this, an engineer whose credentials aren't cached gets
   // a git prompt blocking on stdin during `yarn install`, with no indication why.
   // Fail fast instead; the caller reports it and continues.
-  const env = { ...process.env, GIT_TERMINAL_PROMPT: '0', GIT_ASKPASS: '' };
+  const env = {
+    ...process.env,
+    GIT_TERMINAL_PROMPT: '0',
+    GIT_ASKPASS: '',
+    GIT_SSH_COMMAND: sshCommandWithBatchMode(),
+  };
   const localConfig = readSkillsLocal(target);
 
   for (const key of SOURCE_ENV_KEYS) {
@@ -454,13 +483,18 @@ function delegate(script, target, repo, args, options = {}) {
   delegatedArgs.push(...args);
 
   // Capped for the same reason as run(): this runs from postinstall, so a stalled
-  // child would hang `yarn install` indefinitely. SIGKILL rather than the default
-  // SIGTERM because the child is Bash — it does not reliably forward a term signal
-  // to an in-flight `git`, which would leave an orphan holding the index lock.
+  // child would hang `yarn install` indefinitely.
+  //
+  // Deliberately SIGTERM (the default), not SIGKILL. spawnSync's timeout signals
+  // only the direct child, so neither signal reaches an in-flight `git` grandchild
+  // — killing the whole tree would need `spawn` with `detached: true` and
+  // `process.kill(-pid)`. Given that, SIGTERM is strictly better: it at least lets
+  // Bash run a trap and clean up, where SIGKILL guarantees it cannot. A `git` child
+  // can still outlive the timeout and hold .git/index.lock; that is a known gap,
+  // not something the signal choice fixes.
   const result = spawnSync(bash, delegatedArgs, {
     stdio: options.stdio ?? 'inherit',
     timeout: DELEGATE_TIMEOUT_MS,
-    killSignal: 'SIGKILL',
     ...options,
     env: { ...env, ...options.env },
   });
@@ -806,9 +840,15 @@ function postinstall(args) {
   // plain `yarn install`, with no flags and nothing to read first. Engineers who
   // want to manage skills by hand set SKILLS_AUTO_UPDATE=0 (or
   // SKILLS_SKIP_POSTINSTALL=1 to skip this entirely).
+  //
+  // Only a genuinely absent key defaults to on. An explicitly empty
+  // `SKILLS_AUTO_UPDATE=` is a choice, not an absence: under 0.2.0 `isTruthy('')`
+  // was false, so engineers wrote exactly that to turn syncing off. Treating it as
+  // unset would silently re-enable it for them — and it would contradict the rule
+  // load_saved() applies to an empty SKILLS_DOMAINS, where presence of the key
+  // preserves its previous meaning.
   const configured = getConfigValue(process.env, localConfig, 'SKILLS_AUTO_UPDATE');
-  const unset = configured === undefined || configured === '';
-  const autoUpdate = unset ? true : isTruthy(configured);
+  const autoUpdate = configured === undefined ? true : isTruthy(configured);
   if (!autoUpdate) {
     return 0;
   }

--- a/bin/metamask-skills.mjs
+++ b/bin/metamask-skills.mjs
@@ -241,8 +241,36 @@ function isGitDir(dir) {
   return dirExists(path.join(dir, '.git'));
 }
 
+// Git operations here run during `postinstall`, on the critical path of
+// `yarn install`. Two things must not happen there:
+//
+//   - A credential prompt. A fetch against a private source (the Consensys
+//     overlay) can block on stdin forever, hanging the install with no output.
+//     GIT_TERMINAL_PROMPT=0 and an empty GIT_ASKPASS turn that into an
+//     immediate, reportable failure.
+//   - An unbounded wait. A stalled connection would hang just as long, so every
+//     spawn is capped. Callers can override with an explicit `timeout`.
+//
+// Both belong here rather than in a consumer's package.json: this is where the
+// risky call is made, and an env prefix on the npm script would leak the setting
+// to the whole process tree.
+//
+// The cap is generous on purpose. It exists to stop an indefinite hang, not to
+// enforce a performance budget — the slowest call is a shallow clone of the
+// skills repo, which is quick on a good connection but can take minutes on a
+// poor one or through a VPN. Cutting a legitimately slow clone short would drop
+// the engineer to the stale bundled snapshot, which is worse than waiting.
+// Override per call with an explicit `timeout`.
+const SPAWN_TIMEOUT_MS = 300_000;
+
 function run(cmd, args, options = {}) {
-  return spawnSync(cmd, args, { stdio: options.stdio ?? 'pipe', encoding: 'utf8', ...options });
+  return spawnSync(cmd, args, {
+    stdio: options.stdio ?? 'pipe',
+    encoding: 'utf8',
+    timeout: SPAWN_TIMEOUT_MS,
+    ...options,
+    env: { ...process.env, GIT_TERMINAL_PROMPT: '0', GIT_ASKPASS: '', ...options.env },
+  });
 }
 
 function repoNameFromGitHubUrl(url) {
@@ -343,7 +371,10 @@ function pickBash() {
   ].filter(Boolean);
 
   for (const candidate of new Set(candidates)) {
-    const result = run(candidate, ['--version']);
+    // Local, and probed up to four times per delegate call — the network cap
+    // would be absurd here. An interpreter that can't print its version in
+    // seconds is not one to hand a script to.
+    const result = run(candidate, ['--version'], { timeout: 10_000 });
     if (result.status !== 0) {
       continue;
     }
@@ -373,7 +404,11 @@ function validateConfiguredSource(name, dir) {
 }
 
 function buildDelegatedEnv(target) {
-  const env = { ...process.env };
+  // tools/sync runs `git pull` against each configured source, and one of them is
+  // a private repo. Without this, an engineer whose credentials aren't cached gets
+  // a git prompt blocking on stdin during `yarn install`, with no indication why.
+  // Fail fast instead; the caller reports it and continues.
+  const env = { ...process.env, GIT_TERMINAL_PROMPT: '0', GIT_ASKPASS: '' };
   const localConfig = readSkillsLocal(target);
 
   for (const key of SOURCE_ENV_KEYS) {
@@ -560,7 +595,7 @@ function collectSkills(sources, repo) {
           installedName: `mms-${name}`,
           description: metadata.description || '',
           maturity: metadata.maturity || 'stable',
-          mandatory: isTruthy(metadata.mandatory),
+          base: isTruthy(metadata.base),
           scope: metadata.scope || 'project',
           source,
           path: skillDir,
@@ -737,11 +772,18 @@ function postinstall(args) {
     return 0;
   }
 
-  const cacheReady = ensurePublicSkillsCache(target);
-  const autoUpdate = isTruthy(getConfigValue(process.env, localConfig, 'SKILLS_AUTO_UPDATE'));
+  // Auto-update is on by default so a fresh clone lands the base set from a
+  // plain `yarn install`, with no flags and nothing to read first. Engineers who
+  // want to manage skills by hand set SKILLS_AUTO_UPDATE=0 (or
+  // SKILLS_SKIP_POSTINSTALL=1 to skip this entirely).
+  const configured = getConfigValue(process.env, localConfig, 'SKILLS_AUTO_UPDATE');
+  const unset = configured === undefined || configured === '';
+  const autoUpdate = unset ? true : isTruthy(configured);
   if (!autoUpdate) {
     return 0;
   }
+
+  const cacheReady = ensurePublicSkillsCache(target);
 
   try {
     const { env } = buildDelegatedEnv(target);

--- a/bin/metamask-skills.mjs
+++ b/bin/metamask-skills.mjs
@@ -448,7 +448,7 @@ function delegate(script, target, repo, args, options = {}) {
 
   const result = spawnSync(bash, delegatedArgs, {
     stdio: options.stdio ?? 'inherit',
-    env,
+    env: { ...env, ...options.env },
   });
   return result.status ?? 1;
 }
@@ -792,7 +792,16 @@ function postinstall(args) {
       return 0;
     }
     const repo = resolveRepo(target, repoOverride);
-    const result = delegate('sync', target, repo, passthrough);
+    // An automatic install nobody asked for should be the minimum that works:
+    // the base set. An explicit `yarn skills` still defaults to every domain,
+    // because the engineer asked for skills and expects to get them.
+    //
+    // This only changes sync's *fallback*. A saved SKILLS_DOMAINS, an env var,
+    // or a --domain flag all still win, so an engineer who opted into a domain
+    // does not silently lose it on their next install.
+    const result = delegate('sync', target, repo, passthrough, {
+      env: { SKILLS_DEFAULT_SCOPE: 'base' },
+    });
     return result === 0 ? 0 : 0;
   } catch (error) {
     warn(`auto-update failed: ${error instanceof Error ? error.message : String(error)}`);

--- a/domains/coding/skills/coding-guidelines/skill.md
+++ b/domains/coding/skills/coding-guidelines/skill.md
@@ -1,4 +1,10 @@
 ---
 name: coding-guidelines
-description: General coding guidelines
+description: >-
+  General coding standards for MetaMask client repos: TypeScript-only new
+  code, no `any`, naming, file layout, error handling, and the required-
+  reading and enforcement checklist. Use when writing or refactoring
+  application code, when deciding how to structure a new module, or when
+  checking whether a change meets repo coding standards before opening a PR.
+base: true
 ---

--- a/domains/coding/skills/controller-integration/skill.md
+++ b/domains/coding/skills/controller-integration/skill.md
@@ -10,4 +10,5 @@ description: >
   EngineState/Engine.context or to MESSENGER_FACTORIES and the
   MessengerClient union, or debugging a controller whose state never reaches
   Redux/the UI or resets on restart.
+base: true
 ---

--- a/domains/performance/skills/performance/skill.md
+++ b/domains/performance/skills/performance/skill.md
@@ -1,4 +1,5 @@
 ---
 name: performance
 description: Use for any performance question about the MetaMask Mobile React Native app, at any stage. Trigger when: a screen, list, or interaction feels slow, laggy, or janky (account/network switching, scrolling, typing, FPS drops); planning a feature with real-time/websocket data, frequent updates, or large lists and wanting to avoid perf pitfalls before building; reviewing or auditing PRs/code for excessive re-renders, broken selector memoization, Context providers, hook deps, or bundle bloat; making the app faster for power users with many accounts/assets; measuring time-to-interactive, render counts, or FPS and surfacing them in Sentry; analyzing a captured `.cpuprofile` / React Native Release Profiler trace (e.g. a `sampling-profiler-trace*.cpuprofile`) to find why a flow is slow; or adding render-regression tests so CI catches slowdowns. Covers re-renders, reselect memoization, FlashList, Reanimated, TTI, bundle size, trace() instrumentation, and Release Profiler CPU-profile analysis. Not for correctness bugs, styling/spacing, Solidity gas, or the browser extension.
+base: true
 ---

--- a/domains/pr-workflow/skills/create-pr/skill.md
+++ b/domains/pr-workflow/skills/create-pr/skill.md
@@ -1,4 +1,9 @@
 ---
 name: create-pr
-description: Create GitHub pull request
+description: >-
+  Creates a GitHub pull request end to end: runs precondition checks,
+  generates the PR description, identifies code owners, opens the PR, and
+  offers to add it to the review queue. Use when the user asks to open,
+  create, raise, or submit a PR, or says their branch is ready for review.
+base: true
 ---

--- a/domains/pr-workflow/skills/pr-codeowners/skill.md
+++ b/domains/pr-workflow/skills/pr-codeowners/skill.md
@@ -1,4 +1,9 @@
 ---
 name: pr-codeowners
-description: Identify code owners from CODEOWNERS
+description: >-
+  Identifies the code owners for the files changed on the current branch by
+  matching them against CODEOWNERS, and maps each owning team to its Slack
+  handle. Use when deciding who should review a change, who owns a file or
+  directory, or as the reviewer step of opening a PR.
+base: true
 ---

--- a/domains/pr-workflow/skills/pr-description/skill.md
+++ b/domains/pr-workflow/skills/pr-description/skill.md
@@ -1,4 +1,9 @@
 ---
 name: pr-description
-description: Generate PR description
+description: >-
+  Generates a pull request description for the current branch, following the
+  repo's PR template sections. Use when writing or rewriting a PR body, when
+  the user asks what to put in a PR description, or as the description step
+  of opening a PR.
+base: true
 ---

--- a/domains/pr-workflow/skills/pr-guidelines/skill.md
+++ b/domains/pr-workflow/skills/pr-guidelines/skill.md
@@ -1,4 +1,10 @@
 ---
 name: pr-guidelines
-description: Pull request creation and review guidelines
+description: >-
+  Pull request standards for MetaMask client repos: title and conventional-
+  commit format, PR template compliance, required labels and assignment,
+  branch naming, and review best practices. Use when writing a PR title or
+  description, reviewing someone else's PR, or checking whether a PR meets
+  repo conventions before requesting review.
+base: true
 ---

--- a/domains/testing/skills/mobile-testing/skill.md
+++ b/domains/testing/skills/mobile-testing/skill.md
@@ -7,6 +7,7 @@ description: >
   when the user mentions Jest layers, *.view.test.tsx, *.integration.test.ts,
   Appium smoke, MMQA test-layer tickets, or asks which testing skill to install.
 maturity: stable
+base: true
 ---
 
 # Mobile testing

--- a/domains/ui/skills/component-scaffold/skill.md
+++ b/domains/ui/skills/component-scaffold/skill.md
@@ -5,4 +5,5 @@ description: >-
   Mobile. Use when the user asks to create, add, generate, scaffold,
   initialize, or set up a new component, UI component, or feature
   component.
+base: true
 ---

--- a/domains/ui/skills/ui-development/skill.md
+++ b/domains/ui/skills/ui-development/skill.md
@@ -1,4 +1,11 @@
 ---
 name: ui-development
-description: UI component development guidelines
+description: >-
+  UI component development standards for MetaMask clients: the strict
+  design-system-first component hierarchy, availability checks before
+  building custom components, styling with design tokens, and required
+  imports. Use when building, restyling, or reviewing any UI component, or
+  when choosing between a design-system, component-library, or custom
+  component.
+base: true
 ---

--- a/test/lint-skill-entry.test.mjs
+++ b/test/lint-skill-entry.test.mjs
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, test } from 'node:test';
 import {
+  BASE_DESCRIPTION_MIN,
   BUNDLE_DIRS,
   DESCRIPTION_MAX,
   KNOWN_FRONTMATTER,
@@ -293,6 +294,46 @@ describe('changed-files mode', () => {
     const { code, output } = lint(root, 'domains/testing/skills/unit-testing/skill.md');
     assert.equal(code, 0, output);
     assert.match(output, /warning:/u);
+  });
+
+  // A base skill permanently occupies listing context for every engineer, so the
+  // length floor has to FAIL the job. As a warning it never set a non-zero exit
+  // code, which meant a thin description sat invisibly inside a green check and
+  // "CI warns until it is rewritten" did not actually hold.
+  test('a base skill with a short description fails, not warns', () => {
+    const root = makeRoot();
+    writeSkill(root, 'testing', 'unit-testing', 'name: unit-testing\ndescription: Write unit tests\nbase: true');
+    const { code, output } = lint(root);
+    assert.equal(code, 1);
+    assert.match(output, /base skill needs enough trigger cues/u);
+  });
+
+  test('a base skill at exactly BASE_DESCRIPTION_MIN passes', () => {
+    const root = makeRoot();
+    const description = 'x'.repeat(BASE_DESCRIPTION_MIN);
+    writeSkill(root, 'testing', 'unit-testing', `name: unit-testing\ndescription: ${description}\nbase: true`);
+    assert.equal(lint(root).code, 0);
+  });
+
+  // A short description on a NON-base skill is still fine — the cost only applies
+  // to skills that load for everyone.
+  test('a short description on a non-base skill still passes', () => {
+    const root = makeRoot();
+    writeSkill(root, 'testing', 'unit-testing', 'name: unit-testing\ndescription: Write unit tests');
+    assert.equal(lint(root).code, 0);
+  });
+
+  // `on` was accepted by this linter alone. tools/install, tools/sync and the CLI
+  // all match 1/true/yes only, so `base: on` linted clean as a base skill while the
+  // installer silently skipped it.
+  test('`base: on` is not treated as truthy', () => {
+    const root = makeRoot();
+    const short = 'Write unit tests';
+    writeSkill(root, 'testing', 'unit-testing', `name: unit-testing\ndescription: ${short}\nbase: on`);
+    const { code, output } = lint(root);
+    // Not base -> the length floor must not fire; it is flagged as unrecognised instead.
+    assert.equal(code, 0);
+    assert.match(output, /neither truthy nor falsy/u);
   });
 
   test('a description of exactly DESCRIPTION_MAX passes, +1 fails', () => {

--- a/tools/install
+++ b/tools/install
@@ -461,6 +461,13 @@ process_skill() {
 
   local maturity;  maturity=$(frontmatter_value "$base" "maturity")
   local is_base;   is_base=$(frontmatter_value "$base" "base")
+  # Transition window for the `mandatory` -> `base` rename. Executable code ships in
+  # the pinned npm package while domains/ content can come from a different source
+  # (the origin/main cache, or a private overlay on its own cadence), so the two can
+  # legitimately be out of step. Accepting the old key keeps un-renamed content
+  # working instead of silently installing zero base skills. Remove once every
+  # source has migrated.
+  [[ -z "$is_base" ]] && is_base=$(frontmatter_value "$base" "mandatory")
   local scope;     scope=$(frontmatter_value "$base" "scope")
 
   if skill_excluded "$domain_name" "$skill_name"; then
@@ -552,6 +559,13 @@ preflight_skill() {
 
   local maturity;  maturity=$(frontmatter_value "$base" "maturity")
   local is_base;   is_base=$(frontmatter_value "$base" "base")
+  # Transition window for the `mandatory` -> `base` rename. Executable code ships in
+  # the pinned npm package while domains/ content can come from a different source
+  # (the origin/main cache, or a private overlay on its own cadence), so the two can
+  # legitimately be out of step. Accepting the old key keeps un-renamed content
+  # working instead of silently installing zero base skills. Remove once every
+  # source has migrated.
+  [[ -z "$is_base" ]] && is_base=$(frontmatter_value "$base" "mandatory")
 
   local skill_name; skill_name=$(basename "$skill_dir")
   skill_excluded "$domain_name" "$skill_name" && return 0

--- a/tools/install
+++ b/tools/install
@@ -52,6 +52,7 @@ Optional:
                       repo containing this script.
   --domain <list>     Comma-separated domain filter (default: all)
                       e.g., --domain perps,testing
+                      'none' installs only base skills; 'all' installs everything
   --maturity <level>  Minimum maturity: experimental, stable, deprecated
                       (default: stable; matches stable+deprecated when set to stable)
   --include <list>    Comma-separated skill opt-ins. Each item may be
@@ -177,7 +178,11 @@ body_after_frontmatter() {
 
 domain_allowed() {
   local domain="$1"
-  [[ -z "$DOMAIN_FILTER" ]] && return 0
+  # `none` selects no domains at all, leaving only `base: true` skills (which
+  # bypass this filter) and anything named by --include. `all` and the empty
+  # filter select every domain.
+  [[ "$DOMAIN_FILTER" == "none" ]] && return 1
+  [[ -z "$DOMAIN_FILTER" || "$DOMAIN_FILTER" == "all" ]] && return 0
   local d
   IFS=',' read -ra ds <<< "$DOMAIN_FILTER"
   for d in "${ds[@]}"; do [[ "$d" == "$domain" ]] && return 0; done
@@ -455,7 +460,7 @@ process_skill() {
   [[ -f "$base" ]] || { echo "Warning: no skill.md in $skill_dir, skipping" >&2; return; }
 
   local maturity;  maturity=$(frontmatter_value "$base" "maturity")
-  local mandatory; mandatory=$(frontmatter_value "$base" "mandatory")
+  local is_base;   is_base=$(frontmatter_value "$base" "base")
   local scope;     scope=$(frontmatter_value "$base" "scope")
 
   if skill_excluded "$domain_name" "$skill_name"; then
@@ -471,10 +476,10 @@ process_skill() {
     return
   fi
 
-  # Domain filter — but mandatory skills and explicit skill includes bypass.
+  # Domain filter — but base skills and explicit skill includes bypass.
   if ! $explicit_include && ! domain_allowed "$domain_name"; then
-    if is_truthy "$mandatory"; then
-      log "(mandatory — included despite domain filter)"
+    if is_truthy "$is_base"; then
+      log "(base — included despite domain filter)"
     else
       log "skipped (domain=$domain_name excluded by --domain)"
       return
@@ -546,7 +551,7 @@ preflight_skill() {
   [[ -f "$base" ]] || return 0
 
   local maturity;  maturity=$(frontmatter_value "$base" "maturity")
-  local mandatory; mandatory=$(frontmatter_value "$base" "mandatory")
+  local is_base;   is_base=$(frontmatter_value "$base" "base")
 
   local skill_name; skill_name=$(basename "$skill_dir")
   skill_excluded "$domain_name" "$skill_name" && return 0
@@ -559,7 +564,7 @@ preflight_skill() {
   fi
 
   if ! $explicit_include && ! domain_allowed "$domain_name"; then
-    is_truthy "$mandatory" || return 0
+    is_truthy "$is_base" || return 0
   fi
 
   local name;        name=$(frontmatter_value "$base" "name")

--- a/tools/skill-schema.mjs
+++ b/tools/skill-schema.mjs
@@ -6,7 +6,18 @@
 
 export const REQUIRED_FRONTMATTER = ['name', 'description'];
 export const OPTIONAL_FRONTMATTER = ['maturity', 'base', 'scope', 'metadata'];
-export const KNOWN_FRONTMATTER = [...REQUIRED_FRONTMATTER, ...OPTIONAL_FRONTMATTER];
+
+// Pre-rename spelling of `base`, still READ by tools/install so that content from a
+// source on a different release cadence (the origin/main cache, a private overlay)
+// keeps working while it migrates. Recognised, but the linter warns — it should not
+// be used in new skills, and this list goes away once every source has renamed.
+export const DEPRECATED_FRONTMATTER = ['mandatory'];
+
+export const KNOWN_FRONTMATTER = [
+  ...REQUIRED_FRONTMATTER,
+  ...OPTIONAL_FRONTMATTER,
+  ...DEPRECATED_FRONTMATTER,
+];
 
 export const MATURITY_VALUES = ['experimental', 'stable', 'deprecated'];
 

--- a/tools/skill-schema.mjs
+++ b/tools/skill-schema.mjs
@@ -5,13 +5,21 @@
 // in tools/install (Bash) mirrors BUNDLE_DIRS; keep the two in sync.
 
 export const REQUIRED_FRONTMATTER = ['name', 'description'];
-export const OPTIONAL_FRONTMATTER = ['maturity', 'mandatory', 'scope', 'metadata'];
+export const OPTIONAL_FRONTMATTER = ['maturity', 'base', 'scope', 'metadata'];
 export const KNOWN_FRONTMATTER = [...REQUIRED_FRONTMATTER, ...OPTIONAL_FRONTMATTER];
 
 export const MATURITY_VALUES = ['experimental', 'stable', 'deprecated'];
 
 // `scope: user` installs to $HOME instead of the target repo; anything else is project scope.
 export const SCOPE_VALUES = ['user', 'project'];
+
+// `base: true` marks a skill as part of the required base set for every consumer
+// repo it applies to: it installs regardless of the engineer's domain selection,
+// so a fresh clone lands it with no flags. Reserve it for the small set that every
+// engineer needs — each base skill is a permanent always-on cost in the operator's
+// skill listing, and an oversized listing gets truncated, which silently strips the
+// trigger cues from the skills nobody has invoked yet. Everything else stays
+// domain-gated and opt-in.
 
 // Directories the installer copies alongside skill.md (see tools/install).
 export const BUNDLE_DIRS = ['references', 'scripts', 'assets', 'adapters', 'workflows'];
@@ -35,6 +43,14 @@ export const KNOWN_REPOS = ['metamask-extension', 'metamask-mobile', 'core'];
 // as a deliberate budget decision, and cite the operator and version before claiming any
 // figure is externally imposed.
 export const DESCRIPTION_MAX = 1536;
+
+// A base skill installs for every engineer, so its description is always-on
+// context — and a description too thin to match anything is the failure mode
+// that matters. The description is a skill's ENTIRE trigger surface — the model
+// selects on it alone — so "General coding guidelines" will not fire on the work
+// it governs. A base skill that never triggers is worse than one not installed,
+// because it looks covered. State what it does AND when to use it.
+export const BASE_DESCRIPTION_MIN = 120;
 
 export const RECOMMENDED_SECTIONS = ['When To Use', 'Workflow'];
 

--- a/tools/sync
+++ b/tools/sync
@@ -11,9 +11,11 @@
 #   2. SKILLS_DOMAINS env var      (CI-friendly)
 #   3. saved selection in <target>/.skills.local
 #   4. interactive prompt (TTY)
-#   5. all domains (fallback)
+#   5. base skills only (fallback)
 #
-# Skills with `mandatory: true` install regardless of selection.
+# Skills with `base: true` install regardless of selection — a fresh clone with
+# no configuration lands exactly the base set. Use `all` to select every domain,
+# `none` for base only.
 # Skills with `scope: user` install at user-level (~/.claude, ~/.codex).
 #
 # Env (at least one required):
@@ -21,6 +23,7 @@
 #   CONSENSYS_SKILLS_DIR  Path to local Consensys/skills source (private overlay).
 #                         When both set, private overrides public on name conflict.
 #   SKILLS_DOMAINS        Comma-separated domain filter (overrides saved + prompt).
+#                         'none' = base skills only (default), 'all' = every domain.
 #   SKILLS_MATURITY       Minimum maturity: experimental, stable, deprecated.
 #   SKILLS_INCLUDE        Comma-separated skill opt-ins (domain/skill or skill).
 #   SKILLS_EXCLUDE        Comma-separated skill opt-outs (domain/skill or skill).
@@ -61,7 +64,8 @@ Required:
 
 Options:
   --repo <name>        Consumer repo (auto-detected from <target>/package.json)
-  --domain <list>      Comma-separated domain opt-in filter (overrides default-all)
+  --domain <list>      Comma-separated domain opt-in filter ('none' = base only,
+                       'all' = every domain; default: base only)
   --maturity <level>    Minimum maturity: experimental, stable, deprecated
   --include <list>      Comma-separated skill opt-ins (domain/skill or skill).
                        Repeatable. Alias: --skill.
@@ -69,8 +73,8 @@ Options:
                        Repeatable.
   --save               Persist CLI domain/maturity/include/exclude to .skills.local
   --select             Interactively pick which domains to install (requires
-                       a TTY). Default behavior is install all — use this to
-                       opt out of some.
+                       a TTY). Base skills install either way — use this to
+                       opt into more.
   --include-user       Also install skills with \`scope: user\` (writes to
                        \$HOME — outside this repo). Off by default.
   --prune-stale        Remove installed project-scope mms-* skills that are not
@@ -83,7 +87,7 @@ Options:
 Env:
   METAMASK_SKILLS_DIR  Path to local MetaMask/skills checkout (public, no auth)
   CONSENSYS_SKILLS_DIR Path to local Consensys/skills checkout (private overlay)
-  SKILLS_DOMAINS       Domain filter (overrides saved selection; blank = all)
+  SKILLS_DOMAINS       Domain filter; 'none' = base only (default), 'all' = every domain
   SKILLS_MATURITY      Minimum maturity filter (default: stable)
   SKILLS_INCLUDE       Skill opt-ins; explicit includes bypass domain/maturity
   SKILLS_EXCLUDE       Skill opt-outs; explicit excludes win
@@ -275,9 +279,9 @@ if [[ "${SKILLS_PRUNE_STALE:-}" =~ ^(1|true|TRUE|yes|YES)$ ]]; then
 fi
 
 
-domain_has_mandatory() {
+domain_has_base() {
   local domain_dir="$1"
-  grep -lE '^mandatory:[[:space:]]*(true|yes|1)' "$domain_dir"/skills/*/skill.md >/dev/null 2>&1
+  grep -lE '^base:[[:space:]]*(true|yes|1)' "$domain_dir"/skills/*/skill.md >/dev/null 2>&1
 }
 
 list_domains() {
@@ -308,18 +312,23 @@ interactive_select() {
     i=$((i+1))
     local marker=""
     while IFS= read -r dd; do
-      domain_has_mandatory "$dd" && { marker=" ★"; break; }
+      domain_has_base "$dd" && { marker=" ★"; break; }
     done < <(domain_dirs_for "$d")
     printf "  %2d) %s%s\n" "$i" "$d" "$marker" >&2
   done
   echo >&2
-  echo "  ★ = contains mandatory skills (always installed regardless)" >&2
+  echo "  ★ = contains base skills (always installed regardless)" >&2
   echo >&2
 
   local choice
-  echo "Default is install ALL domains. Pick a subset to opt out of the rest." >&2
-  read -rp "Pick (numbers comma-separated, blank/'a' = all [recommended]): " choice
-  if [[ -z "$choice" || "$choice" == "a" || "$choice" == "all" ]]; then
+  echo "Base skills (★) install either way. Pick the extra domains you want." >&2
+  read -rp "Pick (numbers comma-separated, blank = base only, 'a' = all): " choice
+  if [[ "$choice" == "a" || "$choice" == "all" ]]; then
+    echo "all"
+    return 0
+  fi
+  if [[ -z "$choice" ]]; then
+    echo "none"
     return 0
   fi
 
@@ -336,7 +345,7 @@ interactive_select() {
   echo "$out"
 }
 
-# Resolution order: --domain > env > saved > --select prompt > all (default)
+# Resolution order: --domain > env > saved > --select prompt > base only (default)
 DOMAINS=""
 SOURCE=""
 if [[ -n "$DOMAIN_OVERRIDE" ]]; then
@@ -350,16 +359,18 @@ else
   if [[ -n "$saved" ]]; then
     DOMAINS="$saved"; SOURCE="saved (.skills.local)"
   else
-    SOURCE="all (default — pass --select to choose)"
+    DOMAINS="none"; SOURCE="base only (default — use --select or --domain to add more)"
   fi
 fi
 
 echo
 echo "Maturity: $MATURITY_FILTER  (source: $MATURITY_SOURCE)"
-if [[ -n "$DOMAINS" ]]; then
-  echo "Domains: $DOMAINS  (source: $SOURCE)"
-else
+if [[ "$DOMAINS" == "none" ]]; then
+  echo "Domains: <base skills only>  (source: $SOURCE)"
+elif [[ -z "$DOMAINS" || "$DOMAINS" == "all" ]]; then
   echo "Domains: <all>  (source: $SOURCE)"
+else
+  echo "Domains: $DOMAINS  (source: $SOURCE)"
 fi
 if [[ -n "$INCLUDE_FILTER" ]]; then
   echo "Include skills: $INCLUDE_FILTER  (source: $INCLUDE_SOURCE)"

--- a/tools/sync
+++ b/tools/sync
@@ -11,9 +11,10 @@
 #   2. SKILLS_DOMAINS env var      (CI-friendly)
 #   3. saved selection in <target>/.skills.local
 #   4. interactive prompt (TTY)
-#   5. base skills only (fallback)
+#   5. fallback: base skills only for an automatic install (postinstall sets
+#      SKILLS_DEFAULT_SCOPE=base); every domain for an explicit `yarn skills`
 #
-# Skills with `base: true` install regardless of selection — a fresh clone with
+# Skills with `base: true` install regardless of selection, so a fresh clone with
 # no configuration lands exactly the base set. Use `all` to select every domain,
 # `none` for base only.
 # Skills with `scope: user` install at user-level (~/.claude, ~/.codex).
@@ -23,7 +24,9 @@
 #   CONSENSYS_SKILLS_DIR  Path to local Consensys/skills source (private overlay).
 #                         When both set, private overrides public on name conflict.
 #   SKILLS_DOMAINS        Comma-separated domain filter (overrides saved + prompt).
-#                         'none' = base skills only (default), 'all' = every domain.
+#                         'none' = base skills only, 'all' = every domain.
+#   SKILLS_DEFAULT_SCOPE  Set to 'base' to make the fallback base-only. Exported by
+#                         `metamask-skills postinstall`; not intended to be set by hand.
 #   SKILLS_MATURITY       Minimum maturity: experimental, stable, deprecated.
 #   SKILLS_INCLUDE        Comma-separated skill opt-ins (domain/skill or skill).
 #   SKILLS_EXCLUDE        Comma-separated skill opt-outs (domain/skill or skill).
@@ -65,7 +68,7 @@ Required:
 Options:
   --repo <name>        Consumer repo (auto-detected from <target>/package.json)
   --domain <list>      Comma-separated domain opt-in filter ('none' = base only,
-                       'all' = every domain; default: base only)
+                       'all' = every domain; default: all for an explicit run)
   --maturity <level>    Minimum maturity: experimental, stable, deprecated
   --include <list>      Comma-separated skill opt-ins (domain/skill or skill).
                        Repeatable. Alias: --skill.
@@ -87,7 +90,7 @@ Options:
 Env:
   METAMASK_SKILLS_DIR  Path to local MetaMask/skills checkout (public, no auth)
   CONSENSYS_SKILLS_DIR Path to local Consensys/skills checkout (private overlay)
-  SKILLS_DOMAINS       Domain filter; 'none' = base only (default), 'all' = every domain
+  SKILLS_DOMAINS       Domain filter; 'none' = base only, 'all' = every domain
   SKILLS_MATURITY      Minimum maturity filter (default: stable)
   SKILLS_INCLUDE       Skill opt-ins; explicit includes bypass domain/maturity
   SKILLS_EXCLUDE       Skill opt-outs; explicit excludes win
@@ -345,7 +348,17 @@ interactive_select() {
   echo "$out"
 }
 
-# Resolution order: --domain > env > saved > --select prompt > base only (default)
+# Resolution order: --domain > env > --select prompt > saved > fallback.
+#
+# The fallback differs by how sync was reached. An automatic install nobody
+# asked for should be the minimum that works — the base set. An explicit
+# `yarn skills` defaults to every domain, because the engineer asked for skills
+# and expects to get them. `postinstall` signals the former by exporting
+# SKILLS_DEFAULT_SCOPE=base.
+#
+# Only the fallback changes: a --domain flag, SKILLS_DOMAINS, the picker, and a
+# saved selection all still win, so an engineer who opted into a domain does not
+# silently lose it on their next install.
 DOMAINS=""
 SOURCE=""
 if [[ -n "$DOMAIN_OVERRIDE" ]]; then
@@ -358,8 +371,10 @@ else
   saved=$(load_saved || true)
   if [[ -n "$saved" ]]; then
     DOMAINS="$saved"; SOURCE="saved (.skills.local)"
+  elif [[ "${SKILLS_DEFAULT_SCOPE:-}" == "base" ]]; then
+    DOMAINS="none"; SOURCE="base only (automatic install — run \`yarn skills\` for the rest)"
   else
-    DOMAINS="none"; SOURCE="base only (default — use --select or --domain to add more)"
+    DOMAINS="all"; SOURCE="all domains (default — pass --select or --domain to narrow)"
   fi
 fi
 

--- a/tools/sync
+++ b/tools/sync
@@ -211,24 +211,51 @@ done
 
 # ---- domain resolution ----
 
+# Mirrors stripInlineComment() in bin/metamask-skills.mjs. The two config readers
+# must agree: the JS side already strips ` # comment` tails, so without this a
+# saved `SKILLS_DOMAINS=perps # my choice` reaches the domain validation as
+# "perps#mychoice" and fails the run. `.skills.local.example` documents values with
+# trailing comments, so this is the shape engineers are taught to write.
+strip_inline_comment() {
+  local value="$1"
+  value="${value%%[[:space:]]#*}"
+  # Trim surrounding whitespace.
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+read_config_value() {
+  local key="$1"
+  [[ -f "$CONFIG_FILE" ]] || return 1
+  grep -q "^${key}=" "$CONFIG_FILE" || return 1
+  local raw
+  raw=$(awk -F= -v k="^${key}=" '$0 ~ k {sub(k,""); print; exit}' "$CONFIG_FILE")
+  strip_inline_comment "$raw"
+}
+
 load_saved() {
-  [[ -f "$CONFIG_FILE" ]] || return 0
-  awk -F= '/^SKILLS_DOMAINS=/{sub(/^SKILLS_DOMAINS=/,""); print; exit}' "$CONFIG_FILE"
+  local value
+  value=$(read_config_value SKILLS_DOMAINS) || return 0
+  # Presence of the key means "this engineer made a choice", even when the value is
+  # empty. The old picker wrote a bare `SKILLS_DOMAINS=` for the "all [recommended]"
+  # option, so treating empty as "nothing saved" would drop every one of those
+  # engineers into the new base-only default — silently, because pruning is off by
+  # default, so the skills they lose stay on disk and go stale instead of
+  # disappearing. Empty therefore maps back to `all`, which is what it meant.
+  echo "${value:-all}"
 }
 
 load_saved_maturity() {
-  [[ -f "$CONFIG_FILE" ]] || return 0
-  awk -F= '/^SKILLS_MATURITY=/{sub(/^SKILLS_MATURITY=/,""); print; exit}' "$CONFIG_FILE"
+  read_config_value SKILLS_MATURITY || return 0
 }
 
 load_saved_include() {
-  [[ -f "$CONFIG_FILE" ]] || return 0
-  awk -F= '/^SKILLS_INCLUDE=/{sub(/^SKILLS_INCLUDE=/,""); print; exit}' "$CONFIG_FILE"
+  read_config_value SKILLS_INCLUDE || return 0
 }
 
 load_saved_exclude() {
-  [[ -f "$CONFIG_FILE" ]] || return 0
-  awk -F= '/^SKILLS_EXCLUDE=/{sub(/^SKILLS_EXCLUDE=/,""); print; exit}' "$CONFIG_FILE"
+  read_config_value SKILLS_EXCLUDE || return 0
 }
 
 if [[ -n "$MATURITY_FILTER" ]]; then
@@ -284,7 +311,8 @@ fi
 
 domain_has_base() {
   local domain_dir="$1"
-  grep -lE '^base:[[:space:]]*(true|yes|1)' "$domain_dir"/skills/*/skill.md >/dev/null 2>&1
+  # `mandatory` is the pre-rename key; see the transition note in tools/install.
+  grep -lE '^(base|mandatory):[[:space:]]*(true|yes|1)' "$domain_dir"/skills/*/skill.md >/dev/null 2>&1
 }
 
 list_domains() {
@@ -345,6 +373,16 @@ interactive_select() {
       echo "  (skipping invalid: $n)" >&2
     fi
   done
+
+  # Every entry was invalid. Returning "" would resolve to `all` downstream — an
+  # engineer who ran --select specifically to NARROW their set, then fat-fingered
+  # the numbers, would silently install every domain. Blank input already means
+  # `none`, so an all-invalid selection means the same thing.
+  if [[ -z "$out" ]]; then
+    echo "  (no valid selections — installing base skills only)" >&2
+    echo "none"
+    return 0
+  fi
   echo "$out"
 }
 
@@ -375,6 +413,26 @@ else
     DOMAINS="none"; SOURCE="base only (automatic install — run \`yarn skills\` for the rest)"
   else
     DOMAINS="all"; SOURCE="all domains (default — pass --select or --domain to narrow)"
+  fi
+fi
+
+# Validate the resolved selection against the domains that actually exist. A typo
+# used to install the base set and exit 0, which reads as success — now that
+# SKILLS_DOMAINS is the documented opt-in on a default-on path, a silent no-op is
+# the wrong failure mode. `all`/`none` are sentinels, not directories.
+if [[ -n "$DOMAINS" && "$DOMAINS" != "all" && "$DOMAINS" != "none" ]]; then
+  known_domains=$(list_domains)
+  unknown=""
+  IFS=',' read -ra _requested <<< "$DOMAINS"
+  for _d in "${_requested[@]}"; do
+    _d="${_d// /}"
+    [[ -z "$_d" ]] && continue
+    grep -qxF "$_d" <<< "$known_domains" || unknown+="${unknown:+, }$_d"
+  done
+  if [[ -n "$unknown" ]]; then
+    echo "Error: unknown domain(s): $unknown  (source: $SOURCE)" >&2
+    echo "  Available: $(echo "$known_domains" | tr '\n' ' ')" >&2
+    exit 1
   fi
 fi
 
@@ -436,10 +494,25 @@ $PRUNE_STALE && INSTALL_ARGS+=(--prune-stale)
 $DRY_RUN && INSTALL_ARGS+=(--dry-run)
 
 INSTALL_BIN=""
-# Prefer METAMASK_SKILLS_DIR's tools/install (canonical, kept in sync with latest CLI).
-if [[ -n "${METAMASK_SKILLS_DIR:-}" && -x "$METAMASK_SKILLS_DIR/tools/install" ]]; then
-  INSTALL_BIN="$METAMASK_SKILLS_DIR/tools/install"
+# Run the tools/install that shipped alongside THIS script.
+#
+# This previously preferred "$METAMASK_SKILLS_DIR/tools/install", which defaults to
+# the .skills-cache clone the CLI keeps at `origin/main` — no tag, no commit pin. On
+# the automatic postinstall path that meant `yarn install` exec'ing whatever shell
+# happened to be on main at that instant, bypassing the lockfile pinning, release
+# gating and Socket/CodeQL review that the npm package itself goes through. Once base
+# skills install by default that reaches every engineer and every drive-by
+# contributor of a public repo, on every install.
+#
+# tools/sync is itself invoked from the pinned package, so its own directory is the
+# trustworthy one. The cache still supplies domains/ CONTENT via SOURCES — it just no
+# longer supplies executable CODE.
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+if [[ -x "$SCRIPT_DIR/install" ]]; then
+  INSTALL_BIN="$SCRIPT_DIR/install"
 else
+  # Fallback for a source checkout that has no sibling install: keep the old search
+  # so a git clone of this repo still works standalone.
   for src in "${SOURCES[@]}"; do
     if [[ -x "$src/tools/install" ]]; then
       INSTALL_BIN="$src/tools/install"


### PR DESCRIPTION
## What

Turns on a **base skill set** that installs for every engineer on a fresh clone, with no flags and nothing to read first. Mobile gets 10 skills; everything else stays opt-in.

The `mandatory` frontmatter flag is renamed to `base` and actually used. It was already implemented end to end — `tools/install`, `tools/sync`, the schema, the CLI, even a `★` marker in the interactive picker — but **no skill had ever set it**, and the default domain filter was permissive enough that the bypass had nothing to bypass.

## Why

Three things had to be true together for "base skills by default" to work. Only the flag existed.

| Problem | Fix |
|---|---|
| Empty `SKILLS_DOMAINS` meant *all* domains, so `base` never applied | `none`/`all` sentinels |
| `SKILLS_AUTO_UPDATE` was off by default, so `postinstall` refreshed the cache and installed nothing | Defaults on. The cache refresh moved *behind* the gate, so opted-out engineers no longer pay a network fetch per install |
| Six base descriptions were too thin to ever trigger | Rewritten. `coding-guidelines` was literally `"General coding guidelines"` — 25 characters |

That last one is the subtle one: a skill's description is its **entire trigger surface**. A 25-character description never fires on the work it governs, while appearing to be covered.

## Automatic vs explicit

`yarn skills` reads as "give me the skills", so having it install 10 instead of 36 would be a surprising regression for a command someone typed on purpose. The two paths differ:

| Path | Domains | Installed |
|---|---|---|
| `yarn skills`, no config | all | **36** — unchanged from today |
| `yarn install` → `postinstall`, no config | none | **10** |
| `yarn install` **with `SKILLS_DOMAINS=perps`** | perps | **12** = 10 base + 2 perps |
| `yarn skills --domain none` | none | 10 |

`postinstall` exports `SKILLS_DEFAULT_SCOPE=base` and `tools/sync` branches its **fallback** on that. Everything above the fallback in the resolution order is untouched — a `--domain` flag, `SKILLS_DOMAINS`, the picker, and a saved selection all still win.

That last property is the point of doing it this way. Passing `--domain none` from `postinstall` would have outranked a saved selection, so an engineer who opted into `perps` would have silently lost it on their next `yarn install`.

## The base set (10)

`mobile-testing` · `coding-guidelines` · `controller-integration` · `ui-development` · `component-scaffold` · `performance` · `pr-guidelines` · `create-pr` · `pr-description` · `pr-codeowners`

`pr-description` and `pr-codeowners` are included because `create-pr` delegates its main output to them with "if available" phrasing — without them it silently runs in a reduced mode.

Always-on cost: **~1,130 tokens** per session. The set is deliberately small: when the agent's skill listing overflows its budget, descriptions get truncated starting with the least-invoked skills, so a bloated base set makes *every* skill harder to trigger.

## Safety

Enabling auto-update puts git operations on every engineer's install path, so this also:

- suppresses git credential prompts (`GIT_TERMINAL_PROMPT=0`, empty `GIT_ASKPASS`) in both `run()` and the delegated environment — `tools/sync` pulls the **private** Consensys overlay, which could otherwise block on stdin during `yarn install` with no output
- bounds every spawn: 300s for network git, 10s for local `bash --version` probes

## Guardrails added

- `base: true` + `maturity: experimental` is now a **lint error** — contradictory intent; installing unfinished guidance for everyone is the bad outcome
- warns when a base skill's description is under 120 characters

## Verified

| Check | Result |
|---|---|
| Automatic path (`SKILLS_DEFAULT_SCOPE=base`) | exactly 10, in `.claude/skills` and `.agents/skills` |
| Explicit `yarn skills` | 36 |
| Automatic + `SKILLS_DOMAINS=perps` | 12 — saved selection respected |
| `SKILLS_AUTO_UPDATE=0` / `CI=1` | silent, exit 0 |
| Full `postinstall` → `sync` → `install` | exit 0 |
| Overlay merge intact | `coding-guidelines` 71-byte source stub → 3,990 bytes installed |
| `node --test` | 65/65 |
| `lint-skill-entry.mjs` | 52 skills, 0 errors |

## Migration note

Existing engineers are **not** dropped to 10. Their current installs stay, because pruning is off by default and their next `yarn install` only adds the base set. `yarn skills --prune-stale` once gives a clean state.

This does reach **external contributors**: the skills package is a devDependency of public repos, so a drive-by contributor's `yarn install` now clones this repo into `.skills-cache/` and writes 10 gitignored skill files. Public content, gitignored output, one clone — flagging it rather than letting it be discovered later.

## Related

- Extension's base set: stacked PR on this branch
- Consumer side: MetaMask/metamask-mobile#35263 (draft — needs a published release of this)

Known gaps documented separately: no standardized PR-review skill, platform APIs at 2 of ~11, and five deprecated testing skills that still compete with `mobile-testing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
