### PR TITLE
feat(coding): add Mobile selector-patterns skill

### DIFF
--- a/domains/coding/skills/coding-guidelines/repos/metamask-mobile.md
+++ b/domains/coding/skills/coding-guidelines/repos/metamask-mobile.md
@@ -19,7 +19,7 @@ parent: coding-guidelines
 
 - TypeScript guidelines from contributor docs • Functional components + hooks • PascalCase (components) / camelCase (functions)
 - Reusable components/utilities • TSDoc format • Comprehensive tests following testing layers (below)
-- Redux selectors: install/use `coding/selector-patterns` when writing or updating them.
+- Redux selectors: install **selector-patterns** (`yarn skills --include coding/selector-patterns --save`) when writing or updating them.
 
 **Testing layers** (Mobile — canonical policy: testing domain `knowledge/testing-layers.md`, installed beside `mobile-testing`):
 

--- a/domains/coding/skills/coding-guidelines/repos/metamask-mobile.md
+++ b/domains/coding/skills/coding-guidelines/repos/metamask-mobile.md
@@ -19,6 +19,7 @@ parent: coding-guidelines
 
 - TypeScript guidelines from contributor docs • Functional components + hooks • PascalCase (components) / camelCase (functions)
 - Reusable components/utilities • TSDoc format • Comprehensive tests following testing layers (below)
+- Redux selectors: install/use `coding/selector-patterns` when writing or updating them.
 
 **Testing layers** (Mobile — canonical policy: testing domain `knowledge/testing-layers.md`, installed beside `mobile-testing`):
 

--- a/domains/coding/skills/controller-integration/repos/metamask-mobile.md
+++ b/domains/coding/skills/controller-integration/repos/metamask-mobile.md
@@ -44,7 +44,7 @@ Independently of the path above, the controller class itself comes from one of t
 | 8 | `app/core/Engine/constants.ts` | Append `'<Name>:stateChange'` to `BACKGROUND_STATE_CHANGE_EVENT_NAMES`. ⚠️ Copy the exact event name from the package's `Events` type — some emit `:stateChanged` |
 | 9 | `app/core/Engine/Engine.ts` | (a) import init fn (b) add to `initFunctions` **after** every controller it depends on — insertion order is init order (c) add to `this.context` (d) add to **both** the destructuring and return object of `get state()` |
 | 10 | `app/util/test/initial-background-state.json` | Add default state (run step in §7 verify to get the exact expected value) |
-| 11 | `app/selectors/<name>.ts` (+ test) | `state.engine.backgroundState.<Name> ?? getDefault<Name>State()`; derive with `createSelector` |
+| 11 | `app/selectors/<name>.ts` (+ test) | Leaf: `state.engine.backgroundState.<Name> ?? getDefault<Name>State()`. Install/use `coding/selector-patterns` for naming, `createSelector` / `createDeepEqualSelector`, and tests. |
 | 12 | `.github/CODEOWNERS` | Add glob entries for the init and messenger paths |
 | 13 | `tests/feature-flags/feature-flag-registry.ts` | Register the flag key, if the controller is remote-flag gated |
 

--- a/domains/coding/skills/controller-integration/repos/metamask-mobile.md
+++ b/domains/coding/skills/controller-integration/repos/metamask-mobile.md
@@ -44,7 +44,7 @@ Independently of the path above, the controller class itself comes from one of t
 | 8 | `app/core/Engine/constants.ts` | Append `'<Name>:stateChange'` to `BACKGROUND_STATE_CHANGE_EVENT_NAMES`. ⚠️ Copy the exact event name from the package's `Events` type — some emit `:stateChanged` |
 | 9 | `app/core/Engine/Engine.ts` | (a) import init fn (b) add to `initFunctions` **after** every controller it depends on — insertion order is init order (c) add to `this.context` (d) add to **both** the destructuring and return object of `get state()` |
 | 10 | `app/util/test/initial-background-state.json` | Add default state (run step in §7 verify to get the exact expected value) |
-| 11 | `app/selectors/<name>.ts` (+ test) | Leaf: `state.engine.backgroundState.<Name> ?? getDefault<Name>State()`. Install/use `coding/selector-patterns` for naming, `createSelector` / `createDeepEqualSelector`, and tests. |
+| 11 | `app/selectors/<name>.ts` (+ test) | Leaf: `state.engine.backgroundState.<Name> ?? getDefault<Name>State()`. Naming, factory choice, and tests: `yarn skills --include coding/selector-patterns --save`. |
 | 12 | `.github/CODEOWNERS` | Add glob entries for the init and messenger paths |
 | 13 | `tests/feature-flags/feature-flag-registry.ts` | Register the flag key, if the controller is remote-flag gated |
 

