### PR TITLE
ci(lint): Fix universal installs being accepted by default by flagging missing repo overlays

### DIFF
--- a/.github/scripts/lint-skill-entry.mjs
+++ b/.github/scripts/lint-skill-entry.mjs
@@ -106,6 +106,30 @@ export function lintSkill(skill) {
     }
   }
 
+  // Repo targeting is declared by the SHAPE of repos/, not by its contents, and the two
+  // shapes mean opposite things to the installer. `tools/install` skips a skill whose
+  // repos/ exists but holds no file for the target repo, while a skill with no repos/ at
+  // all installs into every repo. So adding one overlay to a skill that had none does not
+  // widen it — it narrows it from "everywhere" to "that repo alone", silently, and the
+  // skill keeps installing fine in the repo you were looking at.
+  if (skill.repos.length > 0) {
+    const missing = KNOWN_REPOS.filter((r) => !skill.repos.includes(r));
+    if (missing.length > 0) {
+      warnings.push(
+        `repos/ covers ${skill.repos.join(', ')} but not ${missing.join(', ')}; ` +
+          `the installer SKIPS this skill entirely for ${missing.length === 1 ? 'that repo' : 'those repos'}. ` +
+          `Add repos/<repo>.md for each (a stub naming the repo is enough), or delete repos/ ` +
+          `to install everywhere with no repo-specific guidance.`,
+      );
+    }
+  } else {
+    warnings.push(
+      `no repos/ overlay; installs into every repo (${KNOWN_REPOS.join(', ')}) with no ` +
+        `repo-specific guidance. Add a repos/<repo>.md per consumer, or leave as-is if the ` +
+        `skill is genuinely repo-agnostic.`,
+    );
+  }
+
   for (const key of Object.keys(raw)) {
     if (!KNOWN_FRONTMATTER.includes(key) && key !== 'alwaysApply') {
       warnings.push(`unknown frontmatter key "${key}"; operators silently ignore unrecognised keys (typo?)`);


### PR DESCRIPTION
## Overview

A skill with no `repos/` directory installs into **every** consuming repo — `core`, `metamask-extension`, `metamask-mobile`. That is the default, so nobody chose it and no reviewer sees a decision to question.

This adds two `lint-skill-entry` warnings so the omission is visible at review.

## Motivation

Targeting is declared by the **shape** of `repos/`, and the two shapes mean opposite things:

- **no** `repos/` → installs into **every** repo
- **with** `repos/` → only the repos it names; `tools/install:477` skips it for any repo with no `repos/<repo>.md`

So the obvious fix makes it worse. Adding *one* overlay to a skill that had none does not widen it — it narrows it to that repo alone, silently, because the skill still installs correctly in the repo whose overlay was just written.

Hence two warnings: one for reach nobody declared, one for reach a well-meant overlay has quietly removed.

Warnings, not errors: 11 skills on `main` carry no `repos/`, and several are genuinely repo-agnostic (`codex`, `gator-cli`, `x402-payments`). Erroring today would fail correct work.

## Showcase

Across `main`, of 53 skills: **41** partial coverage, **11** no `repos/`, **1** full. Most partial coverage is deliberate; the 11 are the queue.

Of the warnings `lint-skill-entry` now emits, **52 are new here** and 91 pre-date this change.

