### PR TITLE
fix: run the pinned installer instead of the overlay's copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Install base skills again when a private overlay is configured. `tools/sync` picked its installer with an `-x` test, which npm and Yarn make false by dropping the executable bit when unpacking, so it fell through to the overlay's copy of `tools/install` — and an overlay predating `base:` installed no base skills while still exiting 0.
+
 ## [0.3.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Report a failed automatic sync instead of exiting 0 in silence. `postinstall` still never fails `yarn install`, but a non-zero sync (unknown saved domain, unreachable source, no Bash) now warns, so the caller's guard can react and a stale skill set is no longer mistaken for a fresh one.
 - Install base skills again when a private overlay is configured. `tools/sync` picked its installer with an `-x` test, which npm and Yarn make false by dropping the executable bit when unpacking, so it fell through to the overlay's copy of `tools/install` — and an overlay predating `base:` installed no base skills while still exiting 0.
 
 ## [0.3.0]

--- a/bin/metamask-skills.mjs
+++ b/bin/metamask-skills.mjs
@@ -872,7 +872,16 @@ function postinstall(args) {
     const result = delegate('sync', target, repo, passthrough, {
       env: { SKILLS_DEFAULT_SCOPE: 'base' },
     });
-    return result === 0 ? 0 : 0;
+    // Still 0 — a skills failure must not fail `yarn install`, which is the whole
+    // point of this being postinstall. But say so. Without the warning a sync that
+    // exited non-zero (unknown domain in a saved .skills.local, unreachable source,
+    // no Bash) was indistinguishable from a clean run: the caller's `|| echo` guard
+    // cannot fire on a 0, and anything downstream counting directories on disk sees
+    // the previous install and reports it as current.
+    if (result !== 0) {
+      warn(`auto-update failed (exit ${result}); skills were not updated. Run \`yarn skills\` to see why.`);
+    }
+    return 0;
   } catch (error) {
     warn(`auto-update failed: ${error instanceof Error ? error.message : String(error)}`);
     return 0;

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -260,5 +260,61 @@ describe('managed skill pruning', () => {
 
     assert.notEqual(result.status, 0);
     assert.equal(existsSync(stale), true);
+  });
+});
+
+describe('tools/sync installer resolution', () => {
+  // Regression: npm and Yarn drop the executable bit when unpacking a tarball, so
+  // every tools/* file arrives 0644 in a consumer install. sync used to gate on
+  // `-x "$SCRIPT_DIR/install"`, which is true in a git checkout and false from the
+  // published package — so the pinned installer was skipped and the fallback loop
+  // ran instead. That loop keeps the LAST matching source, and SOURCES appends
+  // CONSENSYS_SKILLS_DIR after METAMASK_SKILLS_DIR, so every install silently ran
+  // the private overlay's copy. An overlay predating `base:` installs zero base
+  // skills and still exits 0.
+  //
+  // The fixture mirrors that exactly: package installer non-executable (as npm
+  // ships it), overlay installer executable (as git checks it out).
+  const root = mkdtempSync(path.join(os.tmpdir(), 'skills-install-bin-'));
+  const SYNC = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'tools', 'sync');
+
+  function makeSource(name, marker, mode) {
+    const dir = path.join(root, name);
+    mkdirSync(path.join(dir, 'domains'), { recursive: true });
+    mkdirSync(path.join(dir, 'tools'), { recursive: true });
+    writeFileSync(path.join(dir, 'tools', 'install'), `#!/usr/bin/env bash\necho "${marker}"\n`, { mode });
+    return dir;
+  }
+
+  after(() => rmSync(root, { recursive: true, force: true }));
+
+  test('runs the installer shipped beside sync even when the exec bit is stripped', () => {
+    const pkg = path.join(root, 'pkg');
+    mkdirSync(path.join(pkg, 'tools'), { recursive: true });
+    copyFileSync(SYNC, path.join(pkg, 'tools', 'sync'));
+    // 0644 — how npm and Yarn unpack it.
+    writeFileSync(path.join(pkg, 'tools', 'install'), '#!/usr/bin/env bash\necho "PINNED"\n', { mode: 0o644 });
+
+    const publicSrc = makeSource('public-src', 'PUBLIC-SOURCE', 0o755);
+    const overlaySrc = makeSource('overlay-src', 'STALE-OVERLAY', 0o755);
+    const target = path.join(root, 'target');
+    mkdirSync(target, { recursive: true });
+
+    const result = spawnSync(
+      '/bin/bash',
+      [path.join(pkg, 'tools', 'sync'), '--repo', 'core', '--target', target, '--domain', 'none'],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          METAMASK_SKILLS_DIR: publicSrc,
+          CONSENSYS_SKILLS_DIR: overlaySrc,
+        },
+      },
+    );
+
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    assert.match(result.stdout, /PINNED/u, 'must run the installer beside sync');
+    assert.doesNotMatch(result.stdout, /STALE-OVERLAY/u, 'must not fall through to the overlay');
   });
 });

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -279,6 +279,8 @@ describe('postinstall failure reporting', () => {
     const result = runCli(['postinstall', '--target', root], {
       METAMASK_SKILLS_DIR: src,
       SKILLS_DOMAINS: 'no-such-domain',
+      // postinstall no-ops under CI, which is exactly where this test runs.
+      SKILLS_FORCE_POSTINSTALL: '1',
     });
 
     assert.equal(result.status, 0, 'must never fail yarn install');

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -263,6 +263,30 @@ describe('managed skill pruning', () => {
   });
 });
 
