### PR TITLE
ci: name `@MetaMask/extension-platform` owner of five skill domains

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,14 +16,28 @@
 /domains/assets/         @MetaMask/metamask-assets
 /domains/coding/         @MetaMask/extension-platform @MetaMask/mobile-platform @MetaMask/core-platform
 /domains/general/        @MetaMask/extension-platform @MetaMask/mobile-platform
-/domains/observability/  @MetaMask/extension-platform
+/domains/observability/  @MetaMask/extension-platform @MetaMask/mobile-platform
 /domains/performance/    @MetaMask/extension-platform @MetaMask/mobile-platform
 /domains/perps/          @MetaMask/perps
-/domains/platform/       @MetaMask/extension-platform
+/domains/platform/       @MetaMask/extension-platform @MetaMask/mobile-platform
 /domains/pr-workflow/    @MetaMask/extension-platform @MetaMask/mobile-platform
-/domains/security/       @MetaMask/extension-platform
-/domains/stability/      @MetaMask/extension-platform
+/domains/security/       @MetaMask/extension-platform @MetaMask/mobile-platform
+/domains/stability/      @MetaMask/extension-platform @MetaMask/mobile-platform
 /domains/swaps/          @MetaMask/swaps-engineers
 /domains/testing/        @MetaMask/qa
-/domains/typescript/     @MetaMask/extension-platform
+/domains/typescript/     @MetaMask/extension-platform @MetaMask/mobile-platform
 /domains/ui/             @MetaMask/design-system-engineers
+
+# Repo overlays name one client, so the platform team for that client owns them.
+# Scoped to the domains above: a blanket /domains/**/repos/ rule would move 11 files
+# away from @MetaMask/qa, swaps-engineers, design-system-engineers and perps.
+/domains/observability/skills/*/repos/metamask-extension.md @MetaMask/extension-platform
+/domains/platform/skills/*/repos/metamask-extension.md      @MetaMask/extension-platform
+/domains/security/skills/*/repos/metamask-extension.md      @MetaMask/extension-platform
+/domains/stability/skills/*/repos/metamask-extension.md     @MetaMask/extension-platform
+/domains/typescript/skills/*/repos/metamask-extension.md    @MetaMask/extension-platform
+/domains/observability/skills/*/repos/metamask-mobile.md    @MetaMask/mobile-platform
+/domains/platform/skills/*/repos/metamask-mobile.md         @MetaMask/mobile-platform
+/domains/security/skills/*/repos/metamask-mobile.md         @MetaMask/mobile-platform
+/domains/stability/skills/*/repos/metamask-mobile.md        @MetaMask/mobile-platform
+/domains/typescript/skills/*/repos/metamask-mobile.md       @MetaMask/mobile-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,9 +16,14 @@
 /domains/assets/         @MetaMask/metamask-assets
 /domains/coding/         @MetaMask/extension-platform @MetaMask/mobile-platform @MetaMask/core-platform
 /domains/general/        @MetaMask/extension-platform @MetaMask/mobile-platform
+/domains/observability/  @MetaMask/extension-platform
 /domains/performance/    @MetaMask/extension-platform @MetaMask/mobile-platform
 /domains/perps/          @MetaMask/perps
+/domains/platform/       @MetaMask/extension-platform
 /domains/pr-workflow/    @MetaMask/extension-platform @MetaMask/mobile-platform
+/domains/security/       @MetaMask/extension-platform
+/domains/stability/      @MetaMask/extension-platform
 /domains/swaps/          @MetaMask/swaps-engineers
 /domains/testing/        @MetaMask/qa
+/domains/typescript/     @MetaMask/extension-platform
 /domains/ui/             @MetaMask/design-system-engineers


### PR DESCRIPTION
## Motivation

Five skill domains have no owner. `observability`, `platform`, `security`, `stability` and `typescript` fall through to the `*` catch-all, which names both platform teams, so a change to any of them is owned jointly and by nobody in particular. The domains that already have entries do not work that way: `assets` goes to `@MetaMask/metamask-assets`, `perps` to `@MetaMask/perps`, `testing` to `@MetaMask/qa`.

Ownership has to be expressed at the right granularity, because a domain is not single-client. It holds the cross-client `skill.md` as well as the per-client overlays, so naming one platform team owner of a whole domain claims the shared half too.

## Overview

Two rules per domain rather than one.

**The domain is co-owned** by `@MetaMask/extension-platform` and `@MetaMask/mobile-platform`, matching `coding`, `general`, `performance` and `pr-workflow`.

**A client's overlay is owned by that client's platform team**, expressed where the client-specific material actually lives:

```
/domains/typescript/skills/*/repos/metamask-extension.md  @MetaMask/extension-platform
/domains/typescript/skills/*/repos/metamask-mobile.md     @MetaMask/mobile-platform
```

The overlay rules follow the domain block, because CODEOWNERS resolves last-match-wins and they have to beat the domain rule to apply at all.

They name each of the five domains rather than globbing the domain segment. A blanket `/domains/**/repos/metamask-extension.md` reads better and would move 11 files away from teams that own them today: 7 from `@MetaMask/qa`, 2 from `@MetaMask/swaps-engineers`, and one each from `@MetaMask/design-system-engineers` and `@MetaMask/perps`. The wildcard stays on the skill-name segment, where it is safe.

The domain block is also re-sorted alphabetically so the five land in place rather than at the end.

## Showcase

The paths are added before the directories exist, since each domain arrives in its own PR. Nothing reads CODEOWNERS in CI: greping all five workflows and `lint-skill-entry.mjs` for `codeowners` returns zero, against 14 hits for `skill` in `lint-skill-entry.yml` as a control. An entry for a path that does not exist yet is inert.

Validated with GitHub's own checker rather than by eye, `GET /repos/MetaMask/skills/codeowners/errors`:

| ref | errors | kinds |
|---|---|---|
| `main` | 30 | 30x Unknown owner |
| this branch | 50 | 50x Unknown owner |

**Every error on both refs is `Unknown owner`, and `main` already has 30.** That is team visibility to the querying token, not a defect in the file. The delta of 20 is exactly the new lines: 5 domains x 2 teams, plus 10 overlay rules x 1 team. No error of any other kind appears, which is what confirms the `*` patterns parse; an invalid pattern is reported as one.

Doing this as one PR rather than five is deliberate. Five PRs each editing this block conflict with each other, which two open ones already do.
