### PR TITLE
feat: add the metamask-extension base skill set

### DIFF
--- a/domains/coding/skills/controller-guidelines/skill.md
+++ b/domains/coding/skills/controller-guidelines/skill.md
@@ -1,4 +1,5 @@
 ---
 name: controller-guidelines
 description: BaseController development patterns
+base: true
 ---

--- a/domains/coding/skills/controller-guidelines/skill.md
+++ b/domains/coding/skills/controller-guidelines/skill.md
@@ -1,5 +1,9 @@
 ---
 name: controller-guidelines
-description: BaseController development patterns
+description: >
+  Authoring a MetaMask controller: BaseController or not, state metadata (`persist`,
+  `anonymous`, `usedInUi`), `this.update`, the options-bag constructor, typed messenger
+  actions. Use when writing or reviewing a controller, or changing what it persists or exposes
+  to the UI. To wire one in, see `controller-integration`.
 base: true
 ---

--- a/domains/coding/skills/controller-integration/repos/metamask-extension.md
+++ b/domains/coding/skills/controller-integration/repos/metamask-extension.md
@@ -137,3 +137,18 @@ yarn test:unit app/scripts/messenger-client-init/<name>-controller-init.test.ts
 yarn lint:tsc
 yarn test:e2e:single test/e2e/tests/metrics/errors.spec.ts --update-snapshot  # refreshes enforced Sentry state snapshots
 ```
+
+## 8. Writing the controller itself
+
+This skill covers *integration* — wiring an existing controller into the background.
+For the internals of authoring one (BaseController patterns, state metadata,
+messenger action/event typing), read the sibling `controller-guidelines` skill:
+
+```
+domains/coding/skills/controller-guidelines/skill.md
+```
+
+Both are base skills, and the split is deliberate: `controller-guidelines` answers
+"how do I write this controller", this one answers "how do I wire it in". Reach for
+that one when the question is about state metadata, the options bag, or whether
+BaseController is the right base class at all.

--- a/domains/coding/skills/controller-integration/skill.md
+++ b/domains/coding/skills/controller-integration/skill.md
@@ -1,14 +1,9 @@
 ---
 name: controller-integration
 description: >
-  Wire a new or existing controller — whether imported from a
-  `@metamask/*-controller` npm package or defined locally in the repo — into
-  the MetaMask Mobile Engine or the MetaMask Extension background. Use this
-  skill when: adding a controller to Engine or to the extension's
-  messenger-client init, creating a controller init function or messenger,
-  delegating actions/events between controllers, adding a controller to
-  EngineState/Engine.context or to MESSENGER_FACTORIES and the
-  MessengerClient union, or debugging a controller whose state never reaches
-  Redux/the UI or resets on restart.
+  Wiring a controller into the Mobile Engine or Extension background: init functions,
+  messengers, `MESSENGER_FACTORIES`, `EngineState`. Use when adding a controller, delegating
+  actions/events between controllers, or debugging state that never reaches Redux or resets on
+  restart. To author one, see `controller-guidelines`.
 base: true
 ---

--- a/domains/performance/skills/perf-hooks-effects/skill.md
+++ b/domains/performance/skills/perf-hooks-effects/skill.md
@@ -1,5 +1,9 @@
 ---
 name: perf-hooks-effects
-description: React hooks and effects optimization
+description: >
+  Extension UI hooks and effects: when not to use `useEffect`, dependency arrays, why
+  `JSON.stringify` deps are never the fix, cascading effects, `AbortController` cleanup. Use
+  when an effect loops or fires every render, deps are stringified to force equality, or state
+  lands after unmount. Rendering goes to `perf-rendering`.
 base: true
 ---

--- a/domains/performance/skills/perf-hooks-effects/skill.md
+++ b/domains/performance/skills/perf-hooks-effects/skill.md
@@ -1,4 +1,5 @@
 ---
 name: perf-hooks-effects
 description: React hooks and effects optimization
+base: true
 ---

--- a/domains/performance/skills/perf-react-compiler/skill.md
+++ b/domains/performance/skills/perf-react-compiler/skill.md
@@ -1,5 +1,9 @@
 ---
 name: perf-react-compiler
-description: React Compiler optimization patterns
+description: >
+  React Compiler in the Extension UI: what it optimizes, where it bails out, and when manual
+  memoization is still needed. Use when deciding whether `useMemo`, `useCallback` or
+  `React.memo` are still required, reviewing reflexive memoization, or working out why a
+  component isn't optimized. Dependency arrays go to `perf-hooks-effects`.
 base: true
 ---

--- a/domains/performance/skills/perf-react-compiler/skill.md
+++ b/domains/performance/skills/perf-react-compiler/skill.md
@@ -1,4 +1,5 @@
 ---
 name: perf-react-compiler
 description: React Compiler optimization patterns
+base: true
 ---

--- a/domains/performance/skills/perf-rendering/skill.md
+++ b/domains/performance/skills/perf-rendering/skill.md
@@ -1,4 +1,5 @@
 ---
 name: perf-rendering
 description: Rendering performance optimization
+base: true
 ---

--- a/domains/performance/skills/perf-rendering/skill.md
+++ b/domains/performance/skills/perf-rendering/skill.md
@@ -1,5 +1,9 @@
 ---
 name: perf-rendering
-description: Rendering performance optimization
+description: >
+  Extension UI render performance: list keys, virtualization, `React.memo`, code splitting, Web
+  Workers, debouncing. Use when a long list stutters, scrolling feels janky, a component
+  re-renders more than it should, or a route loads slowly. Effects go to `perf-hooks-effects`;
+  selectors to `perf-state-management`.
 base: true
 ---

--- a/domains/performance/skills/perf-state-management/skill.md
+++ b/domains/performance/skills/perf-state-management/skill.md
@@ -1,5 +1,9 @@
 ---
 name: perf-state-management
-description: Redux and state management optimization
+description: >
+  Extension Redux state and selectors: reducer purity, keeping non-serializable values out of
+  the store, normalization, Immer, batching, identity output selectors. Use when components
+  re-render on unrelated state changes, a selector returns a fresh identity every call, or
+  state is mutated in a reducer. Memoization goes to `perf-rendering`.
 base: true
 ---

--- a/domains/performance/skills/perf-state-management/skill.md
+++ b/domains/performance/skills/perf-state-management/skill.md
@@ -1,4 +1,5 @@
 ---
 name: perf-state-management
 description: Redux and state management optimization
+base: true
 ---

--- a/domains/testing/skills/extension-testing/skill.md
+++ b/domains/testing/skills/extension-testing/skill.md
@@ -8,6 +8,7 @@ description: >
   MetaMaskController, FixtureBuilderV2, page objects, E2E flake, POM
   anti-patterns, or asks which Extension testing skill to install.
 maturity: stable
+base: true
 ---
 
 # Extension testing


### PR DESCRIPTION
## ⚠️ Merge after #135

Stacked on `feat/base-skills-mobile`. The `base` flag this PR sets is introduced there — **merge #135 first**, then this retargets to `main` automatically.

## What

Marks the 10 skills every `metamask-extension` engineer needs as `base`, so a fresh clone lands exactly those.

Four are already shared with Mobile and land in #135 — `coding-guidelines`, `ui-development`, `controller-integration`, `pr-guidelines`. This PR adds the six Extension-only ones:

| Skill | Why base |
|---|---|
| `extension-testing` | Testing entrypoint — unit, integration (stub), Selenium E2E |
| `controller-guidelines` | Authoring a controller: BaseController choice, state metadata, messenger typing |
| `perf-rendering` | Lists, virtualization, memoization, code splitting |
| `perf-hooks-effects` | `useEffect` misuse, dependency arrays, cascading effects |
| `perf-react-compiler` | What the compiler optimizes, where it bails out, when manual memoization remains |
| `perf-state-management` | Redux reducer purity, selector identity, normalization |

Always-on cost: **3,257 characters ≈ 814 tokens** per session across all ten.

## Descriptions

Both caveats from the original version are addressed.

**Descriptions now state trigger conditions, not topics.** They were 34–39 characters — `"Rendering performance optimization"` says what a skill is about but never when to reach for it, and nobody phrases the problem that way; they say the list stutters when they scroll. Each now leads with concrete coverage and ends with a `Use when …` clause in symptom vocabulary.

The original mitigation here — "CI warns on each until rewritten, so the TODO cannot rot" — **was false**, as @Qbandev demonstrated: the linter only sets a non-zero exit on errors, so a warning sat invisibly inside a green check. #135 promotes the base-description floor to an error, which is what makes this PR's descriptions load-bearing rather than optional.

**The four `perf-*` skills now route to each other.** They were mutually indistinguishable — "my component re-renders too much" matched all four equally, so selection was arbitrary and the model could pull ~20KB scattershot. Each now names its siblings, so whichever fires hands off rather than competing.

This mitigates the four-slots-for-one-concern problem; it does not solve it. Consolidating to a single entrypoint with on-demand references, as Mobile's `performance` does, remains the structural fix and is still worth doing separately.

Nothing here is measured. The argument is mechanical — the description is the selection surface, symptoms were absent, siblings were undifferentiated — not the result of a triggering experiment.

## Scope

Proposed from the catalogue rather than from working in `metamask-extension`, so **it still needs owner review** on:

- whether `extension-testing` is genuinely the right single testing entrypoint

Resolved since the original: @MajorLift confirmed `controller-guidelines` and `controller-integration` should **both** be base, with `controller-integration` the more valuable for client work since integrating controllers is routine and authoring them is not. They now cross-reference each other, and `controller-integration`'s Extension reference gains a section pointing at the authoring guidance.

## Known Extension gaps (not addressed here)

| Gap | Notes |
|---|---|
| **Almost no PR automation** | 9 of 10 `pr-workflow` skills are Mobile-only, including `create-pr`. Extension gets PR *standards* but no PR *automation*. Overlay work on existing skills — likely the cheapest high-value win. |
| No `component-scaffold` equivalent | Design-system-first intent has no enforcement at generation time |
| No component-view test layer | The "steer agents toward component view tests" goal is Mobile-only today |
| Platform APIs | 1 of ~11 areas covered |