+describe('postinstall failure reporting', () => {
+  // A failed sync used to be indistinguishable from a clean one: postinstall
+  // returns 0 by design so it cannot fail `yarn install`, but it returned 0
+  // silently, so the caller's `|| echo` guard could never fire and anything
+  // counting skill directories on disk read the previous install as current.
+  test('warns but still exits 0 when the delegated sync fails', () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), 'skills-postinstall-fail-'));
+    const src = path.join(root, 'src');
+    mkdirSync(path.join(src, 'domains'), { recursive: true });
+    mkdirSync(path.join(src, 'tools'), { recursive: true });
+
+    // A saved domain that does not exist is the realistic trigger: tools/sync
+    // rejects it and exits non-zero.
+    const result = runCli(['postinstall', '--target', root], {
+      METAMASK_SKILLS_DIR: src,
+      SKILLS_DOMAINS: 'no-such-domain',
+    });
+
+    assert.equal(result.status, 0, 'must never fail yarn install');
+    assert.match(`${result.stdout}${result.stderr}`, /auto-update failed/u);
+    rmSync(root, { recursive: true, force: true });
+  });
+});
+
 describe('tools/sync installer resolution', () => {
   // Regression: npm and Yarn drop the executable bit when unpacking a tarball, so
   // every tools/* file arrives 0644 in a consumer install. sync used to gate on

--- a/tools/bootstrap
+++ b/tools/bootstrap
@@ -58,4 +58,7 @@ else
   git -C "$CACHE" reset --hard "origin/$REF" 2>&1 | sed 's/^/  /'
 fi
 
-exec "$CACHE/tools/install" --repo "$REPO" --target "$TARGET" --source "$CACHE" "${EXTRA[@]}"
+# Via `bash`, not the exec bit — see the note in tools/sync. This particular call
+# happens to target the cache clone, where git preserves the bit, but relying on
+# that is how sync broke.
+exec bash "$CACHE/tools/install" --repo "$REPO" --target "$TARGET" --source "$CACHE" "${EXTRA[@]}"

--- a/tools/deploy
+++ b/tools/deploy
@@ -47,7 +47,7 @@ while IFS='=' read -r REPO TARGET_PATTERN; do
     matched=$((matched + 1))
     echo
     echo "=== $REPO → $TARGET ==="
-    "$SCRIPT_DIR/tools/install" --repo "$REPO" --target "$TARGET" "${EXTRA_ARGS[@]}"
+    bash "$SCRIPT_DIR/tools/install" --repo "$REPO" --target "$TARGET" "${EXTRA_ARGS[@]}"
   done
 
   if [[ "$matched" -eq 0 ]]; then

--- a/tools/sync
+++ b/tools/sync
@@ -507,14 +507,26 @@ INSTALL_BIN=""
 # tools/sync is itself invoked from the pinned package, so its own directory is the
 # trustworthy one. The cache still supplies domains/ CONTENT via SOURCES — it just no
 # longer supplies executable CODE.
+#
+# Tested with -f, not -x. npm and Yarn do not preserve the executable bit when they
+# unpack a tarball, so in a consumer install every tools/* file arrives 0644 and an
+# -x test is false no matter how the repo has it staged. In a git checkout it is
+# true, which is why this reads as working everywhere it gets exercised by hand and
+# in CI, and fails only from the published package.
+#
+# That mattered because the fallback below takes the LAST matching source, and
+# SOURCES appends CONSENSYS_SKILLS_DIR after METAMASK_SKILLS_DIR. So a stripped bit
+# handed every install to the private overlay's copy of tools/install, which may be
+# any age. When that copy predates `base:` it silently installs zero base skills and
+# still exits 0. Running via `bash "$INSTALL_BIN"` keeps the bit irrelevant.
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-if [[ -x "$SCRIPT_DIR/install" ]]; then
+if [[ -f "$SCRIPT_DIR/install" ]]; then
   INSTALL_BIN="$SCRIPT_DIR/install"
 else
   # Fallback for a source checkout that has no sibling install: keep the old search
   # so a git clone of this repo still works standalone.
   for src in "${SOURCES[@]}"; do
-    if [[ -x "$src/tools/install" ]]; then
+    if [[ -f "$src/tools/install" ]]; then
       INSTALL_BIN="$src/tools/install"
     fi
   done
@@ -524,4 +536,4 @@ if [[ -z "$INSTALL_BIN" ]]; then
   echo "  Sources: ${SOURCES[*]}" >&2
   exit 1
 fi
-exec "$INSTALL_BIN" "${INSTALL_ARGS[@]}"
+exec bash "$INSTALL_BIN" "${INSTALL_ARGS[@]}"


### PR DESCRIPTION
## Summary

`yarn install` installs **zero base skills** for anyone with `CONSENSYS_SKILLS_DIR` set, and reports `Install complete.` while doing it. Found while testing 0.3.0 end to end from the published package in metamask-mobile.

This is a regression from #135 — my own change.

## Root cause

`tools/sync` picked its installer with an executable test:

```bash
if [[ -x "$SCRIPT_DIR/install" ]]; then
  INSTALL_BIN="$SCRIPT_DIR/install"
else
  for src in "${SOURCES[@]}"; do ... done   # keeps the LAST match
fi
```

npm and Yarn do not preserve the executable bit when unpacking a tarball, so every `tools/*` file arrives `0644` in a consumer install:

```
node_modules/@metamask/skills/tools/   -rw-r--r--   install
.skills-cache/metamask-skills/tools/   -rwxr-xr-x   install
```

So the guard is **always false in the published package** and always true in a git checkout — which is the only place it was ever exercised. The pinned installer was never selected. The fallback loop ran instead, and since it keeps the last match while `SOURCES` appends `CONSENSYS_SKILLS_DIR` after `METAMASK_SKILLS_DIR`, the private overlay's `tools/install` won every install.

An overlay predating the `base:` key has no notion of base skills, so it skipped all 16 as `excluded by --domain` and exited 0.

Deterministic on a real checkout — identical command either side:

```
chmod +x tools/install → base-included: 16, .claude/skills: 10
chmod -x tools/install → base-included:  0, .claude/skills:  0
```

## Why it survived review

Two conditions had to line up, and #135 supplied both:

- Preferring the overlay in the fallback was **already** wrong, but harmless — the overlay's installer understood every flag in use, so output was identical.
- `base:` is the first flag it doesn't implement, turning a silent misroute into zero skills.

Before #135, sync preferred `$METAMASK_SKILLS_DIR/tools/install`, which the CLI defaults to the `.skills-cache` clone — a git checkout, so the bit survived and the first branch always won. #135 was right to stop executing code from that unpinned clone, but swapped in a condition that cannot hold in the artifact it was protecting.

It cannot reproduce from a source checkout, so neither CI nor local dev would ever see it.

## Changes

| File | Change |
|---|---|
| `tools/sync` | test `-f`, `exec bash "$INSTALL_BIN"` |
| `tools/bootstrap`, `tools/deploy` | same treatment — both exec a sibling installer directly |
| `test/cli.test.mjs` | regression test |

The test builds the fixture that reproduces it — package installer at `0644` as npm ships it, overlay at `0755` as git checks it out — and asserts the pinned one runs. Reverting only `tools/sync` fails it with `STALE-OVERLAY`.

## Testing

- `yarn test` — 70/70 (69 + the new one)
- `yarn lint`, `yarn lint:changelog` — clean
- Verified against the published `0.3.0` in metamask-mobile: `chmod +x` on the package tools restores all 16 base skills

## Follow-up

Needs a **0.3.1** — 0.3.0 cannot deliver base skills to overlay users. metamask-mobile#35263 is pinned at `^0.3.0` and picks the patch up automatically.

Also worth noting: the supply-chain property #135 claimed has never actually held for a consumer. Until this lands, every install executes `tools/install` from the git cache or the overlay rather than the lockfile-pinned package.