--- a/domains/coding/skills/selector-patterns/repos/metamask-mobile.md
+++ b/domains/coding/skills/selector-patterns/repos/metamask-mobile.md
@@ -86,7 +86,7 @@ Narrow the input to the smallest slice first (`performance` / `mm-selector-memoi
 | boolean, number, string | `createSelector` from `reselect` |
 | object, array, Map, Set | `createDeepEqualSelector` from `app/selectors/util.ts` when the narrowed input still churns (fresh ref every dispatch) and the payload is small enough to deep-compare |
 
-A sub-key read plus a module-level empty constant may stay on `createSelector`. Identity passthrough of a whole controller slice that allocates a new object every dispatch belongs on `createDeepEqualSelector`, or skip the wrapper and use the leaf. Copy before sort: `[...items].sort(cmp)`.
+A sub-key read plus a module-level empty constant may stay on `createSelector`.
 
 ## UI
 
@@ -152,9 +152,5 @@ describe('selectTokensByAddress', () => {
 - New and changed UI: `state.engine.backgroundState` in components, hooks, or other UI
 - Inline `useSelector((state) => …)` derivation
 - `useSelector(x, isEqual)` as a substitute for a stable selector
-- Identity `createSelector` on a whole controller slice
-- Inline `?? {}` / `?? []` creating a new ref on every call
-- Mutating inputs in the result function (`items.sort` without copying)
 - Version-gated flag evaluation outside `feature-flags`
-
-Memoization audits of existing selectors: `performance` (`mm-selector-memoization.md`).
+- Selector memoization (identity wrappers, new refs in result functions, mutation, huge inputs): `performance` (`mm-selector-memoization.md`)

--- a/domains/coding/skills/selector-patterns/repos/metamask-mobile.md
+++ b/domains/coding/skills/selector-patterns/repos/metamask-mobile.md
@@ -5,7 +5,7 @@ parent: selector-patterns
 
 # Selector patterns — MetaMask Mobile
 
-Copy from `app/selectors/addressBookController.ts` (leaf + `createSelector` + `createDeepEqualSelector`) and `app/selectors/tokensController.ts` (collection outputs, stable empty constant). Tests: `yarn jest app/selectors/<feature>.test.ts --no-coverage`. Unit-test shape: `mobile-testing`. Engine wiring that needs a first selector: install/use `coding/selector-patterns` from `controller-integration`. Memoization audits: `performance`. Version-gated flags: `feature-flags`.
+Copy from `app/selectors/tokensController.ts` (`EMPTY_TOKENS_BY_ADDRESS`, `EMPTY_TOKENS`, `selectTokensByAddress`, `selectAllTokensFlat`, `selectTokensLength`). Tests: `yarn jest app/selectors/<feature>.test.ts --no-coverage` (shape: `app/selectors/tokensController.test.ts`; unit-test skill: `mobile-testing`). Opt in: `yarn skills --include coding/selector-patterns --save`. Engine wiring: `controller-integration`. Memoization audits: `performance` (`mm-selector-memoization.md`). Version-gated flags: `feature-flags`.
 
 ## Paths
 
@@ -16,108 +16,125 @@ Copy from `app/selectors/addressBookController.ts` (leaf + `createSelector` + `c
 | Deep-equal helper | `app/selectors/util.ts` → `createDeepEqualSelector` |
 | Collocated tests | `app/selectors/<feature>.test.ts` |
 
-New selectors use `select<Feature><Thing>` (e.g. `selectTokensByChainId`). Existing `get*` names stay; do not rename them in this change.
+New selectors use `select<Feature><Thing>` (e.g. `selectTokensByChainIdAndAddress`). Existing `get*` names stay; do not rename them in this change.
 
 ## Leaf vs derived
 
-Only leaf input selectors read `state.engine.backgroundState`. Use `?? getDefault<Name>State()` when that helper exists.
+Only leaf input selectors read `state.engine.backgroundState`. Use `?? getDefault<Name>State()` when that helper exists. Illustrative leaf (plain function, not a file to copy):
 
 ```ts
-import { RootState } from '../reducers';
+export const selectFooControllerState = (state: RootState) =>
+  state.engine.backgroundState.FooController ?? getDefaultFooControllerState();
+```
+
+Derived selectors compose on a named, narrowed input. From `tokensController.ts`:
+
+```ts
+import { Token, TokensControllerState } from '@metamask/assets-controllers';
 import { createSelector } from 'reselect';
 import { createDeepEqualSelector } from './util';
-import { Hex } from '@metamask/utils';
 
-const EMPTY_ADDRESS_BOOK: Readonly<Record<string, never>> = Object.freeze({});
-const EMPTY_ADDRESS_BOOK_CHAIN: readonly never[] = Object.freeze([]);
-
-export const selectAddressBookControllerState = (state: RootState) =>
-  state.engine.backgroundState.AddressBookController;
-
-export const selectAddressBook = createSelector(
-  selectAddressBookControllerState,
-  (addressBookControllerState) =>
-    addressBookControllerState?.addressBook ?? EMPTY_ADDRESS_BOOK,
+const EMPTY_TOKENS_BY_ADDRESS: Readonly<Record<string, never>> = Object.freeze(
+  {},
 );
 
-export const selectAddressBookByChain = createDeepEqualSelector(
-  [selectAddressBook, (_state: RootState, chainId: Hex) => chainId],
-  (addressBook, chainId: Hex) => {
-    if (!addressBook[chainId]) {
-      return EMPTY_ADDRESS_BOOK_CHAIN;
+const EMPTY_TOKENS: Token[] = Object.freeze([] as Token[]) as Token[];
+
+export const selectTokensByAddress = createDeepEqualSelector(
+  selectTokens,
+  (tokens: Token[]): { [address: string]: Token } => {
+    if (!tokens?.length) {
+      return EMPTY_TOKENS_BY_ADDRESS;
     }
-    return Object.values(addressBook[chainId]);
+
+    return tokens.reduce<Record<string, Token>>((tokensMap, token) => {
+      tokensMap[token.address] = token;
+      return tokensMap;
+    }, {});
   },
+);
+
+export const selectAllTokensFlat = createDeepEqualSelector(
+  getTokensControllerAllTokens,
+  (tokensByAccountByChain: TokensControllerState['allTokens']): Token[] => {
+    const groups = Object.values(tokensByAccountByChain);
+    if (groups.length === 0) {
+      return EMPTY_TOKENS;
+    }
+
+    return groups.reduce<Token[]>((acc, tokensByAccount) => {
+      const tokensArray = Object.values(tokensByAccount).flat();
+      return acc.concat(...tokensArray);
+    }, []);
+  },
+);
+
+export const selectTokensLength = createSelector(
+  selectTokens,
+  (tokens: Token[]) => tokens.length,
 );
 ```
 
-`EMPTY_ADDRESS_BOOK` / `EMPTY_ADDRESS_BOOK_CHAIN` are module-level constants (see `EMPTY_TOKENS_BY_ADDRESS` in `tokensController.ts`). Inline `?? {}` / `?? []` on a plain `createSelector` allocates a new ref every call.
+`EMPTY_TOKENS` / `EMPTY_TOKENS_BY_ADDRESS` are module-level constants. Inline `?? {}` / `?? []` on a plain `createSelector` allocates a new ref every call.
 
 ## Factory choice
+
+Narrow the input to the smallest slice first (`performance` / `mm-selector-memoization.md`). Then:
 
 | Output | Factory |
 |--------|---------|
 | boolean, number, string | `createSelector` from `reselect` |
-| object, array, Map, Set | `createDeepEqualSelector` from `app/selectors/util.ts` |
+| object, array, Map, Set | `createDeepEqualSelector` from `app/selectors/util.ts` when the narrowed input still churns (fresh ref every dispatch) and the payload is small enough to deep-compare |
 
-Identity passthrough of a controller slice (`createSelector(selectX, (s) => s.things)`) belongs on `createDeepEqualSelector`. Copy before sort: `[...items].sort(cmp)`.
+A sub-key read plus a module-level empty constant may stay on `createSelector`. Identity passthrough of a whole controller slice that allocates a new object every dispatch belongs on `createDeepEqualSelector`, or skip the wrapper and use the leaf. Copy before sort: `[...items].sort(cmp)`.
 
 ## UI
 
 ```ts
-const addressBook = useSelector(selectAddressBook);
+const tokensByAddress = useSelector(selectTokensByAddress);
 ```
 
 ## Tests
 
-Collocate `app/selectors/<feature>.test.ts`. At least two state variants per new selector (populated + empty/missing). Present tense, AAA, no "should". `yarn jest app/selectors/<feature>.test.ts --no-coverage`.
+Collocate `app/selectors/<feature>.test.ts`. At least two state variants per new selector (populated + empty/missing). Present tense, AAA, no "should". `yarn jest app/selectors/<feature>.test.ts --no-coverage`. Fixtures (`mockRootState`, `mockToken`, `mockTokensControllerState`) live in `tokensController.test.ts`:
 
 ```ts
-describe('selectAddressBook', () => {
-  it('returns addressBook from AddressBookController state', () => {
-    const mockState = {
+describe('selectTokensByAddress', () => {
+  it('returns tokens mapped by address', () => {
+    expect(selectTokensByAddress(mockRootState)).toStrictEqual({
+      '0xToken1': mockToken,
+    });
+  });
+
+  it('handles an empty tokens array', () => {
+    const stateWithoutTokens = {
+      ...mockRootState,
       engine: {
         backgroundState: {
-          AddressBookController: {
-            addressBook: {
+          TokensController: {
+            ...mockTokensControllerState,
+            allTokens: {
               '0x1': {
-                '0x123': {
-                  address: '0x123',
-                  name: 'Alice',
-                  chainId: '0x1',
-                  memo: 'Friend',
-                  isEns: false,
+                '0xAddress1': [],
+              },
+            },
+            tokens: [],
+          },
+          AccountsController: {
+            internalAccounts: {
+              selectedAccount: '0xAddress1',
+              accounts: {
+                '0xAddress1': {
+                  address: '0xAddress1',
                 },
               },
             },
           },
         },
       },
-    };
+    } as unknown as RootState;
 
-    expect(selectAddressBook(mockState as RootState)).toEqual({
-      '0x1': {
-        '0x123': {
-          address: '0x123',
-          name: 'Alice',
-          chainId: '0x1',
-          memo: 'Friend',
-          isEns: false,
-        },
-      },
-    });
-  });
-
-  it('returns an empty object when addressBook is missing', () => {
-    const mockState = {
-      engine: {
-        backgroundState: {
-          AddressBookController: {},
-        },
-      },
-    };
-
-    expect(selectAddressBook(mockState as RootState)).toEqual({});
+    expect(selectTokensByAddress(stateWithoutTokens)).toStrictEqual({});
   });
 });
 ```
@@ -126,16 +143,18 @@ describe('selectAddressBook', () => {
 
 - New and changed selectors live under `app/selectors/<feature>.ts` (or the feature’s `selectors/` folder), named `select<Feature><Thing>`.
 - Only leaf input selectors read `state.engine.backgroundState` (with `?? getDefault<Name>State()` when that helper exists).
-- Derive with `createSelector` (primitives) or `createDeepEqualSelector` (object / array). Stable module-level empty constants instead of inline `?? {}` / `?? []` on plain `createSelector`.
+- Narrow the input first. Derive with `createSelector` (primitives) or `createDeepEqualSelector` (object / array when the narrowed input still churns and the payload is small enough to compare). Stable module-level empty constants instead of inline `?? {}` / `?? []` on plain `createSelector`.
 - Collocated unit tests with at least two state variants.
 - Components and hooks use `useSelector(selectX)` with the named selector.
 
 ## Reject
 
-- `state.engine.backgroundState` in components, hooks, or other UI
+- New and changed UI: `state.engine.backgroundState` in components, hooks, or other UI
 - Inline `useSelector((state) => …)` derivation
 - `useSelector(x, isEqual)` as a substitute for a stable selector
-- Identity `createSelector` on a controller slice
+- Identity `createSelector` on a whole controller slice
 - Inline `?? {}` / `?? []` creating a new ref on every call
 - Mutating inputs in the result function (`items.sort` without copying)
 - Version-gated flag evaluation outside `feature-flags`
+
+Memoization audits of existing selectors: `performance` (`mm-selector-memoization.md`).

--- a/domains/coding/skills/selector-patterns/repos/metamask-mobile.md
+++ b/domains/coding/skills/selector-patterns/repos/metamask-mobile.md
@@ -1,0 +1,141 @@
+---
+repo: metamask-mobile
+parent: selector-patterns
+---
+
+# Selector patterns — MetaMask Mobile
+
+Copy from `app/selectors/addressBookController.ts` (leaf + `createSelector` + `createDeepEqualSelector`) and `app/selectors/tokensController.ts` (collection outputs, stable empty constant). Tests: `yarn jest app/selectors/<feature>.test.ts --no-coverage`. Unit-test shape: `mobile-testing`. Engine wiring that needs a first selector: install/use `coding/selector-patterns` from `controller-integration`. Memoization audits: `performance`. Version-gated flags: `feature-flags`.
+
+## Paths
+
+| Role | Path |
+|------|------|
+| Default selectors | `app/selectors/<feature>.ts` (or `app/selectors/<feature>/index.ts`) |
+| Feature-private selectors | `app/components/UI/<Feature>/selectors/` |
+| Deep-equal helper | `app/selectors/util.ts` → `createDeepEqualSelector` |
+| Collocated tests | `app/selectors/<feature>.test.ts` |
+
+New selectors use `select<Feature><Thing>` (e.g. `selectTokensByChainId`). Existing `get*` names stay; do not rename them in this change.
+
+## Leaf vs derived
+
+Only leaf input selectors read `state.engine.backgroundState`. Use `?? getDefault<Name>State()` when that helper exists.
+
+```ts
+import { RootState } from '../reducers';
+import { createSelector } from 'reselect';
+import { createDeepEqualSelector } from './util';
+import { Hex } from '@metamask/utils';
+
+const EMPTY_ADDRESS_BOOK: Readonly<Record<string, never>> = Object.freeze({});
+const EMPTY_ADDRESS_BOOK_CHAIN: readonly never[] = Object.freeze([]);
+
+export const selectAddressBookControllerState = (state: RootState) =>
+  state.engine.backgroundState.AddressBookController;
+
+export const selectAddressBook = createSelector(
+  selectAddressBookControllerState,
+  (addressBookControllerState) =>
+    addressBookControllerState?.addressBook ?? EMPTY_ADDRESS_BOOK,
+);
+
+export const selectAddressBookByChain = createDeepEqualSelector(
+  [selectAddressBook, (_state: RootState, chainId: Hex) => chainId],
+  (addressBook, chainId: Hex) => {
+    if (!addressBook[chainId]) {
+      return EMPTY_ADDRESS_BOOK_CHAIN;
+    }
+    return Object.values(addressBook[chainId]);
+  },
+);
+```
+
+`EMPTY_ADDRESS_BOOK` / `EMPTY_ADDRESS_BOOK_CHAIN` are module-level constants (see `EMPTY_TOKENS_BY_ADDRESS` in `tokensController.ts`). Inline `?? {}` / `?? []` on a plain `createSelector` allocates a new ref every call.
+
+## Factory choice
+
+| Output | Factory |
+|--------|---------|
+| boolean, number, string | `createSelector` from `reselect` |
+| object, array, Map, Set | `createDeepEqualSelector` from `app/selectors/util.ts` |
+
+Identity passthrough of a controller slice (`createSelector(selectX, (s) => s.things)`) belongs on `createDeepEqualSelector`. Copy before sort: `[...items].sort(cmp)`.
+
+## UI
+
+```ts
+const addressBook = useSelector(selectAddressBook);
+```
+
+## Tests
+
+Collocate `app/selectors/<feature>.test.ts`. At least two state variants per new selector (populated + empty/missing). Present tense, AAA, no "should". `yarn jest app/selectors/<feature>.test.ts --no-coverage`.
+
+```ts
+describe('selectAddressBook', () => {
+  it('returns addressBook from AddressBookController state', () => {
+    const mockState = {
+      engine: {
+        backgroundState: {
+          AddressBookController: {
+            addressBook: {
+              '0x1': {
+                '0x123': {
+                  address: '0x123',
+                  name: 'Alice',
+                  chainId: '0x1',
+                  memo: 'Friend',
+                  isEns: false,
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expect(selectAddressBook(mockState as RootState)).toEqual({
+      '0x1': {
+        '0x123': {
+          address: '0x123',
+          name: 'Alice',
+          chainId: '0x1',
+          memo: 'Friend',
+          isEns: false,
+        },
+      },
+    });
+  });
+
+  it('returns an empty object when addressBook is missing', () => {
+    const mockState = {
+      engine: {
+        backgroundState: {
+          AddressBookController: {},
+        },
+      },
+    };
+
+    expect(selectAddressBook(mockState as RootState)).toEqual({});
+  });
+});
+```
+
+## Requirements
+
+- New and changed selectors live under `app/selectors/<feature>.ts` (or the feature’s `selectors/` folder), named `select<Feature><Thing>`.
+- Only leaf input selectors read `state.engine.backgroundState` (with `?? getDefault<Name>State()` when that helper exists).
+- Derive with `createSelector` (primitives) or `createDeepEqualSelector` (object / array). Stable module-level empty constants instead of inline `?? {}` / `?? []` on plain `createSelector`.
+- Collocated unit tests with at least two state variants.
+- Components and hooks use `useSelector(selectX)` with the named selector.
+
+## Reject
+
+- `state.engine.backgroundState` in components, hooks, or other UI
+- Inline `useSelector((state) => …)` derivation
+- `useSelector(x, isEqual)` as a substitute for a stable selector
+- Identity `createSelector` on a controller slice
+- Inline `?? {}` / `?? []` creating a new ref on every call
+- Mutating inputs in the result function (`items.sort` without copying)
+- Version-gated flag evaluation outside `feature-flags`

--- a/domains/coding/skills/selector-patterns/skill.md
+++ b/domains/coding/skills/selector-patterns/skill.md
@@ -1,0 +1,40 @@
+---
+name: selector-patterns
+description: >-
+  Redux selector authoring for MetaMask Mobile: named `select<Feature><Thing>`
+  selectors in `app/selectors/`, `createSelector` / `createDeepEqualSelector`
+  from reselect, leaf reads of `state.engine.backgroundState`, and
+  `useSelector(selectX)` in UI. Use when adding or creating a selector,
+  updating or refactoring an existing selector, moving inline `useSelector`
+  derivation out of a component or hook, or answering questions about
+  selectors, reselect, `createSelector`, `createDeepEqualSelector`,
+  `app/selectors`, or `backgroundState`. Version-gated flag selectors go to
+  `feature-flags`. Memoization audits of existing selectors go to
+  `performance`.
+---
+
+# Selector patterns
+
+## When To Use
+
+- Implement / add / create a Redux selector
+- Update / change / refactor an existing selector
+- Questions about selectors, `useSelector`, `createSelector`, `createDeepEqualSelector`, `reselect`, `app/selectors`, or `backgroundState`
+
+Version-gated flag selectors (`validatedVersionGatedFeatureFlag`, `selectRemoteFeatureFlags`, `app/selectors/featureFlagController/`) → **`feature-flags`**.
+
+Memoization audits of existing selectors (broken identity, cascade re-renders) → **`performance`**.
+
+## Workflow
+
+Q&A: answer from the overlay, then stop.
+
+Implement or update:
+
+1. Search for an existing named selector before adding one.
+2. Put new selectors in `app/selectors/<feature>.ts` (or the feature’s `selectors/` folder).
+3. Add a leaf input selector that reads the controller slice. Compose derived selectors on top of it.
+4. Choose `createSelector` (primitive output) or `createDeepEqualSelector` (object / array output).
+5. Name it `select<Feature><Thing>`.
+6. In components and hooks, call `useSelector(selectX)` with that named selector.
+7. Add collocated unit tests with at least two state variants.

--- a/domains/coding/skills/selector-patterns/skill.md
+++ b/domains/coding/skills/selector-patterns/skill.md
@@ -34,7 +34,7 @@ Implement or update:
 1. Search for an existing named selector before adding one.
 2. Put new selectors in `app/selectors/<feature>.ts` (or the feature’s `selectors/` folder).
 3. Add a leaf input selector that reads the controller slice. Compose derived selectors on top of it.
-4. Choose `createSelector` (primitive output) or `createDeepEqualSelector` (object / array output).
+4. Narrow the input to the smallest slice. Choose `createSelector` (primitive output) or `createDeepEqualSelector` (object / array when the narrowed input still churns and the payload is small enough to compare).
 5. Name it `select<Feature><Thing>`.
 6. In components and hooks, call `useSelector(selectX)` with that named selector.
 7. Add collocated unit tests with at least two state variants.

--- a/domains/performance/skills/performance/repos/metamask-mobile.md
+++ b/domains/performance/skills/performance/repos/metamask-mobile.md
@@ -50,7 +50,7 @@ Always pair measurement with the **power-user scenario on Android** — see [ref
 
 | Symptom / task | Start with |
 |---|---|
-| Authoring a new or changed Redux selector (file, naming, tests) | Install/use `coding/selector-patterns`. Memoization audits stay on this skill. |
+| Authoring a new or changed Redux selector (file, naming, tests) | `yarn skills --include coding/selector-patterns --save`. Memoization audits stay on this skill ([mm-selector-memoization.md](references/mm-selector-memoization.md)). |
 | Component re-renders too much; account/network switch is laggy | [mm-selector-memoization.md](references/mm-selector-memoization.md) → [js-profile-react.md](references/js-profile-react.md) |
 | `useSelector` returns new refs; `useSelector(x, isEqual)` band-aids | [mm-redux-antipatterns.md](references/mm-redux-antipatterns.md) |
 | Whole subtree re-renders under a Context provider | [mm-context-performance.md](references/mm-context-performance.md) |

--- a/domains/performance/skills/performance/repos/metamask-mobile.md
+++ b/domains/performance/skills/performance/repos/metamask-mobile.md
@@ -50,6 +50,7 @@ Always pair measurement with the **power-user scenario on Android** — see [ref
 
 | Symptom / task | Start with |
 |---|---|
+| Authoring a new or changed Redux selector (file, naming, tests) | Install/use `coding/selector-patterns`. Memoization audits stay on this skill. |
 | Component re-renders too much; account/network switch is laggy | [mm-selector-memoization.md](references/mm-selector-memoization.md) → [js-profile-react.md](references/js-profile-react.md) |
 | `useSelector` returns new refs; `useSelector(x, isEqual)` band-aids | [mm-redux-antipatterns.md](references/mm-redux-antipatterns.md) |
 | Whole subtree re-renders under a Context provider | [mm-context-performance.md](references/mm-context-performance.md) |


### PR DESCRIPTION
## Description

Opt-in `coding/selector-patterns` skill with a MetaMask Mobile overlay. Agents get a description-triggered guide for authoring and consuming Redux selectors: named `select<Feature><Thing>` selectors, `createSelector` / `createDeepEqualSelector`, leaf reads of `state.engine.backgroundState`, `useSelector(selectX)` in UI, and collocated tests with at least two state variants. Version-gated flag selectors stay on `feature-flags`. Memoization audits stay on `performance`.

Install/use pointers were added on the Mobile overlays for `coding-guidelines`, `controller-integration` (step 11 rewritten so object/array outputs can use `createDeepEqualSelector`), and `performance`.

MCWP-472 asked for an always-on Cursor rule (`alwaysApply: true`). This repo ships opt-in skills, so discovery is the description plus those install/use pointers.

Fixes: https://consensyssoftware.atlassian.net/browse/MCWP-472

## Type of Change

- [x] New skill
- [x] Skill improvement/update
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## Skill Details (if adding a new skill)

**Provider Name:** MetaMask
**Skill Name:** selector-patterns
**Brief Description:** Redux selector authoring for MetaMask Mobile: named `select<Feature><Thing>` selectors in `app/selectors/`, `createSelector` / `createDeepEqualSelector`, leaf reads of `state.engine.backgroundState`, and `useSelector(selectX)` in UI. Use when adding, updating, or asking about selectors.

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/MetaMask/skills/blob/main/CONTRIBUTING.md) guidelines
- [x] My skill follows the [SKILL_TEMPLATE.md](https://github.com/MetaMask/skills/blob/main/.github/SKILL_TEMPLATE.md) format
- [x] I have tested this skill with an AI agent
- [x] My skill does not contain any secrets, private keys, or sensitive data
- [x] I have added appropriate documentation
- [x] My changes don't break existing skills

## Testing

- `yarn audit:skills` — `coding/selector-patterns` had no schema errors
- `./tools/install --repo metamask-mobile --include coding/selector-patterns`
- Two `mobile-skill-consumer` product tickets (Contacts address-book count; Onboarding password-set store read). Product diffs were discarded after capture.

> [!IMPORTANT]
> Skill-test report from two Mobile consumer runs : [skill-test-selector-patterns.local.md](https://github.com/user-attachments/files/31921540/skill-test-selector-patterns.local.md)


## Additional Context

CODEOWNERS: `@MetaMask/extension-platform` `@MetaMask/mobile-platform` `@MetaMask/core-platform` (`/domains/coding/`, `/domains/performance/`)

Made with [Cursor](https://cursor.com)