### PR TITLE
feat: Add skill for Flashlight, a lighthouse tool for Android vitals

### DIFF
--- a/domains/performance/skills/performance/references/js-flashlight.md
+++ b/domains/performance/skills/performance/references/js-flashlight.md
@@ -48,24 +48,24 @@ softwareupdate --install-rosetta --agree-to-license
 4. **Auto Detect** the running app — Flashlight finds the foreground app's package ID for you (no per-app setup).
 5. **Start Measuring.** Click it, then **drive the exact slow flow by hand** on the device (the audited interaction, not idle/startup).
 6. **Read the live vitals** as you interact:
-   - **FPS** — JS thread and UI (main) thread, graphed over time. <55 = dropping frames.
-   - **CPU** — total and **per-thread** (e.g. `mqt_js`, `RenderThread`), so you can see which thread is hot.
+   - **FPS** — a single frame-rate stream, graphed over time. <55 = dropping frames. (Flashlight does **not** split JS-thread vs UI-thread FPS — that's the in-app Perf Monitor; use the per-thread CPU below to attribute a drop.)
+   - **CPU** — total and **per-thread** (e.g. `mqt_js` = JS thread, `RenderThread` = native UI), so you can see which thread is hot. This is Flashlight's real thread-level signal.
    - **RAM** — resident memory over the session.
    - **Score** — an aggregate 0–100 performance rating (higher is better).
 7. **Stop** when done. `measure` is live/interactive, so treat the reading as directional, not a signed-off number.
 
 ## Interpreting Results
 
-Same JS-vs-UI-thread split as the [Perf Monitor / DevTools triage](mm-tools.md):
+When FPS drops, attribute it with the **per-thread CPU** breakdown (Flashlight's real thread signal) — the same JS-vs-UI logic as the [Perf Monitor / DevTools triage](mm-tools.md):
 
 | Live signal | Likely cause | Where to go next |
 |---|---|---|
-| **JS FPS drops**, `mqt_js` CPU high | Expensive renders / selectors / computation on the JS thread | RN DevTools Profiler → [mm-selector-memoization.md](mm-selector-memoization.md) / [mm-redux-antipatterns.md](mm-redux-antipatterns.md) / [mm-hook-dependency-arrays.md](mm-hook-dependency-arrays.md) |
-| **UI FPS drops**, `RenderThread` CPU high (JS fine) | Native rendering / animation / too many views | [mm-layout-animations.md](mm-layout-animations.md) / [native-view-flattening.md](native-view-flattening.md) |
-| **Both drop** | Mixed — start on the JS side | [js-profile-react.md](js-profile-react.md) |
+| FPS drops + **`mqt_js` (JS thread) CPU high** | Expensive renders / selectors / computation on the JS thread | RN DevTools Profiler → [mm-selector-memoization.md](mm-selector-memoization.md) / [mm-redux-antipatterns.md](mm-redux-antipatterns.md) / [mm-hook-dependency-arrays.md](mm-hook-dependency-arrays.md) |
+| FPS drops + **`RenderThread` (native UI) CPU high** (`mqt_js` fine) | Native rendering / animation / too many views | [mm-layout-animations.md](mm-layout-animations.md) / [native-view-flattening.md](native-view-flattening.md) |
+| FPS drops + **both threads hot** | Mixed — start on the JS side | [js-profile-react.md](js-profile-react.md) |
 | **RAM climbs** across a session | Leak | [js-memory-leaks.md](js-memory-leaks.md) / [native-memory-leaks.md](native-memory-leaks.md) |
 
-Flashlight tells you **which thread and roughly how bad**; use RN DevTools Profiler to find the exact component/function to fix.
+Flashlight tells you **which thread and roughly how bad** (via per-thread CPU); use RN DevTools Profiler to find the exact component/function to fix.
 
 ## Scope: live triage only
 

--- a/domains/performance/skills/performance/references/js-flashlight.md
+++ b/domains/performance/skills/performance/references/js-flashlight.md
@@ -1,0 +1,88 @@
+---
+title: Flashlight (live Android vitals)
+impact: MEDIUM
+tags: flashlight, fps, cpu, ram, android, live-vitals
+---
+
+# Skill: Flashlight — live Android vitals (`flashlight measure`)
+
+> **MetaMask note:** Flashlight is an external, Lighthouse-type tool for mobile apps and is **NOT installed in this repo** — it's **not in `package.json`**. The in-repo defaults are the in-app **Perf Monitor** (quick JS-vs-UI check) and the **RN DevTools Profiler** (primary tool). Flashlight is an optional add-on when you want a **device-level, app-agnostic live vitals view on Android** (FPS/CPU/RAM/threads + a score) without wiring anything into the app. Always measure on **Android with the power-user scenario** (~30 accounts, ~90 assets — see [mm-power-user-scenario.md](mm-power-user-scenario.md)). The JS-vs-UI-thread triage lives in [mm-tools.md](mm-tools.md).
+
+Use `flashlight measure` to watch **live** performance vitals of a running Android app while you drive the slow flow by hand. It's a Lighthouse-like tool for mobile ([flashlight.dev](https://flashlight.dev/)) that needs **no code changes** and works even on **release/production builds**.
+
+## Quick Command
+
+```bash
+# Android device plugged in, target app open, then:
+flashlight measure              # starts a local web server (interactive live UI)
+flashlight measure --port 8080  # use a custom port if the default is taken
+```
+
+## When to Use
+
+- You want a fast, at-a-glance FPS/CPU/RAM readout on a **real Android device** while reproducing jank by hand.
+- You're profiling a **release/production build** where RN DevTools / dev tooling isn't available.
+- You want a single **performance score** to sanity-check "is this flow bad?" before deciding where to dig in.
+- Quick, interactive triage — **not** a merge gate. For reproducible before/after or CI numbers use the in-repo Reassure + `trace()` path in [mm-tools.md](mm-tools.md).
+
+## Prerequisites
+
+- **Android only** (iOS support is a work in progress). Use a real device where possible — emulators/simulators don't reflect real performance.
+- An Android device connected over USB (with USB debugging / `adb` working) and the target app already open.
+- The Flashlight CLI installed — see below.
+- **Dev Mode OFF** for accurate numbers (Dev Menu → Settings → JS Dev Mode → OFF).
+
+### Install (from a verified release)
+
+Per the repo security guardrail ([onboarding.md](onboarding.md)): **do not pipe a remote install script straight into a shell.** The vendor advertises `curl https://get.flashlight.dev | bash` (macOS/Linux) and `iwr https://get.flashlight.dev/windows -useb | iex` (Windows) — treat these as supply-chain dependencies: download from the official release channel, pin a version, and verify the binary before running. On Apple Silicon (arm64) you'll also need Rosetta:
+
+```bash
+softwareupdate --install-rosetta --agree-to-license
+```
+
+## Step-by-Step: live measurement
+
+1. **Connect + open the app.** Plug in the Android device and open the target app (dev or release build). Confirm `adb devices` lists it.
+2. **Start the server.** Run `flashlight measure` (or `flashlight measure --port <port>`). It boots a **local web server** and prints a `localhost` URL.
+3. **Open the web UI** in your browser at that URL.
+4. **Auto Detect** the running app — Flashlight finds the foreground app's package ID for you (no per-app setup).
+5. **Start Measuring.** Click it, then **drive the exact slow flow by hand** on the device (the audited interaction, not idle/startup).
+6. **Read the live vitals** as you interact:
+   - **FPS** — JS thread and UI (main) thread, graphed over time. <55 = dropping frames.
+   - **CPU** — total and **per-thread** (e.g. `mqt_js`, `RenderThread`), so you can see which thread is hot.
+   - **RAM** — resident memory over the session.
+   - **Score** — an aggregate 0–100 performance rating (higher is better).
+7. **Stop** when done. `measure` is live/interactive, so treat the reading as directional, not a signed-off number.
+
+## Interpreting Results
+
+Same JS-vs-UI-thread split as the [Perf Monitor / DevTools triage](mm-tools.md):
+
+| Live signal | Likely cause | Where to go next |
+|---|---|---|
+| **JS FPS drops**, `mqt_js` CPU high | Expensive renders / selectors / computation on the JS thread | RN DevTools Profiler → [mm-selector-memoization.md](mm-selector-memoization.md) / [mm-redux-antipatterns.md](mm-redux-antipatterns.md) / [mm-hook-dependency-arrays.md](mm-hook-dependency-arrays.md) |
+| **UI FPS drops**, `RenderThread` CPU high (JS fine) | Native rendering / animation / too many views | [mm-layout-animations.md](mm-layout-animations.md) / [native-view-flattening.md](native-view-flattening.md) |
+| **Both drop** | Mixed — start on the JS side | [js-profile-react.md](js-profile-react.md) |
+| **RAM climbs** across a session | Leak | [js-memory-leaks.md](js-memory-leaks.md) / [native-memory-leaks.md](native-memory-leaks.md) |
+
+Flashlight tells you **which thread and roughly how bad**; use RN DevTools Profiler to find the exact component/function to fix.
+
+## Scope: live triage only
+
+`flashlight measure` is a **live, interactive** readout — performance is **non-deterministic**, so the numbers shift with how you use the app. Treat it as directional triage, not a signed-off measurement. For reproducible before/after numbers or a merge gate, use the in-repo **Reassure** (render count) + **`trace()`** (duration) path in [mm-tools.md](mm-tools.md).
+
+## Common Pitfalls
+
+- **Measuring in dev mode** — JS Dev Mode inflates cost; turn it off for real numbers.
+- **Using an emulator** — measure on a real (ideally lower-end) Android device; that's what users feel.
+- **Trusting a single reading** — it's non-deterministic; re-run to confirm a trend.
+- **Letting `measure` run for a prolonged period** — the CLI can crash on long sessions. Reset/restart it often and keep each measurement short.
+- **Using it as a regression gate** — it has no averaging or gate; use Reassure + `trace()` for that.
+- **Assuming it's installed here** — it isn't in this repo; install it yourself from a verified release.
+
+## Related Skills
+
+- [js-measure-fps.md](js-measure-fps.md) - Perf Monitor + the JS-vs-UI FPS triage this builds on
+- [js-profile-react.md](js-profile-react.md) - Find the exact component/function behind a JS-thread drop
+- [js-lists-flatlist-flashlist.md](js-lists-flatlist-flashlist.md) - Fix scroll-related FPS drops
+- [mm-tools.md](mm-tools.md) - Symptom-first tool tree and the full measurement loop

--- a/domains/performance/skills/performance/references/js-measure-fps.md
+++ b/domains/performance/skills/performance/references/js-measure-fps.md
@@ -6,7 +6,7 @@ tags: fps, performance, monitoring, flashlight
 
 # Skill: Measure JS FPS
 
-> **MetaMask note:** Always measure on **Android with the power-user scenario** (~30 accounts, ~90 assets — see [mm-power-user-scenario.md](mm-power-user-scenario.md)). The in-app **Perf Monitor** (shake → Dev Menu) is the quick check and the **RN DevTools Profiler** is the primary tool. **Flashlight is NOT installed in this repo** — it's an optional external tool; install it separately only if you want an automatable Android score for before/after or CI. The JS-vs-UI-thread split below is the first triage step in [mm-tools.md](mm-tools.md).
+> **MetaMask note:** Always measure on **Android with the power-user scenario** (~30 accounts, ~90 assets — see [mm-power-user-scenario.md](mm-power-user-scenario.md)). The in-app **Perf Monitor** (shake → Dev Menu) is the quick check and the **RN DevTools Profiler** is the primary tool. **Flashlight is NOT installed in this repo** — it's an optional external tool; install it separately only if you want a device-level live Android vitals view (`flashlight measure`, see [js-flashlight.md](js-flashlight.md)). The JS-vs-UI-thread split below is the first triage step in [mm-tools.md](mm-tools.md).
 
 Monitor and measure JavaScript frame rate to quantify app smoothness and identify performance regressions.
 
@@ -16,9 +16,9 @@ Monitor and measure JavaScript frame rate to quantify app smoothness and identif
 # Method 1: Built-in Perf Monitor
 # Shake device → Dev Menu → "Perf Monitor"
 
-# Method 2: Flashlight (Android, detailed reports)
+# Method 2: Flashlight (Android — live vitals) — see js-flashlight.md
 # Install Flashlight from an official, verified release channel first.
-flashlight measure
+flashlight measure   # live web UI: Auto Detect → Start Measuring
 ```
 
 ## When to Use
@@ -57,37 +57,23 @@ flashlight measure
 - **< 60 FPS** = Dropping frames
 - **120 FPS** target for high refresh rate devices (8.3ms per frame)
 
-### Method 2: Flashlight (Automated Benchmarking)
+### Method 2: Flashlight (Android)
 
-> Android only. Provides detailed reports and JSON export.
+> Android only. External tool, **not installed here**. Full workflow in [js-flashlight.md](js-flashlight.md).
 
 ![Flashlight FlatList vs FlashList Comparison](images/flashlight-flatlist-vs-flashlist.png)
 
-Flashlight shows comparative performance data:
+Flashlight surfaces the same vitals without wiring anything into the app:
 - **Score** (0-100): Overall performance rating (higher is better)
 - **Average FPS**: Target 60 FPS for smooth scrolling
-- **FPS Graph**: Real-time frame rate over test duration
-- **CPU/RAM metrics**: Resource consumption
+- **FPS Graph**: Frame rate over the session
+- **CPU/RAM metrics**: Resource consumption (CPU broken out per-thread)
 
 The image shows FlatList (score: 3) vs FlashList (score: 67) - a dramatic difference visible in both the score and FPS graph.
 
-**Installation:**
+Use **`flashlight measure`** for a **live, interactive** web UI to watch vitals while you drive the flow by hand (non-deterministic; great for triage). See [js-flashlight.md](js-flashlight.md).
 
-Install Flashlight from the vendor's official release channel before using it. Prefer a package manager or a version-pinned binary with checksum/signature verification. Do not pipe a remote install script directly into a shell.
-
-**Usage:**
-
-```bash
-# Start measuring (app must be running on Android)
-flashlight measure
-```
-
-**Features:**
-- Real-time FPS graph
-- Average FPS calculation
-- CPU and RAM metrics
-- Overall performance score
-- JSON export for CI comparison
+Install from the vendor's official release channel before using it — prefer a package manager or a version-pinned binary with checksum/signature verification; do not pipe a remote install script directly into a shell.
 
 ### Important: Disable Dev Mode
 
@@ -155,16 +141,6 @@ const longRunningFunction = () => {
 | 30-45 | Noticeable jank | Optimize required |
 | < 30 | Very choppy | Critical fix needed |
 
-## Flashlight CI Integration
-
-```bash
-# Export measurements to JSON
-flashlight measure --output results.json
-
-# Compare builds
-flashlight compare baseline.json current.json
-```
-
 ## Common Pitfalls
 
 - **Measuring in dev mode**: Results will be artificially slow
@@ -174,6 +150,7 @@ flashlight compare baseline.json current.json
 
 ## Related Skills
 
+- [js-flashlight.md](./js-flashlight.md) - Live Android vitals with `flashlight measure`
 - [js-profile-react.md](./js-profile-react.md) - Find what's causing FPS drops
 - [js-animations-reanimated.md](./js-animations-reanimated.md) - Fix animation-related drops
 - [js-lists-flatlist-flashlist.md](./js-lists-flatlist-flashlist.md) - Fix scroll-related drops

--- a/domains/performance/skills/performance/references/mm-tools.md
+++ b/domains/performance/skills/performance/references/mm-tools.md
@@ -80,7 +80,7 @@ Then read what's emitted — a load log (e.g. `source: 'cache' | 'fresh_fetch'`,
       Both dropping → start with JS profiling
 
 "FPS drops while scrolling a list"
-  → Perf Monitor to confirm → RN DevTools Profiler (or Flashlight, if installed) → js-lists-flatlist-flashlist.md
+  → Perf Monitor to confirm → RN DevTools Profiler (or Flashlight live vitals, if installed — js-flashlight.md) → js-lists-flatlist-flashlist.md
 
 "Components re-render too much"
   → React Native DevTools → "why did this render?" → mm-selector-memoization.md / mm-redux-antipatterns.md
@@ -107,7 +107,7 @@ Then read what's emitted — a load log (e.g. `source: 'cache' | 'fresh_fetch'`,
   → instrument with trace() (below) → native-measure-tti.md → bundle-analyze-js.md
 
 "How do I prove my fix is faster?"
-  → Reassure (render count) + trace() (duration) [+ Flashlight FPS, if installed]. Baseline → fix → re-measure.
+  → Reassure (render count) + trace() (duration) [+ Flashlight live FPS for a quick check, if installed — js-flashlight.md]. Baseline → fix → re-measure.
 
 "Prevent regressions going forward"
   → Reassure perf-test in CI  +  E2E performance gates (mms-performance-testing skill)
@@ -144,8 +144,8 @@ Then read what's emitted — a load log (e.g. `source: 'cache' | 'fresh_fetch'`,
 - Network inspection for **pre-0.83** setups where the DevTools Network tab is unavailable on Android. On RN 0.83+ prefer the DevTools [Network panel](js-network-panel.md) (works on Android). WebSocket events still aren't captured by the Network panel — Reactotron remains useful there.
 
 ### Flashlight (optional, external — NOT installed in this repo)
-- **Not in `package.json`** — it's an external Callstack tool. Don't assume it's available; for day-to-day FPS use Perf Monitor + RN DevTools.
-- **If you install it** (separately, from a verified release — don't pipe a remote script to a shell): `flashlight measure --output results.json` → `flashlight compare baseline.json current.json` for an automatable Android score (before/after, CI).
+- **Not in `package.json`** — it's an external, Lighthouse-type tool for mobile apps. Don't assume it's available; for day-to-day FPS use Perf Monitor + RN DevTools.
+- **If you install it** (separately, from a verified release — don't pipe a remote script to a shell): **`flashlight measure`** starts a live, interactive web UI for watching Android vitals (FPS/CPU-per-thread/RAM/score) while you drive the flow by hand. Non-deterministic; good for triage. See [js-flashlight.md](js-flashlight.md). For reproducible before/after or CI numbers, use the in-repo Reassure + `trace()` path instead.
 
 ### Reassure (render-time regression gate) — INSTALLED
 - **Use:** guard a component/hook against render-time regressions before merge.
@@ -221,4 +221,4 @@ A code session often has no running device, so "Measure first" isn't literally p
 
 ## Related
 
-- [mm-power-user-scenario.md](mm-power-user-scenario.md) · [js-measure-fps.md](js-measure-fps.md) · [js-profile-react.md](js-profile-react.md) · [js-performance-panel.md](js-performance-panel.md) · [js-network-panel.md](js-network-panel.md) · [native-measure-tti.md](native-measure-tti.md)
+- [mm-power-user-scenario.md](mm-power-user-scenario.md) · [js-measure-fps.md](js-measure-fps.md) · [js-flashlight.md](js-flashlight.md) · [js-profile-react.md](js-profile-react.md) · [js-performance-panel.md](js-performance-panel.md) · [js-network-panel.md](js-network-panel.md) · [native-measure-tti.md](native-measure-tti.md)

--- a/domains/performance/skills/performance/repos/metamask-mobile.md
+++ b/domains/performance/skills/performance/repos/metamask-mobile.md
@@ -60,7 +60,7 @@ Always pair measurement with the **power-user scenario on Android** — see [ref
 | **Opening / navigating to a screen is slow** (tabs/pager fetch everything, N fetches for 1 visible view, waterfall) | [mm-eager-work-on-mount.md](references/mm-eager-work-on-mount.md) → [native-measure-tti.md](references/native-measure-tti.md) |
 | **Real-time / websocket screen slow or janky** (prices, order book, live balances); slow only on first-open / after backgrounding | [mm-streaming-realtime.md](references/mm-streaming-realtime.md) |
 | **List re-renders fully even though children are memoized** (a hook returns a new array/object every render) | [mm-unstable-hook-return.md](references/mm-unstable-hook-return.md) |
-| FPS drops; want to localize JS vs UI thread | [js-measure-fps.md](references/js-measure-fps.md) → [js-profile-react.md](references/js-profile-react.md) |
+| FPS drops; want to localize JS vs UI thread | [js-measure-fps.md](references/js-measure-fps.md) → [js-profile-react.md](references/js-profile-react.md) (optional device-level Android vitals: [js-flashlight.md](references/js-flashlight.md)) |
 | Need a full timeline (React scheduler + JS + network) for a slow flow, not just re-renders | [js-performance-panel.md](references/js-performance-panel.md) |
 | Inspect network requests / API timings; is a slow screen data-bound or render-bound? | [js-network-panel.md](references/js-network-panel.md) |
 | Memory grows over a session | [js-memory-leaks.md](references/js-memory-leaks.md) / [native-memory-leaks.md](references/native-memory-leaks.md) |


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->

This PR updates the existing `performance` skill to include docs about [Flashlight](https://github.com/bamlab/flashlight), a lighthouse tool for observing live vitals of Android apps. The CLI is optional and not pre-installed

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] New skill
- [x] Skill improvement/update
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## Skill Details (if adding a new skill)

**Provider Name:** 
**Skill Name:** 
**Brief Description:** 

## Checklist

<!-- Mark completed items with an "x" -->

- [x] I have read the [CONTRIBUTING.md](https://github.com/MetaMask/skills/blob/main/CONTRIBUTING.md) guidelines
- [x] My skill follows the [SKILL_TEMPLATE.md](https://github.com/MetaMask/skills/blob/main/.github/SKILL_TEMPLATE.md) format
- [x] I have tested this skill with an AI agent
- [x] My skill does not contain any secrets, private keys, or sensitive data
- [x] I have added appropriate documentation
- [x] My changes don't break existing skills

## Testing

<!-- Describe how you tested this skill -->

Point an independent agent at the skill and give it a realistic prompt that does not name the tool, then confirm it (a) discovers your new guide by following the skill's own links and (b) gives accurate guidance. 

**In Cursor/Claude Code**: install the skill (tools/install --target <mobile-checkout> --domain performance) or point the agent at this repo, then ask a triggering prompt and watch which files it opens.
**Triggering prompts to use:**
"MetaMask Mobile feels janky on a low-end Android device. I want to watch live FPS/CPU/RAM while I reproduce the jank, without adding code. What tool and workflow?"
"How do I profile a release build of MetaMask Mobile on-device for performance?"
**Pass criteria:** it reaches [references/js-flashlight.md](https://github.com/MetaMask/skills/compare/feat/domains/performance/skills/performance/references/js-flashlight.md) by following links (not by keyword-searching), and returns the flashlight measure → Auto Detect → Start Measuring → live vitals flow.

## Additional Context

<!-- Add any other context or screenshots about the PR here -->
